### PR TITLE
fix: make the stack boot and serve end-to-end for local alpha use

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@
 # Copy this file to .env and fill in your values
 
 # Database
-DB_URL=postgresql://cortex:cortex@localhost:5432/cortex
+DATABASE_URL=postgresql://cortex:cortex@localhost:5432/cortex
 
 # LLM Provider
 LLM_PROVIDER=openai

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 
@@ -7,13 +7,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy pyproject.toml first for caching
-COPY pyproject.toml ./
+# Copy pyproject + lockfile first for caching
+COPY pyproject.toml uv.lock ./
 
 # Install uv for fast package management
 RUN pip install uv
 
-# Install dependencies
+# Install dependencies into the project venv
 RUN uv sync --frozen --no-install-project
 
 # Copy source code
@@ -23,8 +23,9 @@ COPY migrations/ ./migrations/
 # Copy migrations to expected location (migrations runner looks for src/../migrations)
 RUN mkdir -p src/migrations && cp -r migrations/* src/migrations/
 
-# Set Python path
+# Set Python path and use the uv-managed venv
 ENV PYTHONPATH=/app/src
+ENV PATH="/app/.venv/bin:$PATH"
 
-# Run the application
-CMD ["python", "-m", "cortex.main"]
+# Run the application (__main__ serves uvicorn)
+CMD ["python", "-m", "cortex"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       POSTGRES_DB: cortex
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./migrations:/docker-entrypoint-initdb.d:ro
     ports:
       - "5432:5432"
     healthcheck:

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -14,7 +14,9 @@ persistence_file mosquitto.db
 
 # Message retention
 max_queued_messages 1000
-message_expiry_interval 86400
+# Retained messages carrying a message-expiry property are purged on access;
+# also sweep the retained tree periodically for expired messages.
+retain_expiry_interval 1440
 
 # Logging
 log_dest file /mosquitto/log/mosquitto.log

--- a/migrations/001_initial.sql
+++ b/migrations/001_initial.sql
@@ -1,11 +1,10 @@
 -- 001_initial.sql
 -- Core schema: schema_migrations table
+-- The application migration runner (cortex.db.migrations.runner) creates
+-- this table and records applied versions; initdb must not seed it or the
+-- runner's bookkeeping collides (duplicate key / type mismatch).
 
 CREATE TABLE IF NOT EXISTS schema_migrations (
-    version INTEGER PRIMARY KEY,
-    applied_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    description TEXT
+    version VARCHAR(255) PRIMARY KEY,
+    applied_at TIMESTAMP DEFAULT NOW()
 );
-
--- Track applied migrations
-INSERT INTO schema_migrations (version, description) VALUES (1, 'Initial schema');

--- a/src/cortex/api/auth.py
+++ b/src/cortex/api/auth.py
@@ -70,8 +70,28 @@ async def get_api_key(
     if token_hash in _token_cache:
         return token_hash
 
-    # If not in cache, we need to check the database
-    # This will be wired up in the bootstrap phase
+    # Fall back to the database: the in-memory cache is loaded at startup,
+    # so tokens created later (e.g. via `cortex token:create`) would be
+    # rejected forever otherwise. Cache hits on success.
+    try:
+        from cortex.api.dependencies import get_db_pool
+
+        db = await get_db_pool()
+        async with db.acquire() as conn:
+            row = await conn.fetchrow(
+                "SELECT id, key_hash, name FROM api_keys WHERE key_hash = $1 AND revoked_at IS NULL",
+                token_hash,
+            )
+            if row is not None:
+                _token_cache[row["key_hash"]] = {
+                    "id": str(row["id"]),
+                    "name": row["name"],
+                }
+                return token_hash
+    except Exception:
+        # DB unavailable: reject rather than crash the request
+        pass
+
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail={"error": "unauthorized", "detail": "Invalid API token"},

--- a/src/cortex/api/routes/sessions.py
+++ b/src/cortex/api/routes/sessions.py
@@ -32,7 +32,7 @@ async def list_sessions(
     return [
         SessionResponse(
             id=s.id,
-            state=s.state.value,
+            state=s.state,
             created_at=s.created_at,
             last_activity_at=s.last_activity_at,
             ended_at=s.ended_at,
@@ -55,7 +55,7 @@ async def create_session(
     session = await policy.create_session(session_repo)
     return SessionResponse(
         id=session.id,
-        state=session.state.value,
+        state=session.state,
         created_at=session.created_at,
         last_activity_at=session.last_activity_at,
         ended_at=session.ended_at,
@@ -86,7 +86,7 @@ async def get_session(
     return SessionWithMessages(
         session=SessionResponse(
             id=result.session.id,
-            state=result.session.state.value,
+            state=result.session.state,
             created_at=result.session.created_at,
             last_activity_at=result.session.last_activity_at,
             ended_at=result.session.ended_at,
@@ -95,7 +95,7 @@ async def get_session(
         messages=[
             MessageResponse(
                 id=m.id,
-                role=m.role.value,
+                role=m.role,
                 content=m.content,
                 tool_calls=m.tool_calls,
                 created_at=m.created_at,
@@ -145,7 +145,7 @@ async def create_message(
 
     return MessageResponse(
         id=msg.id,
-        role=msg.role.value,
+        role=msg.role,
         content=msg.content,
         tool_calls=msg.tool_calls,
         created_at=msg.created_at,
@@ -173,7 +173,7 @@ async def end_session(
 
     return SessionResponse(
         id=session.id,
-        state=session.state.value,
+        state=session.state,
         created_at=session.created_at,
         last_activity_at=session.last_activity_at,
         ended_at=session.ended_at,
@@ -202,7 +202,7 @@ async def resume_session(
 
     return SessionResponse(
         id=session.id,
-        state=session.state.value,
+        state=session.state,
         created_at=session.created_at,
         last_activity_at=session.last_activity_at,
         ended_at=session.ended_at,

--- a/src/cortex/config/loader.py
+++ b/src/cortex/config/loader.py
@@ -4,6 +4,8 @@ Configuration loader for Botticello.
 Loads settings from YAML files and environment variables.
 """
 
+import os
+import re
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -12,6 +14,8 @@ import yaml
 from pydantic import ValidationError
 
 from cortex.config.models import Settings
+
+_UNRESOLVED_ENV_REF = re.compile(r"\$\{?\w+\}?")
 
 
 def find_config_file() -> Path | None:
@@ -54,6 +58,32 @@ def _flatten_dict(d: dict[str, Any], parent_key: str = "", sep: str = "_") -> di
     return dict(items)
 
 
+def _resolve_env_refs(value: Any) -> Any:
+    """Expand ``${VAR}`` references in a YAML scalar.
+
+    Returns the expanded value, or ``None`` when a referenced variable is
+    unset so the caller can fall back to environment variables / defaults
+    instead of passing a literal placeholder to Settings.
+    """
+    if not isinstance(value, str):
+        return value
+
+    def _replace(match: re.Match[str]) -> str:
+        name = match.group(0).strip("${}")
+        if name not in os.environ:
+            raise _UnresolvedEnvRef(name)
+        return os.environ[name]
+
+    try:
+        return _UNRESOLVED_ENV_REF.sub(_replace, value)
+    except _UnresolvedEnvRef:
+        return None
+
+
+class _UnresolvedEnvRef(Exception):
+    """Raised internally when a ${VAR} reference is not set in the environment."""
+
+
 def load_settings(config_path: Path | None = None) -> Settings:
     """
     Load settings from YAML file and environment variables.
@@ -62,6 +92,10 @@ def load_settings(config_path: Path | None = None) -> Settings:
     1. Environment variables
     2. YAML config file
     3. Default values in Settings model
+
+    ``${VAR}`` references inside YAML scalars are resolved from the
+    environment; values whose references are unset are dropped so the
+    environment variable of the same name (or the field default) wins.
 
     Args:
         config_path: Optional path to config YAML file.
@@ -74,7 +108,11 @@ def load_settings(config_path: Path | None = None) -> Settings:
         ValidationError: If settings are invalid.
     """
     # Load YAML config
-    yaml_config = load_yaml_config(config_path)
+    raw_yaml_config = load_yaml_config(config_path)
+    yaml_config = {
+        k: {sk: _resolve_env_refs(sv) for sk, sv in sv.items()} if isinstance(sv, dict) else _resolve_env_refs(sv)
+        for k, sv in raw_yaml_config.items()
+    }
 
     # Convert YAML to Pydantic-compatible nested dict
     settings_data: dict[str, Any] = {

--- a/src/cortex/db/pool.py
+++ b/src/cortex/db/pool.py
@@ -1,5 +1,6 @@
 """Async PostgreSQL connection pool management."""
 
+import json
 import logging
 import re
 from collections.abc import AsyncGenerator
@@ -55,6 +56,22 @@ def _parse_db_url(url: str) -> dict:
     }
 
 
+async def _init_connection(conn: asyncpg.Connection) -> None:
+    """Set up per-connection codecs: return JSON/JSONB as Python objects."""
+    await conn.set_type_codec(
+        "jsonb",
+        encoder=json.dumps,
+        decoder=json.loads,
+        schema="pg_catalog",
+    )
+    await conn.set_type_codec(
+        "json",
+        encoder=json.dumps,
+        decoder=json.loads,
+        schema="pg_catalog",
+    )
+
+
 async def create_pool(settings: Settings) -> asyncpg.Pool:
     """
     Create a connection pool to PostgreSQL.
@@ -86,6 +103,7 @@ async def create_pool(settings: Settings) -> asyncpg.Pool:
         min_size=settings.db_pool_min_size,
         max_size=settings.db_pool_max_size,
         command_timeout=settings.db_pool_timeout,
+        init=_init_connection,
     )
 
     logger.info("Database pool created successfully")

--- a/src/cortex/execution/module.py
+++ b/src/cortex/execution/module.py
@@ -266,8 +266,8 @@ class ExecutionModule:
             {"goal_id": str(goal_id), **data},
         )
 
-    def subscribe(self) -> None:
+    async def subscribe(self) -> None:
         """Subscribe to events."""
         if self._event_bus:
-            self._event_bus.subscribe("goal.created", self.handle_event)
-            self._event_bus.subscribe("recommendation.executed", self.handle_event)
+            await self._event_bus.subscribe("goal.created", self.handle_event)
+            await self._event_bus.subscribe("recommendation.executed", self.handle_event)

--- a/src/cortex/main.py
+++ b/src/cortex/main.py
@@ -144,15 +144,15 @@ async def initialize_app() -> CortexApp:
     from cortex.sessions.repository import PostgresSessionRepository
     from cortex.sessions.interfaces import SessionRepository
 
-    session_repo: SessionRepository = PostgresSessionRepository(cortex.db_pool)
+    session_repo: SessionRepository = PostgresSessionRepository()
     cortex.session_repository = session_repo
 
     # 5b. Create memory repositories
     from cortex.memory.repository import PostgresFactRepository, PostgresConceptRepository
     from cortex.memory.interfaces import FactRepository, ConceptRepository, FactExtractor
 
-    fact_repo: FactRepository = PostgresFactRepository(cortex.db_pool)
-    concept_repo: ConceptRepository = PostgresConceptRepository(cortex.db_pool)
+    fact_repo: FactRepository = PostgresFactRepository()
+    concept_repo: ConceptRepository = PostgresConceptRepository()
     memory_extractor: FactExtractor | None = None
 
     # 5c. Create LLM client
@@ -290,7 +290,7 @@ async def _subscribe_services(cortex: CortexApp) -> None:
         return
 
     # Subscribe execution module
-    cortex.execution_module.subscribe()
+    await cortex.execution_module.subscribe()
 
     # Subscribe memory service to relevant events
     if cortex.memory_service:

--- a/src/cortex/minions/mqtt_client.py
+++ b/src/cortex/minions/mqtt_client.py
@@ -44,22 +44,22 @@ class MinionMQTTClient(MinionGateway):
                 extra={"broker": self._config.broker_url},
             )
 
-            # Create client with optional auth
-            if self._config.username and self._config.password:
-                self._client = aiomqtt.Client(
-                    identifier=self._config.minion_id,
-                    username=self._config.username,
-                    password=self._config.password,
-                )
-            else:
-                self._client = aiomqtt.Client(
-                    identifier=self._config.minion_id,
-                )
+            # aiomqtt 2.x: hostname/port go to the constructor; the client
+            # connects on __aenter__.
+            host_port = self._config.broker_url.replace("mqtt://", "").split("/")[0]
+            host, _, port_str = host_port.partition(":")
+            port = int(port_str) if port_str else self._config.port
 
-            # Connect
-            host = self._config.broker_url.replace("mqtt://", "")
-            port = self._config.port
-            await self._client.connect(host, port, keepalive=self._config.keepalive)
+            self._client = aiomqtt.Client(
+                hostname=host,
+                port=port,
+                identifier=self._config.minion_id,
+                username=self._config.username or None,
+                password=self._config.password or None,
+                keepalive=self._config.keepalive,
+            )
+
+            await self._client.__aenter__()
 
             self._connected = True
             logger.info(
@@ -85,7 +85,7 @@ class MinionMQTTClient(MinionGateway):
 
         # Disconnect client
         if self._client:
-            await self._client.disconnect()
+            await self._client.__aexit__(None, None, None)
             self._client = None
 
         self._connected = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,12 @@
 """Pytest configuration for asyncio tests."""
 
+import os
+
 import pytest
+
+# Real Settings require llm_api_key; config.yaml's ${OPENAI_API_KEY}
+# placeholder is dropped when the variable is unset, so give tests a dummy key.
+os.environ.setdefault("LLM_API_KEY", "test-key")
 
 # pytest-asyncio handles event loop setup automatically
 # No custom event_loop_policy fixture needed


### PR DESCRIPTION
The docker-compose stack failed to build/start on several independent
blockers; all are fixed and verified against a live stack (415 unit tests
pass, /health healthy, chat + sessions + auth work end-to-end):

- Dockerfile: copy uv.lock so `uv sync --frozen` works, base python:3.12
  (project requires >=3.12), and run `python -m cortex` so uvicorn is
  actually served (cortex.main only initializes)
- mosquitto.conf: replace invalid message_expiry_interval directive that
  crashed the broker at startup
- config loader: resolve ${VAR} references in YAML values so env vars win
  over literal placeholders; fix DATABASE_URL name in .env.example
- migrations: app runner is the single source of truth (drop initdb mount,
  align 001 schema with the runner) - fixes duplicate-key crash on boot
- main.py: Postgres*Repository constructors take no arguments
- db pool: register json/jsonb codecs so JSONB columns return dicts
- api auth: fall back to the DB when a token is not in the startup cache,
  so tokens created after boot (cortex token:create) work
- aiomqtt 2.x: hostname/port in constructor, __aenter__/__aexit__ instead
  of removed connect()/disconnect()
- execution module: await EventBus.subscribe (was never awaited)
- sessions route: drop .value on enums already converted by use_enum_values
- tests: provide a dummy LLM_API_KEY in conftest for real Settings loading
