### PR TITLE
feat: LoopEvent streaming models for AgentLoop (ADR-0002)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,3 +24,13 @@ Enum: CLOSED, OPEN, HALF_OPEN. Represents the current state of a circuit breaker
 **LLMFactory**:
 Creates LLMClient instances. Each consumer module (Execution, Memory, Learning) gets its own CircuitBreakerLLMClient with an independent CircuitBreaker, so failures in one module don't affect others.
 _Avoid_: Factory, provider factory
+
+## Agentic Loop
+
+**LoopEvent**:
+A progress signal the AgentLoop emits for its caller (SSE, CLI) as it runs: thinking, text deltas, tool start/result, done, error. Caller-scoped — never published on the event bus.
+_Avoid_: Stream event, loop bus event
+
+**System Event**:
+An event published on the Cortex event bus for any module to consume (e.g. goal.created, concept.rejected). Distinct from LoopEvent: system events are system-wide domain information; LoopEvents are per-caller progress.
+_Avoid_: Domain event, bus event

--- a/docs/AGENTIC_LOOP.md
+++ b/docs/AGENTIC_LOOP.md
@@ -792,58 +792,33 @@ class AgentLoop:
 
 ## Event Emissions
 
-The loop emits events for observability and learning:
+Loop progress is exposed to the loop's caller via `stream_chat()`, which yields
+`LoopEvent` instances (defined in `src/cortex/agentic/events.py`, per ADR-0002).
+These are caller-scoped progress signals — they are **not** published to the
+event bus. Each event's `event_type` is the wire name directly, one vocabulary
+with no mapping table: `thinking`, `text`, `tool_start`, `tool_done`, `done`,
+`error`.
 
 ```python
-# On loop start
-event_bus.publish(Event(
-    type="loop.started",
-    payload={
-        "session_id": session_id,
-        "mode": "chat" | "goal",
-        "user_message": "...",  # Truncated
-    }
-))
-
-# After each LLM call
-event_bus.publish(Event(
-    type="loop.thought",
-    payload={
-        "decision": "respond" | "execute_tools" | "ask_question",
-        "tool_calls": [...],  # If applicable
-        "reasoning": "...",  # If available from LLM
-    }
-))
-
-# After tool execution
-event_bus.publish(Event(
-    type="loop.tools_executed",
-    payload={
-        "tools": [...],
-        "results": [...],
-    }
-))
-
-# On loop completion
-event_bus.publish(Event(
-    type="loop.completed",
-    payload={
-        "iterations": 3,
-        "tools_used": [...],
-        "final_message": "...",
-    }
-))
-
-# On error
-event_bus.publish(Event(
-    type="loop.error",
-    payload={
-        "error_type": "...",
-        "error_message": "...",
-        "recovered": True | False,
-    }
-))
+async for event in stream_chat(session_id=session_id, message=message):
+    # event is a LoopEvent; event.event_type is the SSE wire name
+    match event.event_type:
+        case "thinking":    # ThinkingEvent — a reasoning step
+            ...
+        case "text":        # TextDeltaEvent — a delta of the final response
+            ...
+        case "tool_start":  # ToolStartEvent — a tool call is about to execute
+            ...
+        case "tool_done":   # ToolResultEvent — a tool call finished
+            ...
+        case "done":        # ResponseDoneEvent — the response is complete
+            ...
+        case "error":       # ErrorEvent — the loop failed
+            ...
 ```
+
+Callers that only need the final result use the non-streaming wrapper
+`run_chat()`, which drains the generator into a `ChatResponse`.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1021,13 +1021,7 @@ The Agentic Loop is the heart of Cortex. It implements the Think → Act → Obs
 
 **Event Emissions:**
 
-| Event | When |
-|-------|-------|
-| `loop.started` | Loop begins |
-| `loop.thought` | LLM makes decision |
-| `loop.tools_executed` | Tools completed |
-| `loop.completed` | Loop ends successfully |
-| `loop.error` | Error occurred |
+Loop progress is not published to the event bus. It is exposed to the caller via the `LoopEvent` streaming seam (ADR-0002): `stream_chat()` yields `LoopEvent` instances (see `src/cortex/agentic/events.py`) whose wire names are `thinking`, `text`, `tool_start`, `tool_done`, `done`, `error`.
 
 **Dynamic spawning:**
 - Can spawn temporary worker processes for complex tasks

