### PR TITLE
feat: wire LLM base_url + DeepSeek provider

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,10 @@ database:
   pool_timeout: 30
 
 llm:
-  provider: "openai"
-  api_key: "${OPENAI_API_KEY}"  # Set via environment variable
-  model: "gpt-4o"
+  provider: "openai"  # DeepSeek is OpenAI-compatible
+  api_key: "${LLM_API_KEY}"  # Set via environment variable (.env)
+  base_url: "https://api.deepseek.com"
+  model: "deepseek-chat"
   timeout: 60
 
 mqtt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,8 @@ services:
       MQTT_BROKER_URL: mqtt://mosquitto:1883
       MQTT_PASSWD_PATH: /mosquitto/config/passwd.conf
       LLM_API_KEY: ${LLM_API_KEY}
+      LLM_MODEL: ${LLM_MODEL:-deepseek-chat}
+      LLM_BASE_URL: ${LLM_BASE_URL:-https://api.deepseek.com}
       LOG_LEVEL: INFO
       LOG_FORMAT: console
     volumes:

--- a/src/cortex/llm/providers/openai.py
+++ b/src/cortex/llm/providers/openai.py
@@ -27,10 +27,10 @@ class OpenAIClient(LLMClient):
     Supports GPT-4, GPT-4o, GPT-3.5-turbo and function calling.
     """
 
-    def __init__(self, api_key: str, model: str = "gpt-4o"):
+    def __init__(self, api_key: str, model: str = "gpt-4o", base_url: str | None = None):
         self._api_key = api_key
         self._model = model
-        self._client = AsyncOpenAI(api_key=api_key)
+        self._client = AsyncOpenAI(api_key=api_key, base_url=base_url)
 
     @classmethod
     def from_settings(cls, settings: Settings) -> "OpenAIClient":
@@ -38,6 +38,7 @@ class OpenAIClient(LLMClient):
         return cls(
             api_key=settings.llm_api_key.get_secret_value(),
             model=settings.llm_model,
+            base_url=settings.llm_base_url,
         )
 
     def get_provider_name(self) -> str:

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -114,6 +114,7 @@ class TestOpenAIClient:
         settings = MagicMock()
         settings.llm_api_key.get_secret_value.return_value = "test-key"
         settings.llm_model = "gpt-4o"
+        settings.llm_base_url = None
         return settings
 
     def test_from_settings(self, mock_settings):
@@ -175,6 +176,7 @@ class TestLLMClientFactory:
         settings.llm_provider = "openai"
         settings.llm_api_key.get_secret_value.return_value = "test-key"
         settings.llm_model = "gpt-4o"
+        settings.llm_base_url = None
         return settings
 
     def test_create_default_provider(self, mock_settings):


### PR DESCRIPTION
OpenAIClient ignored `settings.llm_base_url` — any OpenAI-compatible provider was unusable. This wires base_url through and configures DeepSeek locally. Verified live: /chat returns a real DeepSeek response (was 401 against api.openai.com). 415 tests, ruff, mypy green.