### PR TITLE
fix: e2e tests use declared deps aiomqtt/httpx instead of paho/requests (#51)

### DIFF
--- a/tests/e2e/test_docker_compose.py
+++ b/tests/e2e/test_docker_compose.py
@@ -66,12 +66,12 @@ def api_url():
 @pytest.fixture
 def wait_for_api(api_url):
     """Wait for the API to become healthy before proceeding."""
-    import requests
+    import httpx
 
     max_retries = 30
     for _ in range(max_retries):
         try:
-            resp = requests.get(f"{api_url}/health", timeout=5)
+            resp = httpx.get(f"{api_url}/health", timeout=5)
             if resp.status_code == 200:
                 return
         except Exception:
@@ -108,44 +108,23 @@ class TestDockerComposeStack:
 
     def test_api_health_endpoint_responds(self, compose_stack, wait_for_api, api_url):
         """Test that GET /health returns 200."""
-        import requests
+        import httpx
 
-        resp = requests.get(f"{api_url}/health", timeout=10)
+        resp = httpx.get(f"{api_url}/health", timeout=10)
         assert resp.status_code == 200
 
         data = resp.json()
         assert "status" in data
 
-    def test_mosquitto_accepts_connections(self, compose_stack):
+    async def test_mosquitto_accepts_connections(self, compose_stack):
         """Test that Mosquitto MQTT broker accepts connections."""
-        import paho.mqtt.client as mqtt
+        import aiomqtt
 
-        connected = False
-
-        def on_connect(client, userdata, flags, rc):
-            nonlocal connected
-            if rc == 0:
-                connected = True
-
-        client = mqtt.Client(client_id="test-health-check")
-        client.on_connect = on_connect
         try:
-            client.connect("localhost", 1883, keepalive=10)
+            async with aiomqtt.Client(hostname="localhost", port=1883) as client:
+                await client.publish("test/health", payload=b"ping")
         except Exception:
             pytest.skip("Mosquitto not reachable")
-            return
-        client.loop_start()
-
-        # Wait for connection
-        for _ in range(20):
-            if connected:
-                break
-            time.sleep(0.5)
-        else:
-            pytest.fail("Could not connect to Mosquitto")
-
-        client.loop_stop()
-        client.disconnect()
 
     async def test_postgres_accepts_connections(self, compose_stack):
         """Test that Postgres is accepting connections."""


### PR DESCRIPTION
Closes #51

## Summary

Removes the last two undeclared third-party imports from the e2e suite (`tests/e2e/test_docker_compose.py`) — the same structural fragility as #45, caught before it could break a fresh environment:

- `test_mosquitto_accepts_connections` — migrated from `paho-mqtt` (installed only transitively via `aiomqtt`) to **`aiomqtt`**, the project's declared MQTT driver (production: minions). Now an async test: `async with aiomqtt.Client(hostname="localhost", port=1883)` + `await client.publish(...)` proves the broker accepts connections; the paho callback machinery and its deprecation warning are gone. `try/except` → `pytest.skip("Mosquitto not reachable")` preserved.
- `wait_for_api` fixture and `test_api_health_endpoint_responds` — migrated from `requests` (not declared anywhere in `pyproject.toml`) to **`httpx`**, the project's declared HTTP client. Same timeouts (5s poll / 10s attempt), same `except Exception` retry semantics.

Both drivers are hard dependencies (`aiomqtt>=2.0`, `httpx>=0.27`) — the failure mode is eliminated by construction, and the e2e suite now exercises the same drivers as production. Decision consistent with #45 (migrate, don't guard).

## Verification

- Red: `pytest tests/e2e/test_docker_compose.py -q` passes in this env (fragility invisible, as predicted) but `pyproject.toml` declares neither `paho-mqtt` nor `requests` — paho is transitive via aiomqtt, requests is a phantom dep.
- Green: `pytest tests/e2e/test_docker_compose.py -q` → 4 passed, 0 skipped — mosquitto test genuinely connects to `localhost:1883` via aiomqtt; deprecation warning gone.
- Full suite: `python -m pytest -q` → **484 passed, 0 failed**.
- `grep "import paho\|import requests" tests/` → no matches.
- Two-axis review (standards + spec): zero actionable findings; all 5 acceptance criteria verified. Standards confirmed aiomqtt 2.5.1/httpx API against installed versions and production usage (`src/cortex/minions/mqtt_client.py`).
- pre-commit ruff + mypy: clean.

## Out of scope

No marker/testpaths changes; no `pyproject.toml`/CI/src changes — test file only.
