### PR TITLE
feat: CircuitBreaker class — state machine for LLM call protection

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,26 @@
+# Botti-Agent
+
+Personal AI agent system. Cortex provides the core LLM orchestration layer, with modules (Execution, Memory, Learning) consuming LLM services through a factory and client abstraction.
+
+## Language
+
+**LLMClient**:
+Provider-agnostic abstract interface for LLM interactions. Each provider (OpenAI, Anthropic) implements this interface.
+_Avoid_: LLM, model, provider client
+
+**CircuitBreaker**:
+State machine (CLOSED → OPEN → HALF_OPEN → CLOSED) that wraps an LLMClient to fast-fail when failures exceed a threshold within a time window. Prevents thundering-herd retry storms against a rate-limited provider.
+_Avoid_: Retry handler, fallback, breaker
+
+**CircuitBreakerLLMClient**:
+Wrapper that implements the same interface as LLMClient and delegates calls through a CircuitBreaker. Transparent to callers — they receive normal return values when closed, `CircuitOpenError` when open.
+
+**CircuitOpenError**:
+Exception raised when a call is attempted while the circuit is OPEN. Carries `opened_at` and `retry_after` for recovery-aware retry logic.
+
+**CircuitState**:
+Enum: CLOSED, OPEN, HALF_OPEN. Represents the current state of a circuit breaker instance.
+
+**LLMFactory**:
+Creates LLMClient instances. Each consumer module (Execution, Memory, Learning) gets its own CircuitBreakerLLMClient with an independent CircuitBreaker, so failures in one module don't affect others.
+_Avoid_: Factory, provider factory

--- a/src/cortex/llm/__init__.py
+++ b/src/cortex/llm/__init__.py
@@ -2,10 +2,14 @@
 
 from cortex.llm.base import LLMClient
 from cortex.llm.models import ChatMessage, ChatResult, ToolCall, ToolDefinition, Role
