### PR TITLE
feat: SSE adapter for /chat/stream (ADR-0002, #17)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,10 @@ _Avoid_: Done event, completion event, final event
 The consumer that takes the loop's streaming progress and reduces it to a single final response, discarding intermediate signals (thinking, tool activity). Uses the stream when progress matters; uses the drain when only the result matters. Loop errors surface unchanged — the drain never swallows or rewraps them.
 _Avoid_: Convenience wrapper, non-streaming call, response collector
 
+**SSE adapter**:
+The consumer that serializes LoopEvents to SSE frames for the streaming chat endpoint (`/chat/stream`). The wire name of each frame IS the event's `event_type` — one vocabulary, no mapping table — and frames are explicit and minimal: the `done` frame renames `message`→`final_message` and `tools_used`→`tool_calls`. A loop error ends the stream with an `error` frame carrying the error text and code; session lookup happens before the stream starts, so a missing session is an HTTP 404, not an in-stream error.
+_Avoid_: Stream adapter, SSE endpoint, chat stream
+
 **System Event**:
 An event published on the Cortex event bus for any module to consume (e.g. goal.created, concept.rejected). Distinct from LoopEvent: system events are system-wide domain information; LoopEvents are per-caller progress.
 _Avoid_: Domain event, bus event

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1393,7 +1393,7 @@ class Session(BaseModel):
 
 ## Streaming
 
-> Design complete. Protocol: SSE-only.
+> Shipped in #17. Protocol: SSE-only. Endpoint: `POST /chat/stream`.
 
 ### Decision: SSE-Only
 
@@ -1411,280 +1411,184 @@ class Session(BaseModel):
 ### Architecture
 
 ```
-┌─────────────────────────────────────────────────────────────────┐
+┌──────────────────────────────────────────────────────────────────┐
 │                       STREAMING FLOW                             │
 │                                                                  │
-│  Client                     API Gateway                    Loop │
-│  ──────                     ───────────                    ──── │
-│    │                            │                              │  │
-│    │  POST /chat/stream         │                              │  │
-│    │  { message, session_id }  │                              │  │
-│    │────────────────────────────►│                              │  │
-│    │                            │                              │  │
-│    │                            │  start_stream()              │  │
-│    │                            │─────────────────────────────►│  │
-│    │                            │                              │  │
-│    │  ◄─ SSE: thinking ────────│  emit(StreamEvent.THINKING) │  │
-│    │  ◄─ SSE: text ────────────│  emit(StreamEvent.TEXT)     │  │
-│    │  ◄─ SSE: tool_start ──────│  emit(StreamEvent.TOOL)     │  │
-│    │  ◄─ SSE: tool_done ───────│  emit(StreamEvent.TOOL)    │  │
-│    │  ◄─ SSE: text ────────────│  emit(StreamEvent.TEXT)     │  │
-│    │  ◄─ SSE: done ────────────│  emit(StreamEvent.DONE)     │  │
-│    │                            │                              │  │
-│    │  (connection closes)       │                              │  │
-│    ◄─────────────────────────────│                              │  │
+│  Client                     API (chat_stream)               Loop │
+│  ──────                     ─────────────────               ──── │
+│    │                            │                              │ │
+│    │ POST /chat/stream          │                              │ │
+│    │ { message, session_id }    │                              │ │
+│    │───────────────────────────►│                              │ │
+│    │                            │ resolve session              │ │
+│    │                            │ (missing → HTTP 404,         │ │
+│    │                            │  absent → create)            │ │
+│    │                            │                              │ │
+│    │                            │ async for stream_chat()      │ │
+│    │                            │─────────────────────────────►│ │
+│    │                            │◄─ LoopEvent ───────────────  │ │
+│    │                            │match event → SSE frame       │ │
+│    │                            │(event_type IS the wire name) │ │
+│    │◄─ SSE: thinking ────────   │                              │ │
+│    │◄─ SSE: text ────────────   │                              │ │
+│    │◄─ SSE: tool_start ──────   │                              │ │
+│    │◄─ SSE: tool_done ───────   │                              │ │
+│    │◄─ SSE: done ────────────   │                              │ │
+│    │◄─ SSE: error ───────────   │ (on ErrorEvent / exception)  │ │
+│    │                            │                              │ │
+│    │ (connection closes)        │                              │ │
+│    ◄─────────────────────────── │                              │ │
 │                                                                  │
-└─────────────────────────────────────────────────────────────────┘
+└──────────────────────────────────────────────────────────────────┘
 ```
 
 ---
 
 ### API Endpoint
 
-```python
-@router.post("/chat/stream")
-async def chat_stream(
-    request: ChatStreamRequest,
-    response: StreamingResponse
-):
-    """
-    Stream chat response via SSE.
-    
-    Returns:
-        text/event-stream
-        
-    Events:
-        - thinking: Agent is processing
-        - text: Text chunk
-        - tool_start: Tool execution started
-        - tool_done: Tool execution complete
-        - done: Stream finished
-        - error: Stream error (with retry hint)
-    """
-    loop = request.state.agent_loop
-    session_id = request.state.session_id
-    
-    await loop.run_stream(
-        session_id=session_id,
-        message=request.message,
-        stream_manager=StreamManager(response)
-    )
+`chat_stream` (route `POST /stream` on the `/chat` router) consumes the same
+`ChatRequest` as the non-streaming endpoint and returns a `StreamingResponse`
+that iterates `execution_module.stream_chat(...)` — a transparent passthrough
+to `AgentLoop.stream_chat()` (no `MaxIterationsError` swallowing, unlike
+`run_chat()`'s fallback). Session resolution happens before the stream starts,
+then each `LoopEvent` is matched to an SSE frame:
 
-class ChatStreamRequest(BaseModel):
-    session_id: UUID | None = None
-    message: str
-    mode: Literal["chat", "goal"] = "chat"
+```python
+@router.post("/stream")          # router prefix "/chat" → POST /chat/stream
+async def chat_stream(
+    request: ChatRequest,
+    key: str = Depends(get_api_key),
+    interaction_service: InteractionService = Depends(get_interaction_service),
+    execution_module: ExecutionModule = Depends(get_execution_module),
+) -> StreamingResponse:
+    # Session resolution before the stream (see below)...
+    # max_iterations = request.max_iterations or 20
+
+    async def event_generator() -> AsyncGenerator[str, None]:
+        try:
+            async for event in execution_module.stream_chat(
+                session_id=session_id,
+                user_message=request.message,
+                max_iterations=max_iterations,
+            ):
+                match event:
+                    case ThinkingEvent():
+                        yield _sse_event("thinking", {"message": event.message})
+                    case TextDeltaEvent():
+                        yield _sse_event("text", {"delta": event.delta})
+                    case ToolStartEvent():
+                        yield _sse_event("tool_start", {
+                            "tool_name": event.tool_name,
+                            "tool_call_id": event.tool_call_id,
+                        })
+                    case ToolResultEvent():
+                        yield _sse_event("tool_done", {
+                            "tool_name": event.tool_name,
+                            "tool_call_id": event.tool_call_id,
+                            "success": event.success,
+                            "output": event.output,
+                            "error": event.error,
+                            "execution_time_ms": event.execution_time_ms,
+                        })
+                    case ResponseDoneEvent():
+                        yield _sse_event("done", {
+                            "final_message": event.message,
+                            "tool_calls": event.tools_used,
+                            "iterations": event.iterations,
+                        })
+                    case ErrorEvent():
+                        yield _sse_event("error", {"error": event.error, "code": event.code})
+                        return
+                    case _:
+                        logger.warning(f"Unhandled loop event: {type(event).__name__}")
+        except Exception as exc:
+            logger.exception("Unexpected error streaming chat events")
+            yield _sse_event("error", {"error": str(exc), "code": None})
+            raise
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",  # Disable nginx buffering
+        },
+    )
 ```
+
+`_sse_event(event_type, data)` formats each frame as
+`event: {event_type}\ndata: {json.dumps(data)}\n\n`.
 
 ---
 
-### Stream Events
+### Wire Protocol (SSE events)
 
-```python
-class StreamEvent(BaseModel):
-    """Base for all SSE events."""
-    event: str                       # SSE event type name
-    data: str                       # JSON-serialized payload
+One vocabulary: a `LoopEvent`'s `event_type` IS the SSE wire name — the mapping
+is an explicit minimal field mapping, not `to_dict()`. `session_id` and
+`duration_ms` are never on the wire — a per-request SSE connection needs no
+session attribution, and nothing measures duration.
 