--- a/docs/adr/0002-async-generator-as-streaming-seam.md
+++ b/docs/adr/0002-async-generator-as-streaming-seam.md
@@ -18,3 +18,9 @@ Rejected alternatives:
 Consequence: `stream_chat` owns the loop logic. The existing `run_chat()` is a convenience
 wrapper that drains the generator and returns `ChatResponse`. Callers that need a final result
 call `run_chat`; callers that need progress call `stream_chat`.
+
+## Consequences (refined during #14)
+
+`LoopEvent` is a dataclass base (consistent with the agentic core; Pydantic stays at the API boundary). Every event carries `session_id`. `event_type` is a class constant whose values ARE the SSE wire names — one vocabulary: `thinking`, `text`, `tool_start`, `tool_done`, `done`, `error`. `ResponseDoneEvent.tools_used` carries tool names (same semantic as `ChatResponse.tools_used`). `ErrorEvent.code` is a free string with `max_iterations` reserved.
+
+The obsolete `loop.*` members in `EventTypes` (loop.started, loop.thought, loop.tools_executed, loop.completed, loop.error) were removed with #14 — the loop's lifecycle is caller-scoped progress, never bus events.

--- a/src/cortex/agentic/__init__.py
+++ b/src/cortex/agentic/__init__.py
@@ -4,6 +4,15 @@ Provides the core agentic loop: Think → Act → Observe → Respond.
 """
 
 from cortex.agentic.context_builder import ContextBuilder
+from cortex.agentic.events import (
+    ErrorEvent,
+    LoopEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
 from cortex.agentic.executor import LoopExecutor
 from cortex.agentic.loop import AgentLoop
 from cortex.agentic.models import (
@@ -41,6 +50,14 @@ __all__ = [
     "GoalStep",
     "GoalResult",
     "MaxIterationsError",
+    # Streaming
+    "ErrorEvent",
+    "LoopEvent",
+    "ResponseDoneEvent",
+    "TextDeltaEvent",
+    "ThinkingEvent",
+    "ToolResultEvent",
+    "ToolStartEvent",
     # Core
     "ContextBuilder",
     "Reasoner",

--- a/src/cortex/agentic/events.py
+++ b/src/cortex/agentic/events.py
@@ -1,0 +1,105 @@
+"""LoopEvent models for the streaming agent loop (ADR-0002).
+
+These dataclasses are the public seam between ``AgentLoop`` and its
+callers: every progress signal the loop emits is one of these events.
+Consumers of this seam (the SSE adapter in a follow-up issue) consume
+``event_type`` as the wire name directly — one vocabulary, no mapping
+table:
+
+* ``thinking``    — a reasoning step is in progress
+* ``text``        — a text delta of the final response
+* ``tool_start``  — a tool call is about to execute
+* ``tool_done``   — a tool call finished (success or failure)
+* ``done``        — the response is complete
+* ``error``       — the loop failed
+
+Instances are JSON-ready via :meth:`LoopEvent.to_dict`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, ClassVar
+from uuid import UUID
+
+
+@dataclass
+class LoopEvent:
+    """Progress signal from the AgentLoop to its caller (ADR-0002).
+
+    `event_type` is the wire name (one vocabulary, no mapping table).
+    """
+
+    event_type: ClassVar[str] = ""
+    session_id: UUID
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-ready dict; event_type included so payloads are self-describing."""
+        payload = asdict(self)
+        payload["session_id"] = str(self.session_id)
+        return {"event_type": self.event_type, **payload}
+
+
+@dataclass
+class ThinkingEvent(LoopEvent):
+    """The loop is emitting a reasoning step before acting."""
+
+    event_type: ClassVar[str] = "thinking"
+    message: str
+
+
+@dataclass
+class TextDeltaEvent(LoopEvent):
+    """A chunk of the final response text, streamed as it is produced."""
+
+    event_type: ClassVar[str] = "text"
+    delta: str
+
+
+@dataclass
+class ToolStartEvent(LoopEvent):
+    """A tool call is about to execute.
+
+    `tool_call_id` follows the ``ToolCall.id`` ``call_<hex>`` convention so
+    it matches the id later reported by ``ToolResultEvent``.
+    """
+
+    event_type: ClassVar[str] = "tool_start"
+    tool_name: str
+    tool_call_id: str
+
+
+@dataclass
+class ToolResultEvent(LoopEvent):
+    """A tool call finished, reporting success or failure and timing."""
+
+    event_type: ClassVar[str] = "tool_done"
+    tool_name: str
+    tool_call_id: str
+    success: bool
+    output: str | None = None
+    error: str | None = None
+    execution_time_ms: float | None = None
+
+
+@dataclass
+class ResponseDoneEvent(LoopEvent):
+    """The loop produced its final response.
+
+    `tools_used` carries tool *names* (same semantic as
+    ``ChatResponse.tools_used``), not call ids.
+    """
+
+    event_type: ClassVar[str] = "done"
+    message: str
+    tools_used: list[str] = field(default_factory=list)
+    iterations: int = 0
+
+
+@dataclass
+class ErrorEvent(LoopEvent):
+    """The loop failed; `code` distinguishes known failure classes."""
+
+    event_type: ClassVar[str] = "error"
+    error: str
+    code: str | None = None  # reserved: "max_iterations"

--- a/src/cortex/events/types.py
+++ b/src/cortex/events/types.py
@@ -38,12 +38,5 @@ class EventTypes(StrEnum):
     MODULE_SPAWN = "module.spawn"
     MODULE_TERMINATE = "module.terminate"
 
-    # ─── Agentic Loop ─────────────────────────────────────────
-    LOOP_STARTED = "loop.started"
-    LOOP_THOUGHT = "loop.thought"
-    LOOP_TOOLS_EXECUTED = "loop.tools_executed"
-    LOOP_COMPLETED = "loop.completed"
-    LOOP_ERROR = "loop.error"
-
     # ─── Wildcard ─────────────────────────────────────────────
     ALL = "*"

--- a/tests/unit/agentic/test_loop_events.py
+++ b/tests/unit/agentic/test_loop_events.py
@@ -1,0 +1,312 @@
+"""Tests for agentic loop events (ADR-0002 streaming seam contract)."""
+
+import json
+from dataclasses import is_dataclass
+from uuid import UUID, uuid4
+
+import pytest
+
+from cortex.agentic.events import (
+    ErrorEvent,
+    LoopEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
+
+WIRE_NAMES = {
+    ThinkingEvent: "thinking",
+    TextDeltaEvent: "text",
+    ToolStartEvent: "tool_start",
+    ToolResultEvent: "tool_done",
+    ResponseDoneEvent: "done",
+    ErrorEvent: "error",
+}
+
+
+def _sample_events(session_id: UUID) -> list[LoopEvent]:
+    """One fully-populated instance of every event type."""
+    return [
+        ThinkingEvent(session_id=session_id, message="reasoning step"),
+        TextDeltaEvent(session_id=session_id, delta="Hello"),
+        ToolStartEvent(
+            session_id=session_id, tool_name="web_search", tool_call_id="call_abc123"
+        ),
+        ToolResultEvent(
+            session_id=session_id,
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=True,
+            output="search results",
+            execution_time_ms=12.5,
+        ),
+        ResponseDoneEvent(
+            session_id=session_id,
+            message="All done",
+            tools_used=["web_search", "calculator"],
+            iterations=3,
+        ),
+        ErrorEvent(session_id=session_id, error="boom", code="max_iterations"),
+    ]
+
+
+class TestLoopEvent:
+    """Tests for the LoopEvent base class."""
+
+    def test_is_dataclass(self):
+        assert is_dataclass(LoopEvent)
+
+    def test_requires_session_id(self):
+        with pytest.raises(TypeError):
+            LoopEvent()
+
+    def test_base_event_type_is_empty(self):
+        assert LoopEvent.event_type == ""
+
+
+class TestEventContract:
+    """Shared contract across all six event types."""
+
+    def test_all_event_types_are_dataclasses(self):
+        for event_cls in WIRE_NAMES:
+            assert is_dataclass(event_cls)
+
+    def test_all_event_types_subclass_loop_event(self):
+        for event_cls in WIRE_NAMES:
+            assert issubclass(event_cls, LoopEvent)
+
+    def test_all_instances_are_loop_events(self):
+        session_id = uuid4()
+        for event in _sample_events(session_id):
+            assert isinstance(event, LoopEvent)
+
+    def test_every_event_requires_session_id(self):
+        for event_cls in WIRE_NAMES:
+            with pytest.raises(TypeError):
+                event_cls()  # type: ignore[call-arg]
+
+    def test_wire_names_match_vocabulary(self):
+        assert {cls.event_type for cls in WIRE_NAMES} == {
+            "thinking",
+            "text",
+            "tool_start",
+            "tool_done",
+            "done",
+            "error",
+        }
+        for cls, name in WIRE_NAMES.items():
+            assert cls.event_type == name
+
+    def test_event_type_accessible_on_instance(self):
+        session_id = uuid4()
+        for event in _sample_events(session_id):
+            assert event.event_type == WIRE_NAMES[type(event)]
+
+    def test_event_type_not_an_instance_field(self):
+        """ClassVar must not materialize per-instance state in __dict__."""
+        session_id = uuid4()
+        for event in _sample_events(session_id):
+            assert "event_type" not in vars(event)
+
+    def test_to_dict_includes_event_type_and_all_instance_fields(self):
+        session_id = uuid4()
+        for event in _sample_events(session_id):
+            payload = event.to_dict()
+            assert payload["event_type"] == event.event_type
+            for name in vars(event):
+                assert name in payload
+
+    def test_reconstruct_from_to_dict_payload(self):
+        """to_dict payloads are plain-JSON-serializable and rebuild events."""
+        session_id = uuid4()
+        for event in _sample_events(session_id):
+            payload = event.to_dict()
+            json.dumps(payload)  # no default=str: JSON-ready output
+            payload.pop("event_type")
+            payload["session_id"] = UUID(payload["session_id"])
+            assert type(event)(**payload) == event
+
+    def test_json_roundtrip_preserves_all_fields(self):
+        session_id = uuid4()
+        for event in _sample_events(session_id):
+            payload = json.dumps(event.to_dict(), default=str)
+            parsed = json.loads(payload)
+            assert parsed["event_type"] == event.event_type
+            for name, value in vars(event).items():
+                if isinstance(value, UUID):
+                    assert UUID(parsed[name]) == value
+                else:
+                    assert parsed[name] == value
+
+
+class TestThinkingEvent:
+    """Tests for ThinkingEvent."""
+
+    def test_wire_name(self):
+        event = ThinkingEvent(session_id=uuid4(), message="planning")
+        assert event.event_type == "thinking"
+
+    def test_message_field(self):
+        event = ThinkingEvent(session_id=uuid4(), message="planning")
+        assert event.message == "planning"
+
+    def test_to_dict(self):
+        event = ThinkingEvent(session_id=uuid4(), message="planning")
+        assert event.to_dict() == {
+            "event_type": "thinking",
+            "session_id": str(event.session_id),
+            "message": "planning",
+        }
+
+
+class TestTextDeltaEvent:
+    """Tests for TextDeltaEvent."""
+
+    def test_wire_name(self):
+        event = TextDeltaEvent(session_id=uuid4(), delta="Hello")
+        assert event.event_type == "text"
+
+    def test_delta_field(self):
+        event = TextDeltaEvent(session_id=uuid4(), delta="Hello")
+        assert event.delta == "Hello"
+
+
+class TestToolStartEvent:
+    """Tests for ToolStartEvent."""
+
+    def test_wire_name(self):
+        event = ToolStartEvent(
+            session_id=uuid4(), tool_name="web_search", tool_call_id="call_abc123"
+        )
+        assert event.event_type == "tool_start"
+
+    def test_fields(self):
+        event = ToolStartEvent(
+            session_id=uuid4(), tool_name="web_search", tool_call_id="call_abc123"
+        )
+        assert event.tool_name == "web_search"
+        assert event.tool_call_id == "call_abc123"
+
+
+class TestToolResultEvent:
+    """Tests for ToolResultEvent."""
+
+    def test_wire_name(self):
+        event = ToolResultEvent(
+            session_id=uuid4(),
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=True,
+        )
+        assert event.event_type == "tool_done"
+
+    def test_execution_time_ms_defaults_to_none(self):
+        event = ToolResultEvent(
+            session_id=uuid4(),
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=True,
+        )
+        assert event.execution_time_ms is None
+
+    def test_output_defaults_to_none(self):
+        event = ToolResultEvent(
+            session_id=uuid4(),
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=True,
+        )
+        assert event.output is None
+
+    def test_error_defaults_to_none(self):
+        event = ToolResultEvent(
+            session_id=uuid4(),
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=True,
+        )
+        assert event.error is None
+
+    def test_success_with_output(self):
+        event = ToolResultEvent(
+            session_id=uuid4(),
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=True,
+            output="search results",
+        )
+        assert event.success is True
+        assert event.output == "search results"
+        assert event.error is None
+
+    def test_failure_with_error(self):
+        event = ToolResultEvent(
+            session_id=uuid4(),
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=False,
+            error="network timeout",
+        )
+        assert event.success is False
+        assert event.error == "network timeout"
+        assert event.output is None
+
+    def test_execution_time_ms_float(self):
+        event = ToolResultEvent(
+            session_id=uuid4(),
+            tool_name="web_search",
+            tool_call_id="call_abc123",
+            success=True,
+            execution_time_ms=12.5,
+        )
+        assert event.execution_time_ms == 12.5
+
+
+class TestResponseDoneEvent:
+    """Tests for ResponseDoneEvent."""
+
+    def test_wire_name(self):
+        event = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        assert event.event_type == "done"
+
+    def test_tools_used_defaults_to_empty_list(self):
+        event = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        assert event.tools_used == []
+
+    def test_iterations_defaults_to_zero(self):
+        event = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        assert event.iterations == 0
+
+    def test_tools_used_holds_tool_names(self):
+        event = ResponseDoneEvent(
+            session_id=uuid4(), message="Done", tools_used=["web_search", "calculator"]
+        )
+        assert event.tools_used == ["web_search", "calculator"]
+
+    def test_default_tools_used_is_not_shared(self):
+        first = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        second = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        first.tools_used.append("web_search")
+        assert second.tools_used == []
+
+
+class TestErrorEvent:
+    """Tests for ErrorEvent."""
+
+    def test_wire_name(self):
+        event = ErrorEvent(session_id=uuid4(), error="boom")
+        assert event.event_type == "error"
+
+    def test_error_required(self):
+        with pytest.raises(TypeError):
+            ErrorEvent(session_id=uuid4())
+
+    def test_code_defaults_to_none(self):
+        event = ErrorEvent(session_id=uuid4(), error="boom")
+        assert event.code is None
+
+    def test_code_max_iterations_reserved(self):
+        event = ErrorEvent(session_id=uuid4(), error="boom", code="max_iterations")
+        assert event.code == "max_iterations"


### PR DESCRIPTION
## What

Implements #14 — the LoopEvent streaming seam contract for the AgentLoop (ADR-0002).

**New: `src/cortex/agentic/events.py`**
- Dataclass base `LoopEvent` with `session_id: UUID` on every event and `to_dict()` (plain-JSON-serializable, event_type included)
- 6 event types: `ThinkingEvent`, `TextDeltaEvent`, `ToolStartEvent`, `ToolResultEvent` (incl. `execution_time_ms`), `ResponseDoneEvent` (`tools_used` = tool names, same semantic as `ChatResponse.tools_used`), `ErrorEvent` (`code` free string, `max_iterations` reserved)
- `event_type` is a ClassVar whose values ARE the SSE wire names — one vocabulary: `thinking`, `text`, `tool_start`, `tool_done`, `done`, `error`

**Removed:** dead `loop.*` members from `EventTypes` (loop.started, loop.thought, loop.tools_executed, loop.completed, loop.error) — the loop lifecycle is caller-scoped progress, never bus events (ADR-0002).

**Docs:** CONTEXT.md glossary (LoopEvent vs System Event), ADR-0002 Consequences, AGENTIC_LOOP.md and ARCHITECTURE.md updated to the LoopEvent seam.

## Design decisions (grilling session)
Dataclasses (not Pydantic — core convention); session_id on the base; wire-name vocabulary; tools_used (names); base-class annotation, no union alias; ErrorEvent.code free string.

## Verification
- 36 new tests (tests/unit/agentic/test_loop_events.py), full agentic suite green (116)
- Full suite: 456 passed (1 pre-existing e2e failure: docker-compose test missing psycopg2)
- ruff clean, mypy strict clean on touched modules
- 2 review cycles: standards + spec, zero actionable findings

Closes #14