+from cortex.llm.circuit_breaker import CircuitBreaker, CircuitOpenError, CircuitState
 from cortex.llm.config import GenerationConfig
 from cortex.llm.factory import LLMClientFactory
 
 __all__ = [
+    "CircuitBreaker",
+    "CircuitOpenError",
+    "CircuitState",
     "LLMClient",
     "ChatMessage",
     "ChatResult",

--- a/src/cortex/llm/circuit_breaker.py
+++ b/src/cortex/llm/circuit_breaker.py
@@ -1,0 +1,187 @@
+"""Circuit Breaker — State machine for fast-failing on repeated LLM failures.
+
+Wraps an async LLM call (``LLMClient.chat()``) with a configurable state machine:
+
+    CLOSED → OPEN → HALF_OPEN → CLOSED
+
+Usage::
+
+    cb = CircuitBreaker()
+    result = await cb.call(client.chat(messages))
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from asyncio import Lock
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+class CircuitState(enum.Enum):
+    """Current state of the circuit breaker."""
+
+    CLOSED = "closed"
+    OPEN = "open"
+    HALF_OPEN = "half_open"
+
+
+class CircuitOpenError(Exception):
+    """Raised when a request is rejected because the circuit is OPEN.
+
+    Args:
+        opened_at: Time (monotonic) when the circuit entered OPEN state.
+        retry_after: Seconds a caller should wait before retrying.
+    """
+
+    def __init__(self, opened_at: float, retry_after: float) -> None:
+        self.opened_at = opened_at
+        self.retry_after = retry_after
+        super().__init__(f"Circuit is OPEN (opened_at={opened_at}, retry_after={retry_after})")
+
+
+class CircuitBreaker:
+    """Async circuit breaker protecting LLM calls from cascading failures.
+    All state transitions are serialized via ``asyncio.Lock``. The
+    ``state`` property read is not independently locked — may see a stale
+    value during a concurrent transition (acceptable for monitoring/logging).
+
+    Parameters
+    ----------
+    failure_threshold:
+        Consecutive failures within ``failure_window`` seconds to trip OPEN.
+    recovery_timeout:
+        Seconds to stay OPEN before transitioning to HALF_OPEN.
+    half_open_successes:
+        Successful calls in HALF_OPEN to transition back to CLOSED.
+    failure_window:
+        Sliding window in seconds for counting failures.
+    _time:
+        Injectable clock (default ``time.monotonic``) — used for deterministic
+        testing.
+    """
+
+    def __init__(
+        self,
+        failure_threshold: int = 5,
+        recovery_timeout: float = 30.0,
+        half_open_successes: int = 3,
+        failure_window: float = 60.0,
+        _time: Callable[[], float] | None = None,
+    ) -> None:
+        self.failure_threshold = failure_threshold
+        self.recovery_timeout = recovery_timeout
+        self.half_open_successes = half_open_successes
+        self.failure_window = failure_window
+        self._time = _time or time.monotonic
+
+        self._lock = Lock()
+        self._state = CircuitState.CLOSED
+
+        # Failure tracking (CLOSED state)
+        self._failure_timestamps: list[float] = []
+
+        # Half-open tracking
+        self._half_open_success_count = 0
+
+        # Open state timer
+        self._opened_at: float | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> CircuitState:
+        """Current state of the circuit breaker. Read is not independently locked — may see a stale value during a concurrent transition."""
+        return self._state
+
+    async def call(self, coro: Awaitable[T]) -> T:
+        """Execute ``coro`` through the circuit breaker state machine.
+
+        Args:
+            coro: An awaitable (typically ``client.chat(…)``).
+
+        Returns:
+            The coroutine's result on success.
+
+        Raises:
+            CircuitOpenError: If the circuit is OPEN and has not elapsed
+                ``recovery_timeout``.
+            Exception: The underlying coroutine's exception (re-raised).
+        """
+        async with self._lock:
+            self._prune_old_failures()
+
+            if self._state is CircuitState.OPEN:
+                elapsed = self._time() - self._opened_at
+                if elapsed < self.recovery_timeout:
+                    raise CircuitOpenError(
+                        opened_at=self._opened_at,
+                        retry_after=self.recovery_timeout - elapsed,
+                    )
+                # Timeout elapsed → transition to HALF_OPEN
+                self._state = CircuitState.HALF_OPEN
+                self._half_open_success_count = 0
+
+            if self._state is CircuitState.HALF_OPEN:
+                return await self._handle_half_open(coro)
+
+            # CLOSED (default / fall-through)
+            return await self._handle_closed(coro)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _handle_closed(self, coro: Awaitable[T]) -> T:
+        """Execute in CLOSED state — pass through, track failures."""
+        try:
+            result = await coro
+        except Exception:
+            self._failure_timestamps.append(self._time())
+            if len(self._failure_timestamps) >= self.failure_threshold:
+                self._trip_open()
+            raise
+
+        # Success — reset failure count
+        self._failure_timestamps.clear()
+        return result
+
+    async def _handle_half_open(self, coro: Awaitable[T]) -> T:
+        """Execute in HALF_OPEN state — trial request."""
+        try:
+            result = await coro
+        except Exception:
+            # Failure → back to OPEN, timer resets
+            self._trip_open()
+            raise
+
+        # Success → increment
+        self._half_open_success_count += 1
+        if self._half_open_success_count >= self.half_open_successes:
+            self._reset_closed()
+        return result
+
+    def _trip_open(self) -> None:
+        """Transition to OPEN state."""
+        self._state = CircuitState.OPEN
+        self._opened_at = self._time()
+        self._failure_timestamps.clear()
+        self._half_open_success_count = 0
+
+    def _reset_closed(self) -> None:
+        """Transition to CLOSED state."""
+        self._state = CircuitState.CLOSED
+        self._failure_timestamps.clear()
+        self._half_open_success_count = 0
+        self._opened_at = None
+
+    def _prune_old_failures(self) -> None:
+        """Remove failure timestamps older than ``failure_window``."""
+        now = self._time()
+        cutoff = now - self.failure_window
+        self._failure_timestamps = [t for t in self._failure_timestamps if t > cutoff]

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -1,0 +1,308 @@
+"""Tests for the CircuitBreaker state machine."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cortex.llm.circuit_breaker import CircuitBreaker, CircuitOpenError, CircuitState
+import asyncio
+
+
+class TestCircuitState:
+    """Enum correctness."""
+
+    def test_states(self):
+        assert CircuitState.CLOSED.value == "closed"
+        assert CircuitState.OPEN.value == "open"
+        assert CircuitState.HALF_OPEN.value == "half_open"
+
+
+class TestCircuitOpenError:
+    """Exception carries opened_at and retry_after."""
+
+    def test_attributes(self):
+        err = CircuitOpenError(opened_at=100.0, retry_after=30.0)
+        assert err.opened_at == 100.0
+        assert err.retry_after == 30.0
+
+    def test_str_representation(self):
+        err = CircuitOpenError(opened_at=100.0, retry_after=30.0)
+        msg = str(err)
+        assert "100.0" in msg
+        assert "30.0" in msg
+
+
+class TestCircuitBreakerDefaults:
+    """Default constructor values."""
+
+    def test_defaults(self):
+        cb = CircuitBreaker()
+        assert cb.failure_threshold == 5
+        assert cb.recovery_timeout == 30.0
+        assert cb.half_open_successes == 3
+        assert cb.state == CircuitState.CLOSED
+
+
+class TestCircuitBreakerClosedToOpen:
+    """CLOSED → OPEN after failure_threshold failures in failure_window."""
+
+    @pytest.mark.asyncio
+    async def test_stays_closed_on_success(self):
+        """Success does not transition to OPEN."""
+        cb = CircuitBreaker(failure_threshold=3, _time=lambda: 0.0)
+        assert cb.state == CircuitState.CLOSED
+
+        mock_coro = AsyncMock(return_value="ok")
+        result = await cb.call(mock_coro())
+        assert result == "ok"
+        assert cb.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_opens_after_threshold_failures(self):
+        """After failure_threshold failures in window → OPEN."""
+        cb = CircuitBreaker(failure_threshold=3, _time=lambda: 0.0)
+        assert cb.state == CircuitState.CLOSED
+
+        mock_coro = AsyncMock(side_effect=ValueError("fail"))
+        for _ in range(3):
+            with pytest.raises(ValueError):
+                await cb.call(mock_coro())
+
+        assert cb.state == CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_raises_circuit_open_error(self):
+        """In OPEN state, call raises CircuitOpenError with retry_after."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=30.0, _time=lambda: 0.0)
+
+        mock_coro = AsyncMock(side_effect=ValueError("fail"))
+        for _ in range(3):
+            with pytest.raises(ValueError):
+                await cb.call(mock_coro())
+
+        assert cb.state == CircuitState.OPEN
+
+        with pytest.raises(CircuitOpenError) as exc_info:
+            await cb.call(AsyncMock()())
+
+        assert exc_info.value.opened_at == 0.0
+        assert exc_info.value.retry_after == 30.0
+
+    @pytest.mark.asyncio
+    async def test_old_failures_pruned(self):
+        """Failures outside the window are pruned — resets the count."""
+        cb = CircuitBreaker(failure_threshold=2, failure_window=60.0, _time=lambda: _time_val)
+
+        _time_val = 0.0
+        mock_coro = AsyncMock(side_effect=ValueError("fail"))
+
+        # First failure at t=0
+        with pytest.raises(ValueError):
+            await cb.call(mock_coro())
+
+        _time_val = 70.0  # outside 60s window
+
+        # Second failure at t=70 — old failure pruned, count=1 not >=2
+        with pytest.raises(ValueError):
+            await cb.call(mock_coro())
+        assert cb.state == CircuitState.CLOSED
+
+        # Third failure at t=70.0 (still the same instant, second stays)
+        with pytest.raises(ValueError):
+            await cb.call(mock_coro())
+        assert cb.state == CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_success_resets_failure_count(self):
+        """A success in CLOSED resets the failure count."""
+        cb = CircuitBreaker(failure_threshold=3, _time=lambda: 0.0)
+
+        mock_fail = AsyncMock(side_effect=ValueError("fail"))
+        with pytest.raises(ValueError):
+            await cb.call(mock_fail())
+        with pytest.raises(ValueError):
+            await cb.call(mock_fail())
+
+        # Now a success — resets count
+        mock_ok = AsyncMock(return_value="ok")
+        result = await cb.call(mock_ok())
+        assert result == "ok"
+
+        # Two more failures should NOT trip (count reset to 0)
+        with pytest.raises(ValueError):
+            await cb.call(mock_fail())
+        with pytest.raises(ValueError):
+            await cb.call(mock_fail())
+        assert cb.state == CircuitState.CLOSED
+
+        # Third failure trips since count is now 3
+        with pytest.raises(ValueError):
+            await cb.call(mock_fail())
+        assert cb.state == CircuitState.OPEN
+
+
+class TestCircuitBreakerOpenToHalfOpen:
+    """OPEN → HALF_OPEN after recovery_timeout."""
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_half_open_after_timeout(self):
+        """After recovery_timeout, state becomes HALF_OPEN."""
+        cb = CircuitBreaker(failure_threshold=2, recovery_timeout=30.0, _time=lambda: _time_val)
+
+        _time_val = 0.0
+        mock_fail = AsyncMock(side_effect=ValueError("fail"))
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await cb.call(mock_fail())
+
+        assert cb.state == CircuitState.OPEN
+
+        # Advance clock past recovery_timeout, then call — should transition to HALF_OPEN and pass through
+        _time_val = 31.0
+        mock_ok = AsyncMock(return_value="recovered")
+        result = await cb.call(mock_ok())
+        assert result == "recovered"
+        assert cb.state == CircuitState.HALF_OPEN
+
+    @pytest.mark.asyncio
+    async def test_stays_open_before_timeout(self):
+        """Calling before recovery_timeout passes still raises CircuitOpenError."""
+        cb = CircuitBreaker(failure_threshold=2, recovery_timeout=30.0, _time=lambda: _time_val)
+
+        _time_val = 0.0
+        mock_fail = AsyncMock(side_effect=ValueError("fail"))
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await cb.call(mock_fail())
+        assert cb.state == CircuitState.OPEN
+
+        _time_val = 10.0  # only 10s elapsed, still < 30
+        with pytest.raises(CircuitOpenError):
+            await cb.call(AsyncMock()())
+
+        assert cb.state == CircuitState.OPEN
+
+    @pytest.mark.asyncio
+    async def test_retry_after_updates_on_reopen(self):
+        """When HALF_OPEN fails and re-opens, the timer resets."""
+        cb = CircuitBreaker(failure_threshold=2, recovery_timeout=30.0, _time=lambda: _time_val)
+
+        _time_val = 0.0
+        mock_fail = AsyncMock(side_effect=ValueError("fail"))
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await cb.call(mock_fail())
+        assert cb.state == CircuitState.OPEN
+
+        # Transition to HALF_OPEN
+        _time_val = 31.0
+        with pytest.raises(ValueError):
+            await cb.call(mock_fail())
+        # HALF_OPEN failure → back to OPEN, timer reset to now (31.0)
+        assert cb.state == CircuitState.OPEN
+
+        # At 60.0 (only 29s since re-open), should still raise CircuitOpenError
+        _time_val = 60.0
+        with pytest.raises(CircuitOpenError):
+            await cb.call(AsyncMock()())
+        assert cb.state == CircuitState.OPEN
+
+        # At 62.0 (31s since re-open), transitions to HALF_OPEN
+        _time_val = 62.0
+        mock_ok = AsyncMock(return_value="ok")
+        result = await cb.call(mock_ok())
+        assert result == "ok"
+        assert cb.state == CircuitState.HALF_OPEN
+
+
+class TestCircuitBreakerHalfOpenToClosed:
+    """HALF_OPEN → CLOSED after half_open_successes successes."""
+
+    @pytest.mark.asyncio
+    async def test_closes_after_required_successes(self):
+        """half_open_successes successes in HALF_OPEN → CLOSED."""
+        cb = CircuitBreaker(failure_threshold=2, recovery_timeout=30.0, half_open_successes=3, _time=lambda: _time_val)
+
+        _time_val = 0.0
+        mock_fail = AsyncMock(side_effect=ValueError("fail"))
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await cb.call(mock_fail())
+
+        # Move to HALF_OPEN
+        _time_val = 31.0
+        # First success
+        result = await cb.call(AsyncMock(return_value="ok1")())
+        assert result == "ok1"
+        assert cb.state == CircuitState.HALF_OPEN
+
+        # Second success
+        _time_val = 32.0
+        result = await cb.call(AsyncMock(return_value="ok2")())
+        assert result == "ok2"
+        assert cb.state == CircuitState.HALF_OPEN
+
+        # Third success → CLOSED
+        _time_val = 33.0
+        result = await cb.call(AsyncMock(return_value="ok3")())
+        assert result == "ok3"
+        assert cb.state == CircuitState.CLOSED
+
+    @pytest.mark.asyncio
+    async def test_half_open_failure_opens_again(self):
+        """A failure in HALF_OPEN → OPEN, resetting timer."""
+        cb = CircuitBreaker(failure_threshold=2, recovery_timeout=30.0, half_open_successes=3, _time=lambda: _time_val)
+
+        _time_val = 0.0
+        mock_fail = AsyncMock(side_effect=ValueError("fail"))
+        for _ in range(2):
+            with pytest.raises(ValueError):
+                await cb.call(mock_fail())
+        assert cb.state == CircuitState.OPEN
+
+        _time_val = 31.0
+        # HALF_OPEN, one success
+        result = await cb.call(AsyncMock(return_value="ok1")())
+        assert result == "ok1"
+        assert cb.state == CircuitState.HALF_OPEN
+
+        # Then a failure → back to OPEN
+        _time_val = 32.0
+        with pytest.raises(ValueError):
+            await cb.call(mock_fail())
+        assert cb.state == CircuitState.OPEN
+
+        # Check timer was reset (need another 30s)
+        _time_val = 33.0
+        with pytest.raises(CircuitOpenError):
+            await cb.call(AsyncMock()())
+
+        _time_val = 63.0
+        result = await cb.call(AsyncMock(return_value="ok_after_reopen")())
+        assert result == "ok_after_reopen"
+        assert cb.state == CircuitState.HALF_OPEN
+
+
+class TestCircuitBreakerConcurrency:
+    """Async safety with concurrent calls."""
+
+    @pytest.mark.asyncio
+    async def test_lock_prevents_race(self):
+        """Concurrent access to state is safe (basic smoke test)."""
+
+        cb = CircuitBreaker(failure_threshold=2, _time=lambda: 0.0)
+        mock_fail = AsyncMock(side_effect=ValueError("fail"))
+
+        exceptions = []
+
+        async def fail_call():
+            try:
+                await cb.call(mock_fail())
+            except (ValueError, CircuitOpenError):
+                exceptions.append(True)
+
+        # Fire 4 concurrent failing calls
+        await asyncio.gather(fail_call(), fail_call(), fail_call(), fail_call())
+        # After at least 2 failures, the breaker should be OPEN
+        assert cb.state == CircuitState.OPEN
+        assert len(exceptions) == 4


### PR DESCRIPTION
Implements #33

### Changes
- **New:** `src/cortex/llm/circuit_breaker.py` — `CircuitBreaker`, `CircuitState`, `CircuitOpenError`
- **New:** `tests/unit/test_circuit_breaker.py` — 15 tests (state transitions, concurrency, failure pruning)
- **Modified:** `src/cortex/llm/__init__.py` — exports new types
- **Modified:** `CONTEXT.md` — domain vocabulary for circuit breaker

### Key design decisions
- Injected `_time` parameter for deterministic testing (avoids `asyncio.sleep` in tests)
- `asyncio.Lock` for async-safe state transitions
- `except Exception` (not `BaseException`) — CancelledError/KeyboardInterrupt don't trip the breaker

Closes #33