-class StreamEventType(str, Enum):
-    THINKING = "thinking"
-    TEXT = "text"
-    TOOL_START = "tool_start"
-    TOOL_DONE = "tool_done"
-    TOOL_ERROR = "tool_error"
-    DONE = "done"
-    ERROR = "error"
-
-class ThinkingPayload(BaseModel):
-    """Agent is processing."""
-    message: str                    # "Planning steps..."
-
-class TextDeltaPayload(BaseModel):
-    """Text chunk."""
-    delta: str                      # New text
-
-class ToolStartPayload(BaseModel):
-    """Tool execution started."""
-    tool_name: str
-    arguments: dict                 # Sanitized (no secrets)
-
-class ToolDonePayload(BaseModel):
-    """Tool execution complete."""
-    tool_name: str
-    success: bool
-    result: str | None              # Summary or error
-
-class DonePayload(BaseModel):
-    """Stream complete."""
-    final_message: str              # Full assembled text
-    tool_calls: list[str]           # Tools used
-    iterations: int
-    duration_ms: int
-```
-
-### SSE Format
+| SSE event | Payload | Source event |
+|-----------|---------|--------------|
+| `thinking` | `{message}` | `ThinkingEvent` |
+| `text` | `{delta}` | `TextDeltaEvent` |
+| `tool_start` | `{tool_name, tool_call_id}` | `ToolStartEvent` |
+| `tool_done` | `{tool_name, tool_call_id, success, output, error, execution_time_ms}` | `ToolResultEvent` |
+| `done` | `{final_message, tool_calls, iterations}` | `ResponseDoneEvent` (renames `message`→`final_message`, `tools_used`→`tool_calls`) |
+| `error` | `{error, code}` | `ErrorEvent` (`code` is `"max_iterations"` or `null`) |
 
 ```
 event: thinking
 data: {"message": "Let me check your calendar..."}
 
 event: text
-data: {"delta": "You have a meeting"}
-
-event: text
-data: {"delta": " at 2pm with"}
-
-event: text
-data: {"delta": " John."}
+data: {"delta": "You have a meeting at 2pm with John."}
 
 event: tool_start
-data: {"tool_name": "shell", "arguments": {"command": "git status"}}
+data: {"tool_name": "shell", "tool_call_id": "call_01"}
 
 event: tool_done
-data: {"tool_name": "shell", "success": true, "result": "On branch main"}
-
-event: text
-data: {"delta": " Your repo is on branch main."}
+data: {"tool_name": "shell", "tool_call_id": "call_01", "success": true, "output": "On branch main", "error": null, "execution_time_ms": 234}
 
 event: done
