### PR TITLE
feat: run_chat() as drain wrapper over stream_chat() (ADR-0002, #16)

### DIFF
--- a/docs/AGENTIC_LOOP.md
+++ b/docs/AGENTIC_LOOP.md
@@ -516,55 +516,43 @@ class AgentLoop:
     async def run_chat(
         self,
         session_id: UUID,
-        user_message: str
+        user_message: str,
+        *,
+        max_iterations: int | None = None
     ) -> ChatResponse:
         """
         Run the agentic loop for chat mode.
-        
-        Loop: Context → Think → [Act → Observe] → Respond
+
+        Drain wrapper over stream_chat(): consumes the generator, accumulates
+        the response text from TextDeltaEvent deltas and the final metadata
+        from ResponseDoneEvent, and returns the resulting ChatResponse.
+        Progress events (thinking, tool start/result) and ErrorEvent are
+        ignored — the generator re-raises the original exception, so errors
+        (e.g. MaxIterationsError) propagate unchanged.
         """
-        messages = [Message(role=Role.USER, content=user_message)]
+        response_text = ""
+        tools_used: list[str] = []
         iterations = 0
-        max_iterations = 20
 
-        while iterations < max_iterations:
-            # Build context
-            context = await self.context_builder.build(
-                session_id=session_id,
-                user_message=user_message,
-                mode=Mode.CHAT
-            )
+        async for event in self.stream_chat(
+            session_id=session_id,
+            user_message=user_message,
+            max_iterations=max_iterations,
+        ):
+            match event:
+                case TextDeltaEvent(delta=delta):
+                    response_text += delta
+                case ResponseDoneEvent(tools_used=used, iterations=iters):
+                    tools_used, iterations = used, iters
+                case _:
+                    pass  # progress events + ErrorEvent; generator re-raises
 
-            # Think
-            decision = await self.reasoner.reason(context)
-
-            if isinstance(decision, Decision.Respond):
-                # Done! Return response
-                return ChatResponse(
-                    message=decision.text,
-                    iterations=iterations,
-                    tool_calls=[]
-                )
-
-            elif isinstance(decision, Decision.ExecuteTools):
-                # Act
-                results = await self.executor.execute(decision.tool_calls)
-
-                # Observe: add results to messages
-                messages.extend(self._tool_messages(decision.tool_calls, results))
-
-                iterations += 1
-
-            elif isinstance(decision, Decision.AskQuestion):
-                # Clarification needed
-                return ChatResponse(
-                    message=decision.question,
-                    iterations=iterations,
-                    tool_calls=[]
-                )
-
-        # Safety: max iterations
-        raise MaxIterationsError(max_iterations)
+        return ChatResponse(
+            message=response_text,
+            tools_used=tools_used,
+            iterations=iterations,
+            session_id=session_id,
+        )
 
     async def run_goal(
         self,

--- a/src/cortex/agentic/loop.py
+++ b/src/cortex/agentic/loop.py
@@ -78,6 +78,13 @@ class AgentLoop:
         """
         Run loop for chat mode.
 
+        Drain wrapper over stream_chat(): consumes the generator, accumulates
+        the response text from TextDeltaEvent deltas and the final metadata
+        from ResponseDoneEvent, and returns the resulting ChatResponse.
+        Progress events (thinking, tool start/result) and ErrorEvent are
+        ignored — the generator re-raises the original exception, so errors
+        propagate unchanged.
+
         Args:
             session_id: Current session
             user_message: The user's message
@@ -89,86 +96,28 @@ class AgentLoop:
         Raises:
             MaxIterationsError: If loop exceeds max iterations
         """
-        max_iters = max_iterations or self._max_chat_iterations
-        iterations = 0
+        response_text = ""
         tools_used: list[str] = []
-        messages: list[Message] = []
-
-        # Add user message
-        messages.append(Message(
+        iterations = 0
+        async for event in self.stream_chat(
             session_id=session_id,
-            role=MessageRole.USER,
-            content=user_message,
-        ))
-
-        while iterations < max_iters:
-            # 1. Context - build reasoning context
-            context = await self._context_builder.build(
-                session_id=session_id,
-                user_message=user_message,
-                mode=Mode.CHAT,
-            )
-
-            # Inject current messages into context
-            context.conversation = messages
-
-            # 2. Think - reason about what to do
-            decision = await self._reasoner.reason(context)
-
-            # Handle decision
-            match decision.decision_type:
-                case DecisionType.RESPOND:
-                    # Done! Return the response
-                    return ChatResponse(
-                        message=decision.text or "I'm not sure how to respond.",
-                        iterations=iterations,
-                        tools_used=tools_used,
-                        session_id=session_id,
-                    )
-
-                case DecisionType.ASK_QUESTION:
-                    # Return the question
-                    return ChatResponse(
-                        message=decision.text or "Could you clarify?",
-                        iterations=iterations,
-                        tools_used=tools_used,
-                        session_id=session_id,
-                    )
-
-                case DecisionType.EXECUTE_TOOLS:
-                    # 3. Act - execute tools
-                    if decision.tool_calls:
-                        results = await self._executor.execute_tools(decision.tool_calls)
-
-                        # Track tools used
-                        for call in decision.tool_calls:
-                            tools_used.append(call.name)
-
-                        # 4. Observe - add tool results to conversation
-                        for call, result in zip(decision.tool_calls, results):
-                            msg = Message(
-                                session_id=session_id,
-                                role=MessageRole.TOOL_RESULT,
-                                content=(
-                                    result.output or ""
-                                    if result.success
-                                    else f"Error: {result.error}"
-                                ),
-                            )
-                            messages.append(msg)
-
-                        iterations += 1
-                    else:
-                        # No tools to execute, respond
-                        return ChatResponse(
-                            message="I couldn't determine what tools to use.",
-                            iterations=iterations,
-                            tools_used=tools_used,
-                            session_id=session_id,
-                        )
-
-        # Exceeded max iterations
-        raise MaxIterationsError(max_iters)
+            user_message=user_message,
+            max_iterations=max_iterations,
+        ):
+            match event:
+                case TextDeltaEvent(delta=delta):
+                    response_text += delta
+                case ResponseDoneEvent(tools_used=used, iterations=iters):
+                    tools_used, iterations = used, iters
+                # Ignore progress events; stream_chat re-raises the original exception
+                case _:
+                    pass
+        return ChatResponse(
+            message=response_text,
+            tools_used=tools_used,
+            iterations=iterations,
+            session_id=session_id,
+        )
 
     async def stream_chat(
         self,

--- a/tests/unit/agentic/test_loop.py
+++ b/tests/unit/agentic/test_loop.py
@@ -46,7 +46,7 @@ class TestAgentLoop:
     def mock_executor(self):
         """Create a mock executor."""
         executor = MagicMock()
-        executor.execute_tools = AsyncMock()
+        executor.execute_single = AsyncMock()
         return executor
 
     @pytest.fixture
@@ -106,24 +106,29 @@ class TestAgentLoop:
             Decision.respond("File contents are..."),
         ])
 
-        mock_executor.execute_tools = AsyncMock(return_value=[
-            ToolResult(tool_call_id="1", tool_name="file_read", success=True, output="content")
-        ])
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="1", tool_name="file_read", success=True, output="content",
+        ))
 
         response = await loop.run_chat(session_id, "Read the file")
 
