### PR TITLE
feat: coverage gate in CI + pin system invariants (CB1, SP1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,23 @@ jobs:
       - name: Run mypy
         run: uv run mypy src/cortex
 
+  coverage:
+    name: Coverage (pytest-cov)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Run coverage
+        run: uv run pytest tests/unit -q --cov=src/cortex --cov-report=term --cov-fail-under=70
+
   build:
     name: Docker build
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -95,8 +95,10 @@ Every non-obvious call is written down with its rationale in
 | [0008](docs/adr/0008-embedding-semantic-search.md) | Embedding-based semantic fact search |
 | [0009](docs/adr/0009-circuit-breaker.md) | Circuit breaker for resilience |
 | [0010](docs/adr/0010-per-module-config.md) | Per-module configuration |
+| [0011](docs/adr/0011-public-get-or-create-session.md) | Public get_or_create_session on InteractionService |
+| [0012](docs/adr/0012-system-invariants.md) | System invariants — CircuitBreaker + SessionPolicy |
 
-(Full list, 0001–0011, in the folder.)
+(Full list, 0001–0012, in the folder.)
 
 ## Architecture at a glance
 

--- a/docs/adr/0012-system-invariants.md
+++ b/docs/adr/0012-system-invariants.md
@@ -1,0 +1,104 @@
+# ADR-0012: System Invariants — CircuitBreaker and SessionPolicy
+
+Status: accepted (2026-08-06)
+
+Per the agentic workflow (WORKFLOW.md phase 3), domain laws are recorded in
+the campaign format — law → negation → where verified — and each law MUST
+have a test that can fail (anti-vacuity: an invariant without a test that can
+fail is an opinion). This ADR is the canonical home for the invariants of the
+modules written so far.
+
+---
+
+## CircuitBreaker (`src/cortex/llm/circuit_breaker.py`)
+
+### CB1 — OPEN fast-fails without executing the underlying call
+
+- **Law**: while the circuit is OPEN (before `recovery_timeout` elapses),
+  `call()` raises `CircuitOpenError` and the wrapped coroutine is NEVER
+  awaited.
+- **Negation**: a call while OPEN awaits the provider (thundering herd).
+- **Where verified**: `tests/unit/test_circuit_breaker.py::
+  TestCircuitBreakerClosedToOpen::test_open_never_executes_underlying_coro`
+  (added 2026-08-06; was unpinned — the old test only asserted the error).
+
+### CB2 — OPEN transitions to HALF_OPEN exactly after recovery_timeout
+
+- **Law**: before `recovery_timeout`, calls stay OPEN; on the first call at/after
+  the timeout, the circuit moves to HALF_OPEN with the success counter reset
+  to zero.
+- **Negation**: the circuit recovers early, or never recovers.
+- **Where verified**: `test_transitions_to_half_open_after_timeout`,
+  `test_stays_open_before_timeout`.
+
+### CB3 — one failure in HALF_OPEN reopens the circuit with a fresh timer
+
+- **Law**: any failure in HALF_OPEN trips the circuit back to OPEN and
+  restarts `opened_at`/`retry_after`.
+- **Negation**: a HALF_OPEN failure keeps the circuit half-open.
+- **Where verified**: `test_half_open_failure_opens_again`,
+  `test_retry_after_updates_on_reopen`.
+
+### CB4 — CLOSED requires half_open_successes consecutive successes to recover
+
+- **Law**: the circuit closes only after `half_open_successes` consecutive
+  successes in HALF_OPEN; a success in CLOSED resets the failure counter.
+- **Negation**: a single success in HALF_OPEN closes the circuit.
+- **Where verified**: `test_closes_after_required_successes`,
+  `test_success_resets_failure_count`.
+
+### CB5 — CLOSED trips OPEN on failure_threshold failures within failure_window
+
+- **Law**: `failure_threshold` failures within the sliding `failure_window`
+  trip the circuit; failures older than the window are pruned and do not
+  count.
+- **Negation**: stale failures count, or the threshold never trips.
+- **Where verified**: `test_opens_after_threshold_failures`,
+  `test_old_failures_pruned`.
+
+---
+
+## SessionPolicy (`src/cortex/sessions/policy.py`)
+
+### SP1 — an ENDED session is terminal
+
+- **Law**: an ENDED session is never handed back as a resumable session;
+  `get_or_create_session` and `resume_session` treat ENDED as absent and
+  create/return a fresh ACTIVE session instead.
+- **Negation**: an ENDED session is returned for continued use.
+- **Where verified**: `test_returns_none_for_ended_session` (resume),
+  `test_ended_session_is_terminal_creates_new` (get_or_create, added
+  2026-08-06). **This was a real bug**: `get_or_create_session` returned the
+  ENDED session unchanged; fixed in 0012 by filtering `ENDED` before reuse.
+
+### SP2 — created sessions are immediately ACTIVE
+
+- **Law**: `create_session` and `get_or_create_session` (create path) return a
+  session in ACTIVE state, never CREATED.
+- **Negation**: a session is created but left in CREATED.
+- **Where verified**: `test_creates_then_marks_active`,
+  `test_creates_new_when_id_is_none`.
+
+### SP3 — IDLE sessions auto-resume on first use
+
+- **Law**: adding a message to or resuming an IDLE session transitions it to
+  ACTIVE; an ACTIVE session is left unchanged.
+- **Negation**: an IDLE session stays idle while being used.
+- **Where verified**: `test_auto_resumes_idle_session`,
+  `test_resumes_idle_session`, `test_passes_through_active_session_unchanged`.
+
+### SP4 — end_session is idempotent and stamps the timestamp
+
+- **Law**: `end_session` sets state ENDED with a non-null `ended_at`.
+- **Negation**: an ended session lacks a timestamp or stays active.
+- **Where verified**: `test_marks_ended_with_timestamp`.
+
+---
+
+## Governance
+
+- New domain laws for touched modules MUST be appended here (or to the
+  `## System Invariants` section of the relevant spec) and pinned with a
+  failing-capable test, per the workflow's anti-vacuity rule.
+- When a module has no domain laws, the skip annotation on the ticket must
+  state "no domain laws" explicitly.

--- a/src/cortex/sessions/policy.py
+++ b/src/cortex/sessions/policy.py
@@ -77,9 +77,13 @@ async def end_session(repo: SessionRepository, session_id: UUID) -> Session | No
 async def get_or_create_session(
     repo: SessionRepository, session_id: UUID | None
 ) -> Session:
-    """Look up a session by id, or create a new ACTIVE one if id is None or missing."""
+    """Look up a session by id, or create a new ACTIVE one if id is None, missing, or ENDED.
+
+    An ENDED session is terminal (see SP1): it is never handed back as a
+    resumable session — a fresh one is created instead.
+    """
     if session_id is not None:
         session = await repo.get(session_id)
-        if session is not None:
+        if session is not None and session.state != SessionState.ENDED:
             return session
     return await create_session(repo)

--- a/tests/unit/sessions/test_policy.py
+++ b/tests/unit/sessions/test_policy.py
@@ -180,3 +180,20 @@ class TestGetOrCreateSession:
 
         assert result.state == SessionState.ACTIVE
         mock_repo.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_ended_session_is_terminal_creates_new(self, mock_repo):
+        """INVARIANT SP1: an ENDED session is terminal — get_or_create must
+        never hand it back as a resumable session."""
+        ended = Session(id=uuid4(), state=SessionState.ENDED)
+        mock_repo.get.return_value = ended
+        new_session = Session(id=uuid4(), state=SessionState.CREATED)
+        active = Session(id=new_session.id, state=SessionState.ACTIVE)
+        mock_repo.create.return_value = new_session
+        mock_repo.update_state.return_value = active
+
+        result = await policy.get_or_create_session(mock_repo, ended.id)
+
+        assert result.state == SessionState.ACTIVE
+        mock_repo.create.assert_called_once()
+        mock_repo.update_state.assert_called_once_with(new_session.id, SessionState.ACTIVE)

--- a/tests/unit/test_circuit_breaker.py
+++ b/tests/unit/test_circuit_breaker.py
@@ -89,6 +89,29 @@ class TestCircuitBreakerClosedToOpen:
         assert exc_info.value.retry_after == 30.0
 
     @pytest.mark.asyncio
+    async def test_open_never_executes_underlying_coro(self):
+        """INVARIANT CB1: in OPEN, calls fast-fail WITHOUT awaiting the coro."""
+        cb = CircuitBreaker(failure_threshold=3, recovery_timeout=30.0, _time=lambda: 0.0)
+
+        for _ in range(3):
+            with pytest.raises(ValueError):
+                await cb.call(AsyncMock(side_effect=ValueError("fail"))())
+
+        assert cb.state == CircuitState.OPEN
+
+        # The underlying coroutine body must never run while OPEN.
+        executed = False
+
+        async def underlying() -> str:
+            nonlocal executed
+            executed = True
+            return "should-not-run"
+
+        with pytest.raises(CircuitOpenError):
+            await cb.call(underlying())
+        assert executed is False
+
+    @pytest.mark.asyncio
     async def test_old_failures_pruned(self):
         """Failures outside the window are pruned — resets the count."""
         cb = CircuitBreaker(failure_threshold=2, failure_window=60.0, _time=lambda: _time_val)


### PR DESCRIPTION
## Coverage gate (A)
New CI job runs pytest-cov with `--cov-fail-under=70` (current 71.8%). Becomes a required check on master (after merge).

## System invariants (D)
ADR-0012 records domain laws for CircuitBreaker (CB1-CB5) and SessionPolicy (SP1-SP4) in the campaign format (law → negation → where verified), per the workflow anti-vacuity rule.

## Real bug found
SP1: `get_or_create_session` returned an ENDED session unchanged (terminal-state violation) — fixed to treat ENDED like missing. CB1 (OPEN never awaits the provider) was unpinned — now tested; code already honored it.

Verified: 417 tests, coverage 71.8% ≥ 70, ruff + mypy clean.