-data: {"final_message": "You have a meeting at 2pm with John. Your repo is on branch main.", "tool_calls": ["shell"], "iterations": 2, "duration_ms": 2341}
+data: {"final_message": "You have a meeting at 2pm with John.", "tool_calls": ["shell"], "iterations": 2}
+
+event: error
+data: {"error": "Max iterations reached", "code": "max_iterations"}
 ```
 
-### StreamManager
+---
 
-```python
-class StreamManager:
-    """
-    Manages SSE streaming to clients.
-    
-    Responsibilities:
-    - Serialize events to SSE format
-    - Handle client disconnect
-    - Buffer for slow clients (drop oldest if full)
-    """
-    
-    def __init__(
-        self,
-        response: StreamingResponse,
-        buffer_size: int = 10
-    ):
-        self._response = response
-        self._buffer: asyncio.Queue[StreamEvent] = asyncio.Queue(maxsize=buffer_size)
-        self._closed = False
-    
-    async def emit(self, event: StreamEvent) -> None:
-        """
-        Emit an event to the stream.
-        
-        Non-blocking: if buffer full, drops oldest event.
-        This prevents slow clients from blocking the agent.
-        """
-        if self._closed:
-            return
-            
-        try:
-            self._buffer.put_nowait(event)
-        except asyncio.QueueFull:
-            # Drop oldest, add newest
-            try:
-                self._buffer.get_nowait()
-                self._buffer.put_nowait(event)
-            except:
-                pass
-    
-    async def flush(self) -> None:
-        """Flush buffered events to client."""
-        while not self._buffer.empty():
-            event = await self._buffer.get()
-            await self._send_event(event)
-    
-    async def _send_event(self, event: StreamEvent) -> None:
-        """Send single event as SSE."""
-        await self._response.stream(
-            f"event: {event.event}\n"
-            f"data: {event.data}\n\n"
-        )
-    
-    async def close(self) -> None:
-        """Close the stream."""
-        self._closed = True
-        await self._response.alice()
-```
+### Session Resolution
 
-### Integration with Agentic Loop
+Session resolution happens before the stream starts, under the same policy as
+the non-streaming endpoint:
 
-```python
-class StreamingAgentLoop:
-    """
-    Streaming version of the Agentic Loop.
-    
-    Replaces run_chat() with run_stream() that emits events
-    to a StreamManager instead of collecting a final response.
-    """
-    
-    async def run_stream(
-        self,
-        session_id: UUID,
-        message: str,
-        stream: StreamManager
-    ) -> None:
-        """
-        Run chat with streaming output.
-        
-        Args:
-            session_id: Conversation session
-            message: User input
-            stream: StreamManager to emit events to
-        """
-        # Emit thinking
-        await stream.emit(StreamEvent(
-            event="thinking",
-            data=json.dumps({"message": "Thinking..."})
-        ))
-        
-        # Build context
-        context = await self.context_builder.build(session_id, message)
-        
-        # Run loop with streaming
-        async for chunk in self.reasoner.reason_stream(context):
-            await stream.emit(StreamEvent(
-                event="text",
-                data=json.dumps({"delta": chunk})
-            ))
-        
-        # Run tools if needed (non-streaming for v1)
-        if tool_calls := self.last_decision.tool_calls:
-            for call in tool_calls:
-                await stream.emit(StreamEvent(
-                    event="tool_start",
-                    data=json.dumps({
-                        "tool_name": call.name,
-                        "arguments": sanitize_args(call.arguments)
-                    })
-                ))
-                
-                result = await self.executor.execute(call)
-                
-                await stream.emit(StreamEvent(
-                    event="tool_done",
-                    data=json.dumps({
-                        "tool_name": call.name,
-                        "success": result.success,
-                        "result": summarize_result(result)
-                    })
-                ))
-        
-        # Emit done
-        await stream.emit(StreamEvent(
-            event="done",
-            data=json.dumps({
-                "final_message": self.full_response,
-                "tool_calls": [c.name for c in tool_calls],
-                "iterations": self.iterations,
-                "duration_ms": self.duration_ms
-            })
-        ))
-```
+- A provided `session_id` that does not exist → HTTP 404 (never an in-stream
+  `error` frame).
+- An absent `session_id` → a new session is created.
+
+The stream itself only iterates `execution_module.stream_chat()`; no session
+work happens inside the generator.
+
+---
+
+### Error Policy
+
+- **Expected `ErrorEvent`:** the adapter yields the `error` frame and returns.
+  The loop's yield-then-reraise contract stays silent on the server, so
+  expected conditions like `max_iterations` produce no traceback.
+- **Unexpected exceptions** in the adapter (bugs, serialization): yield an
+  `error{code: null}` frame, log, then re-raise — never silent.
+- **Unknown event types:** logged and skipped from the wire — dropped, but not
+  silent.
+
+Consequence: streaming and non-streaming diverge on max-iterations — the stream
+emits `error{code: "max_iterations"}` and ends, while non-streaming
+`run_chat()` returns the friendly fallback message.
+
+---
 
 ### v1 Scope
 
@@ -1692,9 +1596,8 @@ class StreamingAgentLoop:
 ✅ Chat text streaming (SSE text event)
 ✅ Thinking indicator (SSE thinking event)
 ✅ Tool start/done events (SSE tool_start, tool_done)
-✅ Done event with stats
-✅ Non-blocking buffering (slow client protection)
-✅ Graceful disconnect handling
+✅ Done event with final message, tool calls, iterations
+✅ Error frames (error{error, code}) for expected and unexpected failures
 
 ❌ Tool output streaming (tail -f style)
 ❌ Tool progress updates (steps/percentage)
@@ -1702,6 +1605,8 @@ class StreamingAgentLoop:
 ❌ Stream reconnection/resume
 ❌ E2E encryption (not needed for local deployment)
 ```
+
+---
 
 ### Client Example
 