-        assert mock_executor.execute_tools.called
+        assert mock_executor.execute_single.called
         assert response.iterations >= 1
 
     @pytest.mark.asyncio
-    async def test_run_chat_max_iterations(self, loop, mock_context_builder, mock_reasoner):
+    async def test_run_chat_max_iterations(self, loop, mock_context_builder, mock_reasoner, mock_executor):
         """Run chat should raise after max iterations."""
+        from cortex.tools.interfaces import ToolResult
+
         session_id = uuid4()
 
         mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
         mock_reasoner.reason = AsyncMock(return_value=Decision.execute_tools([
             ToolCall(id="1", name="shell", arguments={"cmd": "true"})
         ]))
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="1", tool_name="shell", success=True, output="ok",
+        ))
 
         with pytest.raises(MaxIterationsError):
             await loop.run_chat(session_id, "Loop test", max_iterations=5)
@@ -140,6 +145,164 @@ class TestAgentLoop:
         response = await loop.run_chat(session_id, "")
 
         assert response is not None
+
+    @pytest.mark.asyncio
+    async def test_run_chat_returns_complete_response(
+        self, loop, mock_context_builder, mock_reasoner
+    ) -> None:
+        """RESPOND path returns a complete ChatResponse with all fields."""
+        session_id = uuid4()
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.respond("Hello!"))
+
+        response = await loop.run_chat(session_id, "Hi")
+
+        assert isinstance(response, ChatResponse)
+        assert response.message == "Hello!"
+        assert response.iterations == 0
+        assert response.tools_used == []
+        assert response.session_id == session_id
+
+    @pytest.mark.asyncio
+    async def test_run_chat_ask_question_returns_complete_response(
+        self, loop, mock_context_builder, mock_reasoner
+    ) -> None:
+        """ASK_QUESTION path returns a complete ChatResponse with the question."""
+        session_id = uuid4()
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.ask_question(
+            "Did you mean file A or file B?"
+        ))
+
+        response = await loop.run_chat(session_id, "Open the file")
+
+        assert isinstance(response, ChatResponse)
+        assert response.message == "Did you mean file A or file B?"
+        assert response.iterations == 0
+        assert response.tools_used == []
+        assert response.session_id == session_id
+
+    @pytest.mark.asyncio
+    async def test_run_chat_propagates_tools_used(
+        self, loop, mock_context_builder, mock_reasoner, mock_executor
+    ) -> None:
+        """Tool round-trip propagates tools_used and iterations into the response."""
+        from cortex.tools.interfaces import ToolResult
+
+        session_id = uuid4()
+        call = ToolCall(id="call_1", name="search", arguments={"q": "x"})
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(side_effect=[
+            Decision.execute_tools([call], reasoning="searching"),
+            Decision.respond("Found it.", reasoning="synthesized"),
+        ])
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_1", tool_name="search", success=True, output="found",
+        ))
+
+        response = await loop.run_chat(session_id, "Find it")
+
+        assert response.message == "Found it."
+        assert response.tools_used == ["search"]
+        assert response.iterations >= 1
+        assert response.session_id == session_id
+
+    @pytest.mark.asyncio
+    async def test_run_chat_reraises_original_exception(
+        self, loop, mock_context_builder, mock_reasoner
+    ) -> None:
+        """A failing reasoner propagates the original exception, unwrapped."""
+        session_id = uuid4()
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(side_effect=ValueError("boom"))
+
+        with pytest.raises(ValueError, match="boom"):
+            await loop.run_chat(session_id, "Hi")
+
+    @pytest.mark.asyncio
+    async def test_run_chat_max_iterations_override_bound(
+        self, loop, mock_context_builder, mock_reasoner, mock_executor
+    ) -> None:
+        """max_iterations override bounds the loop at the override, not the default."""
+        from cortex.tools.interfaces import ToolResult
+
+        session_id = uuid4()
+        call = ToolCall(id="call_1", name="shell", arguments={"cmd": "true"})
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.execute_tools(
+            [call], reasoning="running",
+        ))
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_1", tool_name="shell", success=True, output="ok",
+        ))
+
+        with pytest.raises(MaxIterationsError) as exc_info:
+            await loop.run_chat(session_id, "Loop", max_iterations=2)
+
+        assert exc_info.value.max_iterations == 2
+
+    @pytest.mark.asyncio
+    async def test_run_chat_empty_tool_calls_fallback(
+        self, loop, mock_context_builder, mock_reasoner
+    ) -> None:
+        """EXECUTE_TOOLS with empty tool_calls returns the fallback text."""
+        session_id = uuid4()
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.execute_tools(
+            [], reasoning="no tools available",
+        ))
+
+        response = await loop.run_chat(session_id, "Do something")
+
+        assert response.message == "I couldn't determine what tools to use."
+        assert response.iterations == 0
+        assert response.tools_used == []
+        assert response.session_id == session_id
+
+    @pytest.mark.asyncio
+    async def test_run_chat_does_not_publish_loop_events(
+        self, loop, mock_context_builder, mock_reasoner, mock_event_bus
+    ) -> None:
+        """Loop events are caller-scoped: run_chat never publishes them on the bus."""
+        session_id = uuid4()
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.respond("Hello!"))
+
+        response = await loop.run_chat(session_id, "Hi")
+
+        assert response.message == "Hello!"
+        mock_event_bus.publish.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_run_chat_accumulates_multiple_deltas(self, loop, monkeypatch) -> None:
+        """The drainer concatenates TextDeltaEvent deltas, not ResponseDoneEvent.message."""
+        session_id = uuid4()
+
+        async def fake_stream_chat(*args, **kwargs):
+            yield TextDeltaEvent(session_id, delta="Hel")
+            yield TextDeltaEvent(session_id, delta="lo")
+            yield ResponseDoneEvent(
+                session_id,
+                message="Hello!",
+                tools_used=["tool_a"],
+                iterations=3,
+            )
+
+        monkeypatch.setattr(loop, "stream_chat", fake_stream_chat)
+
+        response = await loop.run_chat(session_id, "Hi")
+
+        assert response.message == "Hello"
+        assert response.tools_used == ["tool_a"]
+        assert response.iterations == 3
+        assert response.session_id == session_id
 
 
 class TestAgentLoopGoalMode:
