### PR TITLE
chore: add pre-commit hooks (ruff, mypy)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.12
+    hooks:
+      - id: ruff
+        name: ruff (lint)
+        args: [src, tests]
+        files: ^(src|tests)/
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.20.2
+    hooks:
+      - id: mypy
+        name: mypy (typecheck)
+        args: [src/cortex]
+        pass_filenames: false
+        additional_dependencies:
+          - pydantic>=2.0
+          - pydantic-settings>=2.0
+          - asyncpg>=0.29
+          - openai>=1.0
+          - aiomqtt>=2.0
+          - pyyaml>=6.0
+          - structlog>=24.0
+          - tenacity>=8.0
+          - fastapi>=0.115
+          - httpx>=0.27
+          - typer>=0.15
+          - uvicorn>=0.30
+          - types-PyYAML
+          - types-colorama


### PR DESCRIPTION
Local gate mirroring the CI checks: ruff (src/tests) + mypy (src/cortex) run on every commit. Installed via pre-commit 4.6.0; verified passing on all files. Push-to-master is blocked by branch protection, hence the PR.