@@ -1721,7 +1626,7 @@ function parseSSELines(chunk) {
     const lines = chunk.split('\n');
     const events = [];
     let current = {};
-    
+
     for (const line of lines) {
         if (line === '') {
             if (current.event && current.data) {
@@ -1740,11 +1645,11 @@ function parseSSELines(chunk) {
 while (true) {
     const { done, value } = await reader.read();
     if (done) break;
-    
+
     const chunk = decoder.decode(value);
     parseSSELines(chunk).forEach(({ event, data }) => {
         const payload = JSON.parse(data);
-        
+
         switch (event) {
             case 'thinking':
                 showThinking(payload.message);
@@ -1756,24 +1661,29 @@ while (true) {
                 showToolExecuting(payload.tool_name);
                 break;
             case 'tool_done':
-                showToolResult(payload.tool_name, payload.result);
+                showToolResult(payload.tool_name, payload.output, payload.error);
                 break;
             case 'done':
-                showStats(payload.iterations, payload.duration_ms);
+                showStats(payload.iterations);
+                break;
+            case 'error':
+                showError(payload.error, payload.code);
                 break;
         }
     });
 }
 ```
 
+---
+
 ### Settled Questions
 
 - **Protocol:** SSE-only (no WebSocket)
-- **Tool output:** Not streamed (final summary only)
+- **Tool output:** Not streamed (final summary in `tool_done.output`)
 - **Tool progress:** Simple start/done events (no steps)
 - **Client → Server:** Not needed for v1
 - **Reconnection:** Not supported (new stream per request)
-- **Backpressure:** Buffer with drop-oldest policy (prevents slow clients blocking agent)
+- **Backpressure:** No explicit buffering — `StreamingResponse` streams frames as the generator produces them; `X-Accel-Buffering: no` disables proxy buffering (nginx)
 
 ---
 

--- a/docs/adr/0002-async-generator-as-streaming-seam.md
+++ b/docs/adr/0002-async-generator-as-streaming-seam.md
@@ -33,3 +33,11 @@ The obsolete `loop.*` members in `EventTypes` (loop.started, loop.thought, loop.
 - `EXECUTE_TOOLS` with an empty `tool_calls` list responds with the fallback text ("I couldn't determine what tools to use.") as a normal `TextDeltaEvent` + `ResponseDoneEvent` — parity with `run_chat`, iterations not incremented.
 - `TextDeltaEvent` is one event per RESPOND/ASK_QUESTION carrying the full response text. "Delta" means a unit of response text — chunk size is never guaranteed; multiple deltas per response only materialize if the reasoner streams tokens.
 - `run_chat()` is untouched by #15; its drainer rewrite is #16.
+
+## Consequences (refined during #17)
+
+- `ExecutionModule` exposes a transparent `stream_chat()` passthrough: it delegates to `AgentLoop.stream_chat()` unchanged — no `MaxIterationsError` swallowing (unlike `run_chat()`'s fallback). The yield-then-reraise contract must reach the consumer intact; the SSE adapter is the consumer that decides what to do with the reraise.
+- SSE wire format is an explicit minimal mapping, not `to_dict()`: `thinking{message}`, `text{delta}`, `tool_start{tool_name,tool_call_id}`, `tool_done{tool_name,tool_call_id,success,output,error,execution_time_ms}`, `done{final_message,tool_calls,iterations}`, `error{error,code}`. `done` renames `message`→`final_message` and `tools_used`→`tool_calls`; `session_id` and `duration_ms` are not on the wire — a per-request SSE connection needs no session attribution, and nothing measures duration.
+- Session resolution happens before the stream starts: a missing session is an HTTP 404, never an in-stream `error` frame. The stream itself only iterates `stream_chat()`.
+- Error policy: on `ErrorEvent` the adapter yields the `error` frame and returns — the loop's reraise stays silent, so expected conditions like `max_iterations` produce no server traceback. Unexpected exceptions in the adapter yield an `error{code:null}` frame and then re-raise, so bugs are logged.
+- Consequence of the above: streaming and non-streaming diverge on max-iterations — the stream emits `error{code:"max_iterations"}` and ends, while non-streaming `run_chat()` returns the friendly fallback message.

--- a/src/cortex/api/routes/chat.py
+++ b/src/cortex/api/routes/chat.py
@@ -194,7 +194,8 @@ async def chat_stream(
                         yield _sse_event("error", {"error": event.error, "code": event.code})
                         return
                     case _:
-                        # Never silently drop progress from an unknown event.
+                        # Unknown event types are logged and skipped from the
+                        # wire — dropped, but not silent.
                         logger.warning(f"Unhandled loop event: {type(event).__name__}")
         except Exception as exc:
             # Unexpected adapter errors (bugs, serialization) — logged, not silent.

--- a/src/cortex/api/routes/chat.py
+++ b/src/cortex/api/routes/chat.py
@@ -3,13 +3,21 @@
 from __future__ import annotations
 
 import json
+import logging
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
-from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 
+from cortex.agentic.events import (
+    ErrorEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
 from cortex.api.auth import get_api_key
 from cortex.api.dependencies import (
     get_execution_module,
@@ -20,6 +28,8 @@ from cortex.api.schemas import ChatRequest, ChatResponse, ErrorResponse
 if TYPE_CHECKING:
     from cortex.execution.module import ExecutionModule
     from cortex.interaction.service import InteractionService
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 
@@ -107,6 +117,13 @@ async def chat_stream(
     """
     Streaming chat endpoint using Server-Sent Events.
 
+    Session resolution happens before the stream starts: a provided
+    session_id that does not exist is an HTTP 404 (same as the
+    non-streaming endpoint); an absent session_id creates a session
+    through the same policy. The stream itself only iterates
+    ``execution_module.stream_chat()`` and maps each LoopEvent to an
+    SSE frame (one vocabulary — the event_type IS the wire name).
+
     Events emitted:
     - thinking: Agent is thinking
     - text: Text delta
@@ -115,48 +132,75 @@ async def chat_stream(
     - done: Response complete
     - error: Error occurred
     """
+    # Get or create session (before the stream, same policy as non-streaming)
+    if request.session_id:
+        session = await interaction_service.get_session(request.session_id)
+        if not session:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail={"error": "not_found", "detail": "Session not found"},
+            )
+        session_id = request.session_id
+    else:
+        session = await interaction_service._get_or_create_session(None)
+        session_id = session.id
+
+    max_iterations = request.max_iterations or 20
 
     async def event_generator() -> AsyncGenerator[str, None]:
-        session_id: UUID | None = request.session_id
-
         try:
-            # Get or create session
-            if session_id:
-                session = await interaction_service.get_session(session_id)
-                if not session:
-                    yield _sse_event("error", {"message": "Session not found"})
-                    return
-            else:
-                session = await interaction_service._get_or_create_session(None)
-                session_id = session.id
-
-            # Send initial thinking event
-            yield _sse_event("thinking", {"message": "Processing your request..."})
-
-            # Run chat (simplified - full streaming would need loop modification)
-            max_iterations = request.max_iterations or 20
-
-            response = await execution_module.run_chat(
+            async for event in execution_module.stream_chat(
                 session_id=session_id,
                 user_message=request.message,
                 max_iterations=max_iterations,
-            )
-
-            # Stream the response text
-            yield _sse_event("text", {"delta": response.message})
-    # Stream the response text
-            yield _sse_event(
-                "done",
-                {
-                    "final_message": response.message,
-                    "tool_calls": response.tools_used or [],
-                    "iterations": response.iterations,
-                    "duration_ms": 0,  # TODO: track duration
-                },
-            )
-
-        except Exception as e:
-            yield _sse_event("error", {"message": str(e)})
+            ):
+                match event:
+                    case ThinkingEvent():
+                        yield _sse_event("thinking", {"message": event.message})
+                    case TextDeltaEvent():
+                        yield _sse_event("text", {"delta": event.delta})
+                    case ToolStartEvent():
+                        yield _sse_event(
+                            "tool_start",
+                            {
+                                "tool_name": event.tool_name,
+                                "tool_call_id": event.tool_call_id,
+                            },
+                        )
+                    case ToolResultEvent():
+                        yield _sse_event(
+                            "tool_done",
+                            {
+                                "tool_name": event.tool_name,
+                                "tool_call_id": event.tool_call_id,
+                                "success": event.success,
+                                "output": event.output,
+                                "error": event.error,
+                                "execution_time_ms": event.execution_time_ms,
+                            },
+                        )
+                    case ResponseDoneEvent():
+                        yield _sse_event(
+                            "done",
+                            {
+                                "final_message": event.message,
+                                "tool_calls": event.tools_used,
+                                "iterations": event.iterations,
+                            },
+                        )
+                    case ErrorEvent():
+                        # Terminal frame; the loop's reraise stays silent for
+                        # expected conditions (e.g. max_iterations).
+                        yield _sse_event("error", {"error": event.error, "code": event.code})
+                        return
+                    case _:
+                        # Never silently drop progress from an unknown event.
+                        logger.warning(f"Unhandled loop event: {type(event).__name__}")
+        except Exception as exc:
+            # Unexpected adapter errors (bugs, serialization) — logged, not silent.
+            logger.exception("Unexpected error streaming chat events")
+            yield _sse_event("error", {"error": str(exc), "code": None})
+            raise
 
     return StreamingResponse(
         event_generator(),

--- a/src/cortex/execution/module.py
+++ b/src/cortex/execution/module.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -19,6 +20,7 @@ from cortex.agentic.models import (
 from cortex.events import EventEmitter
 
 if TYPE_CHECKING:
+    from cortex.agentic.events import LoopEvent
     from cortex.events import EventBus
 
 logger = logging.getLogger(__name__)
@@ -89,6 +91,37 @@ class ExecutionModule:
                 message="I ran out of iterations. Please try a simpler request.",
                 iterations=max_iterations or 20,
             )
+
+    async def stream_chat(
+        self,
+        session_id: UUID,
+        user_message: str,
+        *,
+        max_iterations: int | None = None,
+    ) -> AsyncGenerator[LoopEvent, None]:
+        """
+        Stream chat progress events as a transparent passthrough.
+
+        Delegates to ``self._agent_loop.stream_chat(...)`` unchanged and
+        yields events as-is — including the yield-then-reraise error
+        contract: ``MaxIterationsError`` (and any other exception) is NOT
+        swallowed, unlike ``run_chat()``'s fallback.
+
+        Args:
+            session_id: Current session
+            user_message: User's message
+            max_iterations: Optional iteration limit
+
+        Yields:
+            LoopEvent progress signals (thinking, tool_start, tool_done,
+            text, done, error).
+        """
+        async for event in self._agent_loop.stream_chat(
+            session_id=session_id,
+            user_message=user_message,
+            max_iterations=max_iterations,
+        ):
+            yield event
 
     async def create_goal(
         self,

--- a/tests/unit/api/test_chat_stream.py
+++ b/tests/unit/api/test_chat_stream.py
@@ -139,12 +139,43 @@ class TestChatStreamSSE:
         assert response.status_code == 200
         assert response.headers["content-type"].startswith("text/event-stream")
         assert response.headers["cache-control"] == "no-cache"
+        assert response.headers["connection"] == "keep-alive"
+        assert response.headers["x-accel-buffering"] == "no"
         assert parse_sse(response.text) == [
             ("thinking", {"message": "Let me reason."}),
             ("text", {"delta": "Hello there!"}),
             ("done", {"final_message": "Hello there!", "tool_calls": [], "iterations": 1}),
         ]
         assert fake_exec.calls == [(session_id, "hi", 20)]
+
+    def test_multiple_text_deltas_yield_one_frame_each_in_order(self):
+        """Two TextDeltaEvents produce two text frames in order — text
+        streams as it accumulates, not just at the end."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            TextDeltaEvent(session_id=session_id, delta="Hello "),
+            TextDeltaEvent(session_id=session_id, delta="world!"),
+            ResponseDoneEvent(
+                session_id=session_id,
+                message="Hello world!",
+                tools_used=[],
+                iterations=1,
+            ),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        assert parse_sse(response.text) == [
+            ("text", {"delta": "Hello "}),
+            ("text", {"delta": "world!"}),
+            ("done", {"final_message": "Hello world!", "tool_calls": [], "iterations": 1}),
+        ]
 
     def test_tool_round_interleaves_start_done_pairs(self):
         """ToolStartEvent/ToolResultEvent interleave as paired frames carrying
@@ -340,6 +371,33 @@ class TestChatStreamSSE:
             ("error", {"error": "Max iterations exceeded", "code": "max_iterations"}),
         ]
 
+    def test_error_event_passes_null_code_through(self):
+        """An ErrorEvent with code None must put null on the wire — the
+        documented contract is 'max_iterations' for MaxIterationsError, null
+        otherwise, and the arm passes event.code through unchanged."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            ErrorEvent(
+                session_id=session_id,
+                error="Tool exhausted retries",
+                code=None,
+            ),
+            TextDeltaEvent(session_id=session_id, delta="must not stream"),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        assert response.status_code == 200
+        assert parse_sse(response.text) == [
+            ("error", {"error": "Tool exhausted retries", "code": None}),
+        ]
+
     def test_unexpected_exception_yields_error_null_frame_and_reraises(self):
         """An exception escaping stream_chat without an ErrorEvent yields an
         error{code: null} frame, then the exception re-raises (surfaces out
@@ -381,91 +439,12 @@ class TestChatStreamSSE:
         ]
 
         # Through the full HTTP path the exception surfaces out of the
-        # stream (never swallowed into a silent end).
+        # stream (never swallowed into a silent end). It raises at the
+        # stream entry, before httpx constructs a Response, so no body is
+        # iterated.
         surfacing_client = build_client(fake_exec, fake_interaction, raise_server_exceptions=True)
         with pytest.raises(RuntimeError, match="boom"):
             with surfacing_client.stream(
                 "POST", "/chat/stream", json=payload, headers=AUTH_HEADERS
-            ) as response:
-                assert response.status_code == 200
-                for _ in response.iter_bytes():
-                    pass
-
-
-class TestExecutionModuleStreamChat:
-    """ExecutionModule.stream_chat transparent passthrough (user story 7)."""
-
-    @pytest.mark.asyncio
-    async def test_stream_chat_passes_events_through_unchanged(self):
-        """Events pass through in order, unchanged, with arguments delegated."""
-        from cortex.execution.module import ExecutionModule
-
-        session_id = uuid4()
-        scripted = [
-            ThinkingEvent(session_id=session_id, message="reasoning"),
-            ToolStartEvent(session_id=session_id, tool_name="web_search", tool_call_id="call_1"),
-            TextDeltaEvent(session_id=session_id, delta="hi"),
-            ResponseDoneEvent(
-                session_id=session_id,
-                message="hi",
-                tools_used=["web_search"],
-                iterations=1,
-            ),
-        ]
-
-        class FakeLoop:
-            calls: list[tuple[UUID, str, int | None]] = []
-
-            async def stream_chat(
-                self,
-                session_id: UUID,
-                user_message: str,
-                *,
-                max_iterations: int | None = None,
             ):
-                FakeLoop.calls.append((session_id, user_message, max_iterations))
-                for event in scripted:
-                    yield event
-
-        module = ExecutionModule(agent_loop=FakeLoop())
-
-        seen = [event async for event in module.stream_chat(session_id, "hello")]
-
-        assert seen == scripted
-        assert FakeLoop.calls == [(session_id, "hello", None)]
-
-    @pytest.mark.asyncio
-    async def test_stream_chat_reraises_max_iterations_after_error_event(self):
-        """The yield-then-reraise contract survives the passthrough: an
-        ErrorEvent is yielded, then MaxIterationsError propagates (unlike
-        run_chat's fallback)."""
-        from cortex.agentic.models import MaxIterationsError
-        from cortex.execution.module import ExecutionModule
-
-        session_id = uuid4()
-
-        class FakeLoop:
-            async def stream_chat(
-                self,
-                session_id: UUID,
-                user_message: str,
-                *,
-                max_iterations: int | None = None,
-            ):
-                yield ErrorEvent(
-                    session_id=session_id,
-                    error="Max iterations exceeded",
-                    code="max_iterations",
-                )
-                raise MaxIterationsError(max_iterations or 20)
-
-        module = ExecutionModule(agent_loop=FakeLoop())
-
-        seen: list[Any] = []
-        with pytest.raises(MaxIterationsError):
-            async for event in module.stream_chat(session_id, "hello", max_iterations=3):
-                seen.append(event)
-
-        assert len(seen) == 1
-        assert isinstance(seen[0], ErrorEvent)
-        assert seen[0].code == "max_iterations"
+                pass

--- a/tests/unit/api/test_chat_stream.py
+++ b/tests/unit/api/test_chat_stream.py
@@ -1,0 +1,471 @@
+"""Route-level SSE tests for POST /chat/stream (issue #17).
+
+The seam is the full HTTP path: auth, session resolution, SSE framing and
+streaming. The execution module and interaction service are fakes so the
+loop itself is never exercised.
+"""
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cortex.agentic.events import (
+    ErrorEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
+from cortex.api.auth import get_api_key
+from cortex.api.dependencies import get_execution_module, get_interaction_service
+from cortex.main import create_app
+from cortex.sessions.models import Session
+
+AUTH_HEADERS = {"Authorization": "Bearer dummy-key"}
+
+
+def parse_sse(body: str) -> list[tuple[str, dict[str, Any]]]:
+    """Parse an SSE body into (event, data) frames."""
+    frames: list[tuple[str, dict[str, Any]]] = []
+    for block in body.split("\n\n"):
+        if not block.strip():
+            continue
+        event: str | None = None
+        data: str | None = None
+        for line in block.splitlines():
+            if line.startswith("event: "):
+                event = line.removeprefix("event: ")
+            elif line.startswith("data: "):
+                data = line.removeprefix("data: ")
+        assert event is not None, f"SSE block missing event name: {block!r}"
+        assert data is not None, f"SSE block missing data: {block!r}"
+        frames.append((event, json.loads(data)))
+    return frames
+
+
+class FakeExecutionModule:
+    """Scripted stream_chat: yields pre-built LoopEvents, or raises."""
+
+    def __init__(
+        self,
+        events: list[Any] | None = None,
+        exc: Exception | None = None,
+    ):
+        self._events = events or []
+        self._exc = exc
+        self.calls: list[tuple[UUID, str, int | None]] = []
+
+    async def stream_chat(
+        self,
+        session_id: UUID,
+        user_message: str,
+        *,
+        max_iterations: int | None = None,
+    ):
+        self.calls.append((session_id, user_message, max_iterations))
+        if self._exc is not None:
+            raise self._exc
+        for event in self._events:
+            yield event
+
+
+class FakeInteractionService:
+    """Records session lookups/creations; serves a scripted existing session."""
+
+    def __init__(self, existing_session: Session | None = None):
+        self._existing_session = existing_session
+        self.created_sessions: list[Session] = []
+
+    async def get_session(self, session_id: UUID) -> Session | None:
+        if self._existing_session is not None and self._existing_session.id == session_id:
+            return self._existing_session
+        return None
+
+    async def _get_or_create_session(self, session_id: UUID | None) -> Session:
+        session = Session()
+        self.created_sessions.append(session)
+        return session
+
+
+def build_client(
+    execution_module: FakeExecutionModule,
+    interaction_service: FakeInteractionService,
+    *,
+    raise_server_exceptions: bool = True,
+) -> TestClient:
+    """App with the three chat dependencies overridden by fakes."""
+    settings = MagicMock()
+    settings.version = "0.1.0"
+    with patch("cortex.main.get_settings", return_value=settings):
+        app = create_app()
+    app.dependency_overrides[get_api_key] = lambda: "dummy-key"
+    app.dependency_overrides[get_execution_module] = lambda: execution_module
+    app.dependency_overrides[get_interaction_service] = lambda: interaction_service
+    return TestClient(app, raise_server_exceptions=raise_server_exceptions)
+
+
+class TestChatStreamSSE:
+    """POST /chat/stream maps LoopEvents to SSE frames at the route seam."""
+
+    def test_respond_script_frames_in_order(self):
+        """RESPOND script streams thinking, text, done in order with
+        documented payload field names."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            ThinkingEvent(session_id=session_id, message="Let me reason."),
+            TextDeltaEvent(session_id=session_id, delta="Hello there!"),
+            ResponseDoneEvent(
+                session_id=session_id,
+                message="Hello there!",
+                tools_used=[],
+                iterations=1,
+            ),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        assert response.headers["cache-control"] == "no-cache"
+        assert parse_sse(response.text) == [
+            ("thinking", {"message": "Let me reason."}),
+            ("text", {"delta": "Hello there!"}),
+            ("done", {"final_message": "Hello there!", "tool_calls": [], "iterations": 1}),
+        ]
+        assert fake_exec.calls == [(session_id, "hi", 20)]
+
+    def test_tool_round_interleaves_start_done_pairs(self):
+        """ToolStartEvent/ToolResultEvent interleave as paired frames carrying
+        success/output/error/execution_time_ms, before text and done."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            ThinkingEvent(session_id=session_id, message="Looking it up."),
+            ToolStartEvent(session_id=session_id, tool_name="web_search", tool_call_id="call_1"),
+            ToolResultEvent(
+                session_id=session_id,
+                tool_name="web_search",
+                tool_call_id="call_1",
+                success=True,
+                output="results",
+                error=None,
+                execution_time_ms=12.5,
+            ),
+            ToolStartEvent(session_id=session_id, tool_name="calculator", tool_call_id="call_2"),
+            ToolResultEvent(
+                session_id=session_id,
+                tool_name="calculator",
+                tool_call_id="call_2",
+                success=False,
+                output=None,
+                error="division by zero",
+                execution_time_ms=3.0,
+            ),
+            TextDeltaEvent(session_id=session_id, delta="Found it."),
+            ResponseDoneEvent(
+                session_id=session_id,
+                message="Found it.",
+                tools_used=["web_search", "calculator"],
+                iterations=2,
+            ),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "find it", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        assert parse_sse(response.text) == [
+            ("thinking", {"message": "Looking it up."}),
+            (
+                "tool_start",
+                {"tool_name": "web_search", "tool_call_id": "call_1"},
+            ),
+            (
+                "tool_done",
+                {
+                    "tool_name": "web_search",
+                    "tool_call_id": "call_1",
+                    "success": True,
+                    "output": "results",
+                    "error": None,
+                    "execution_time_ms": 12.5,
+                },
+            ),
+            (
+                "tool_start",
+                {"tool_name": "calculator", "tool_call_id": "call_2"},
+            ),
+            (
+                "tool_done",
+                {
+                    "tool_name": "calculator",
+                    "tool_call_id": "call_2",
+                    "success": False,
+                    "output": None,
+                    "error": "division by zero",
+                    "execution_time_ms": 3.0,
+                },
+            ),
+            ("text", {"delta": "Found it."}),
+            (
+                "done",
+                {
+                    "final_message": "Found it.",
+                    "tool_calls": ["web_search", "calculator"],
+                    "iterations": 2,
+                },
+            ),
+        ]
+
+    def test_done_frame_renames_never_drops(self):
+        """The done frame carries final_message/tool_calls/iterations, never
+        the model field names message/tools_used, and never omits a field."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            ResponseDoneEvent(
+                session_id=session_id,
+                message="Done.",
+                tools_used=["web_search"],
+                iterations=3,
+            ),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "go", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        done_payload = parse_sse(response.text)[-1][1]
+        assert done_payload == {
+            "final_message": "Done.",
+            "tool_calls": ["web_search"],
+            "iterations": 3,
+        }
+        assert "message" not in done_payload
+        assert "tools_used" not in done_payload
+
+    def test_missing_session_returns_404_with_zero_frames(self):
+        """A provided session_id that does not exist is an HTTP 404 before
+        any frame — stream_chat is never invoked."""
+        fake_exec = FakeExecutionModule([
+            TextDeltaEvent(session_id=uuid4(), delta="never"),
+        ])
+        fake_interaction = FakeInteractionService()  # no existing session
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(uuid4())},
+            headers=AUTH_HEADERS,
+        )
+
+        assert response.status_code == 404
+        assert "event: " not in response.text
+        assert fake_exec.calls == []
+
+    def test_absent_session_creates_and_streams_normally(self):
+        """An absent session_id exercises the creation path; frames stream
+        with the newly created session id."""
+        fake_exec = FakeExecutionModule([
+            ThinkingEvent(session_id=uuid4(), message="Fresh session."),
+            ResponseDoneEvent(
+                session_id=uuid4(),
+                message="Done.",
+                tools_used=[],
+                iterations=1,
+            ),
+        ])
+        fake_interaction = FakeInteractionService()
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "hi"},
+            headers=AUTH_HEADERS,
+        )
+
+        assert response.status_code == 200
+        assert len(fake_interaction.created_sessions) == 1
+        created = fake_interaction.created_sessions[0]
+        assert fake_exec.calls[0][0] == created.id
+        assert fake_exec.calls[0][2] == 20  # max_iterations default
+        assert parse_sse(response.text) == [
+            ("thinking", {"message": "Fresh session."}),
+            ("done", {"final_message": "Done.", "tool_calls": [], "iterations": 1}),
+        ]
+
+    def test_error_event_is_terminal_and_propagates_max_iterations_code(self):
+        """An ErrorEvent yields exactly one error frame with code
+        'max_iterations'; the stream ends — events scripted after the error
+        never surface."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            ErrorEvent(
+                session_id=session_id,
+                error="Max iterations exceeded",
+                code="max_iterations",
+            ),
+            TextDeltaEvent(session_id=session_id, delta="must not stream"),
+            ResponseDoneEvent(session_id=session_id, message="must not stream"),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        assert response.status_code == 200
+        assert parse_sse(response.text) == [
+            ("error", {"error": "Max iterations exceeded", "code": "max_iterations"}),
+        ]
+
+    def test_unexpected_exception_yields_error_null_frame_and_reraises(self):
+        """An exception escaping stream_chat without an ErrorEvent yields an
+        error{code: null} frame, then the exception re-raises (surfaces out
+        of the stream, so it is logged by the server — never silent).
+
+        The frame itself is asserted at the route-handler seam: buffering
+        ASGI clients (Starlette TestClient, httpx ASGITransport) cannot
+        deliver body chunks sent before a mid-stream app exception, so the
+        partial body is unobservable through the HTTP transport.
+        """
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule(exc=RuntimeError("boom"))
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        payload = {"message": "hi", "session_id": str(session_id)}
+
+        # The error{code: null} frame is yielded before the exception
+        # re-raises out of the stream.
+        from cortex.api.routes.chat import chat_stream
+        from cortex.api.schemas import ChatRequest
+
+        response = asyncio.run(
+            chat_stream(
+                ChatRequest(message="hi", session_id=session_id),
+                key="dummy-key",
+                interaction_service=fake_interaction,
+                execution_module=fake_exec,
+            )
+        )
+
+        async def drain() -> list[str]:
+            frames: list[str] = []
+            with pytest.raises(RuntimeError, match="boom"):
+                async for chunk in response.body_iterator:
+                    frames.append(chunk)
+            return frames
+
+        assert parse_sse("".join(asyncio.run(drain()))) == [
+            ("error", {"error": "boom", "code": None}),
+        ]
+
+        # Through the full HTTP path the exception surfaces out of the
+        # stream (never swallowed into a silent end).
+        surfacing_client = build_client(fake_exec, fake_interaction, raise_server_exceptions=True)
+        with pytest.raises(RuntimeError, match="boom"):
+            with surfacing_client.stream(
+                "POST", "/chat/stream", json=payload, headers=AUTH_HEADERS
+            ) as response:
+                assert response.status_code == 200
+                for _ in response.iter_bytes():
+                    pass
+
+
+class TestExecutionModuleStreamChat:
+    """ExecutionModule.stream_chat transparent passthrough (user story 7)."""
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_passes_events_through_unchanged(self):
+        """Events pass through in order, unchanged, with arguments delegated."""
+        from cortex.execution.module import ExecutionModule
+
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id=session_id, message="reasoning"),
+            ToolStartEvent(session_id=session_id, tool_name="web_search", tool_call_id="call_1"),
+            TextDeltaEvent(session_id=session_id, delta="hi"),
+            ResponseDoneEvent(
+                session_id=session_id,
+                message="hi",
+                tools_used=["web_search"],
+                iterations=1,
+            ),
+        ]
+
+        class FakeLoop:
+            calls: list[tuple[UUID, str, int | None]] = []
+
+            async def stream_chat(
+                self,
+                session_id: UUID,
+                user_message: str,
+                *,
+                max_iterations: int | None = None,
+            ):
+                FakeLoop.calls.append((session_id, user_message, max_iterations))
+                for event in scripted:
+                    yield event
+
+        module = ExecutionModule(agent_loop=FakeLoop())
+
+        seen = [event async for event in module.stream_chat(session_id, "hello")]
+
+        assert seen == scripted
+        assert FakeLoop.calls == [(session_id, "hello", None)]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_reraises_max_iterations_after_error_event(self):
+        """The yield-then-reraise contract survives the passthrough: an
+        ErrorEvent is yielded, then MaxIterationsError propagates (unlike
+        run_chat's fallback)."""
+        from cortex.agentic.models import MaxIterationsError
+        from cortex.execution.module import ExecutionModule
+
+        session_id = uuid4()
+
+        class FakeLoop:
+            async def stream_chat(
+                self,
+                session_id: UUID,
+                user_message: str,
+                *,
+                max_iterations: int | None = None,
+            ):
+                yield ErrorEvent(
+                    session_id=session_id,
+                    error="Max iterations exceeded",
+                    code="max_iterations",
+                )
+                raise MaxIterationsError(max_iterations or 20)
+
+        module = ExecutionModule(agent_loop=FakeLoop())
+
+        seen: list[Any] = []
+        with pytest.raises(MaxIterationsError):
+            async for event in module.stream_chat(session_id, "hello", max_iterations=3):
+                seen.append(event)
+
+        assert len(seen) == 1
+        assert isinstance(seen[0], ErrorEvent)
+        assert seen[0].code == "max_iterations"

--- a/tests/unit/execution/test_module.py
+++ b/tests/unit/execution/test_module.py
@@ -2,11 +2,18 @@
 
 from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
-from cortex.agentic.models import ChatResponse, GoalResult, GoalStatus
+from cortex.agentic.events import (
+    ErrorEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolStartEvent,
+)
+from cortex.agentic.models import ChatResponse, GoalResult, GoalStatus, MaxIterationsError
 from cortex.execution.module import ExecutionModule
 
 
@@ -146,8 +153,6 @@ class TestExecutionModule:
 
     @pytest.mark.asyncio
     async def test_run_goal_max_iterations(self, mock_event_bus):
-        from cortex.agentic.models import MaxIterationsError
-
         mock_loop = MagicMock()
         mock_loop.run_goal = AsyncMock(side_effect=MaxIterationsError(10))
 
@@ -243,3 +248,77 @@ class TestExecutionModuleEdgeCases:
 
         # Should not raise
         await module.handle_event(mock_event)
+
+
+class TestExecutionModuleStreamChat:
+    """ExecutionModule.stream_chat transparent passthrough (user story 7)."""
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_passes_events_through_unchanged(self):
+        """Events pass through in order, unchanged, with arguments delegated."""
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id=session_id, message="reasoning"),
+            ToolStartEvent(session_id=session_id, tool_name="web_search", tool_call_id="call_1"),
+            TextDeltaEvent(session_id=session_id, delta="hi"),
+            ResponseDoneEvent(
+                session_id=session_id,
+                message="hi",
+                tools_used=["web_search"],
+                iterations=1,
+            ),
+        ]
+
+        class FakeLoop:
+            calls: list[tuple[UUID, str, int | None]] = []
+
+            async def stream_chat(
+                self,
+                session_id: UUID,
+                user_message: str,
+                *,
+                max_iterations: int | None = None,
+            ):
+                FakeLoop.calls.append((session_id, user_message, max_iterations))
+                for event in scripted:
+                    yield event
+
+        module = ExecutionModule(agent_loop=FakeLoop())
+
+        seen = [event async for event in module.stream_chat(session_id, "hello")]
+
+        assert seen == scripted
+        assert FakeLoop.calls == [(session_id, "hello", None)]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_reraises_max_iterations_after_error_event(self):
+        """The yield-then-reraise contract survives the passthrough: an
+        ErrorEvent is yielded, then MaxIterationsError propagates (unlike
+        run_chat's fallback)."""
+        session_id = uuid4()
+
+        class FakeLoop:
+            async def stream_chat(
+                self,
+                session_id: UUID,
+                user_message: str,
+                *,
+                max_iterations: int | None = None,
+            ):
+                yield ErrorEvent(
+                    session_id=session_id,
+                    error="Max iterations exceeded",
+                    code="max_iterations",
+                )
+                raise MaxIterationsError(max_iterations or 20)
+
+        module = ExecutionModule(agent_loop=FakeLoop())
+
+        seen: list[ErrorEvent] = []
+        with pytest.raises(MaxIterationsError):
+            async for event in module.stream_chat(session_id, "hello", max_iterations=3):
+                seen.append(event)
+
+        assert len(seen) == 1
+        assert isinstance(seen[0], ErrorEvent)
+        assert seen[0].code == "max_iterations"


### PR DESCRIPTION
Closes #17

## Summary

`/chat/stream` now consumes `ExecutionModule.stream_chat()` — a transparent passthrough to `AgentLoop.stream_chat()` — and maps each `LoopEvent` to an SSE frame whose wire name IS the event's `event_type` (one vocabulary, no mapping table). The stub that called `run_chat()` and emitted a synthetic thinking event is removed.

- `src/cortex/execution/module.py` — new `stream_chat()` transparent passthrough (no `MaxIterationsError` swallowing; yield-then-reraise contract intact, unlike `run_chat()`'s fallback).
- `src/cortex/api/routes/chat.py` — session resolution moved before the stream (missing provided session → HTTP 404, same as non-streaming; absent → created); the event generator iterates `stream_chat()` and maps events via an explicit minimal match: `thinking{message}`, `text{delta}`, `tool_start{tool_name,tool_call_id}`, `tool_done{...success,output,error,execution_time_ms}`, `done{final_message,tool_calls,iterations}`, `error{error,code}` — no `session_id`/`duration_ms` on the wire. Error policy: `ErrorEvent` → terminal `error` frame (loop reraise silent for expected conditions like max-iterations); unexpected exception → `error{code:null}` frame + re-raise (logged).
- `tests/unit/api/test_chat_stream.py` — new route-level SSE tests (TestClient + dependency overrides: fake execution module scripting `LoopEvent`s, fake interaction service): frame order + documented payloads, tool interleave, multi-delta accumulation, done rename (never drops), 404 with zero frames, session creation path, `error{code:"max_iterations"}` terminal, `error{code:null}` + re-raise.
- `tests/unit/execution/test_module.py` — `TestExecutionModuleStreamChat`: passthrough transparency + yield-then-reraise of `MaxIterationsError`.
- `docs/ARCHITECTURE.md` — "## Streaming" section aligned to the shipped endpoint (removed never-built `StreamManager`/`run_stream`/`ChatStreamRequest` fiction; added wire-protocol table, session-resolution and error-policy subsections).
- `CONTEXT.md` — **SSE adapter** glossary entry; `docs/adr/0002` — "Consequences (refined during #17)".

## Verification

- `python -m pytest tests/unit/api/test_chat_stream.py tests/unit/execution/test_module.py -q` → 24 passed
- Full suite: 483 passed, 1 failed — `tests/e2e/test_docker_compose.py::test_postgres_accepts_connections` (`ModuleNotFoundError: psycopg2`), pre-existing issue #45, unrelated.
- Two-axis review (standards + spec): 2 rounds, zero actionable findings; all 6 acceptance criteria and all 4 System Invariants pinned by non-vacuous tests (invariant-negation tests written first, red → green).
- pre-commit ruff + mypy: clean on all commits.

## Out of scope (per item body)

Goal-mode streaming (#18), changes to `AgentLoop.stream_chat`/`run_chat` or the `LoopEvent` models, token-level streaming, `session_id` on the wire.