@@ -597,9 +760,9 @@ class TestStreamChat:
         stream_events = [e async for e in loop.stream_chat(session_id, "Find it")]
         done_event = next(e for e in stream_events if isinstance(e, ResponseDoneEvent))
 
-        # run_chat with the same script
+        # run_chat with the same script (execute_single is exhausted by the stream half)
         mock_reasoner.reason = AsyncMock(side_effect=list(script))
-        mock_executor.execute_tools = AsyncMock(return_value=list(results))
+        mock_executor.execute_single = AsyncMock(side_effect=list(results))
         response = await loop.run_chat(session_id, "Find it")
 
         assert done_event.message == response.message


### PR DESCRIPTION
Closes #16 — ADR-0002: `run_chat()` as drain wrapper.

## Summary

`AgentLoop.run_chat()` no longer re-implements the agentic loop. Its body is now a drain over `stream_chat()`: it accumulates `TextDeltaEvent` deltas, captures `tools_used`/`iterations` from `ResponseDoneEvent`, ignores progress events via a catch-all arm, and lets the generator's re-raise propagate original exceptions unchanged (no wrapping, no swallowing — including `MaxIterationsError`). One copy of the loop logic; two consumption modes.

- `src/cortex/agentic/loop.py` — `run_chat` body replaced with the drainer; signature and contract unchanged; `stream_chat`/`run_goal` untouched.
- `tests/unit/agentic/test_loop.py` — 3 mechanical updates (fixture `execute_single`, tool-execution test, parity test) + 8 new drainer tests (complete ChatResponse on RESPOND/ASK_QUESTION, tools_used round-trip, exact-type error propagation, override bound via `exc_info.value.max_iterations`, empty-tool fallback, no bus publication, discriminating multi-delta accumulation). 19 → 27 tests.
- `docs/AGENTIC_LOOP.md` — stale `run_chat` code block replaced with the drainer.

## Verification

- `python -m pytest tests/unit/agentic/test_loop.py -q` → 27 passed
- Full suite: 472 passed, 1 failed — `tests/e2e/test_docker_compose.py::test_postgres_accepts_connections` (`ModuleNotFoundError: psycopg2`), pre-existing issue #45, unrelated.
- ruff + mypy on the changed files: clean (repo-wide baseline errors pre-exist on HEAD; pre-commit ruff/mypy passed on commit).
- Two-axis review (standards + spec): round-2 verdict APPROVED — 12/12 acceptance criteria, all 7 system invariants pinned by tests that fail on violation, zero actionable findings.

## Out of scope (per item body)

SSE route wiring (#17), goal-mode streaming (#18), `ExecutionModule`, `docs/IMPLEMENTATION_PLAN.md`. `CONTEXT.md` glossary entries from the design session land separately.