### PR TITLE
fix: migrate e2e postgres test to asyncpg (#45)

### DIFF
--- a/tests/e2e/test_docker_compose.py
+++ b/tests/e2e/test_docker_compose.py
@@ -147,19 +147,19 @@ class TestDockerComposeStack:
         client.loop_stop()
         client.disconnect()
 
-    def test_postgres_accepts_connections(self, compose_stack):
+    async def test_postgres_accepts_connections(self, compose_stack):
         """Test that Postgres is accepting connections."""
-        import psycopg2
+        import asyncpg
 
         try:
-            conn = psycopg2.connect(
+            conn = await asyncpg.connect(
                 host="localhost",
                 port=5432,
                 user="cortex",
                 password="cortex",
                 database="cortex",
-                connect_timeout=10,
+                timeout=10,
             )
-            conn.close()
+            await conn.close()
         except Exception:
             pytest.skip("Postgres not reachable")


### PR DESCRIPTION
Closes #45

## Summary

Fixes the pre-existing full-suite failure `tests/e2e/test_docker_compose.py::TestDockerComposeStack::test_postgres_accepts_connections` (`ModuleNotFoundError: No module named 'psycopg2'`).

- `tests/e2e/test_docker_compose.py` — the test is migrated from `psycopg2` (never a project dependency) to **`asyncpg`** (the production driver used by the repository layer). The test is now async (`async def` + `await asyncpg.connect(..., timeout=10)` + `await conn.close()`); the `try/except` → `pytest.skip("Postgres not reachable")` is preserved. The unguarded-import failure mode is eliminated by construction: `asyncpg` is a hard dependency (`asyncpg>=0.29`), so a fresh environment can no longer hard-fail on this test.

Chosen direction (Option 2 from #45, decided with the user): the e2e test now exercises the same driver as production, instead of a driver the project never installs.

## Verification

- Red: single test → `ModuleNotFoundError: No module named 'psycopg2'` (raised before the skip logic).
- Green: single test **passes for real** — docker-compose is available in this environment; the stack came up and `asyncpg.connect` succeeded against `localhost:5432`. When docker-compose/postgres is unavailable, the fixture or the try/except skips cleanly.
- Full suite: `python -m pytest -q` → **484 passed, 0 failed** (was 483 passed, 1 failed) — the last remaining hard failure in `tests/e2e/` is gone.
- Two-axis review (standards + spec): zero actionable findings; all 4 acceptance criteria verified.
- pre-commit ruff + mypy: clean.

## Out of scope

Marker/testpaths changes (Option 3) — CI already runs `pytest tests/unit` explicitly; the mosquitto test's unguarded `import paho` is a separate latent fragility, not this bug.
