### PR TITLE
fix: register meta tools at boot and honor the LLM tool-call contract (#53)

### DIFF
--- a/src/cortex/agentic/loop.py
+++ b/src/cortex/agentic/loop.py
@@ -201,6 +201,25 @@ class AgentLoop:
                     case DecisionType.EXECUTE_TOOLS:
                         # 3. Act - execute tools
                         if decision.tool_calls:
+                            # Record the assistant's tool-call decision in the
+                            # conversation (internal shape — the LLM provider
+                            # translates to its own wire format). Providers
+                            # require an assistant message with the tool calls
+                            # to precede the tool messages that answer them.
+                            messages.append(Message(
+                                session_id=session_id,
+                                role=MessageRole.ASSISTANT,
+                                content="",
+                                tool_calls=[
+                                    {
+                                        "id": call.id,
+                                        "name": call.name,
+                                        "arguments": call.arguments,
+                                    }
+                                    for call in decision.tool_calls
+                                ],
+                            ))
+
                             for call in decision.tool_calls:
                                 # Track tools used
                                 tools_used.append(call.name)
@@ -232,6 +251,7 @@ class AgentLoop:
                                         if result.success
                                         else f"Error: {result.error}"
                                     ),
+                                    tool_call_id=call.id,
                                 )
                                 messages.append(msg)
 

--- a/src/cortex/agentic/reasoner.py
+++ b/src/cortex/agentic/reasoner.py
@@ -11,6 +11,7 @@ from cortex.agentic.models import (
 )
 from cortex.llm.models import ChatMessage, Role
 from cortex.sessions.models import MessageRole
+from cortex.tools.interfaces import ToolCall
 
 if TYPE_CHECKING:
     from cortex.llm.base import LLMClient
@@ -141,6 +142,12 @@ class Reasoner:
             messages.append(ChatMessage(
                 role=_MESSAGE_ROLE_TO_LLM_ROLE[msg.role],
                 content=msg.content,
+                tool_call_id=msg.tool_call_id,
+                tool_calls=(
+                    [ToolCall(**tc) for tc in msg.tool_calls]
+                    if msg.tool_calls
+                    else None
+                ),
             ))
 
         return messages

--- a/src/cortex/llm/models.py
+++ b/src/cortex/llm/models.py
@@ -29,6 +29,7 @@ class ChatMessage(BaseModel):
     content: str | None = None
     name: str | None = None
     tool_call_id: str | None = None
+    tool_calls: list[ToolCall] | None = None  # Assistant tool-call turns (internal type)
 
     model_config = {
         "extra": "allow",

--- a/src/cortex/llm/providers/openai.py
+++ b/src/cortex/llm/providers/openai.py
@@ -165,4 +165,28 @@ class OpenAIClient(LLMClient):
         if message.tool_call_id:
             result["tool_call_id"] = message.tool_call_id
 
+        if message.tool_calls:
+            result["tool_calls"] = self.translate_tool_calls(message.tool_calls)
+
         return result
+
+    def translate_tool_calls(self, tool_calls: list[ToolCall]) -> list[dict[str, Any]]:
+        """
+        Translate internal ToolCall objects to the OpenAI wire shape.
+
+        The wire shape (type/function nesting, JSON-string arguments) is a
+        provider detail — it never travels above this module.
+        """
+        import json
+
+        return [
+            {
+                "id": call.id,
+                "type": "function",
+                "function": {
+                    "name": call.name,
+                    "arguments": json.dumps(call.arguments),
+                },
+            }
+            for call in tool_calls
+        ]

--- a/src/cortex/main.py
+++ b/src/cortex/main.py
@@ -164,9 +164,11 @@ async def initialize_app() -> CortexApp:
     # 5d. Create tool registry and executor
     from cortex.tools.executor import DefaultToolExecutor
     from cortex.tools.interfaces import ToolRegistry
+    from cortex.tools.meta import register_meta_tools
     from cortex.tools.registry import InMemoryToolRegistry
 
     tool_registry: ToolRegistry = InMemoryToolRegistry()
+    register_meta_tools(tool_registry)
     base_executor: ToolExecutor = DefaultToolExecutor(registry=tool_registry)
     tool_executor_service = ToolExecutorService(
         base_executor=base_executor,
@@ -244,6 +246,7 @@ async def initialize_app() -> CortexApp:
         "memory_service": cortex.memory_service,
         "minion_service": None,  # Will be initialized separately
         "llm_client": cortex.llm_client,
+        "tool_registry": tool_registry,
     }
 
     # Create FastAPI app with wired dependencies

--- a/src/cortex/sessions/models.py
+++ b/src/cortex/sessions/models.py
@@ -31,6 +31,7 @@ class Message(BaseModel):
     role: MessageRole
     content: str
     tool_calls: list[dict[str, Any]] | None = None  # Serialized tool calls
+    tool_call_id: str | None = None  # For TOOL_RESULT messages: the call being answered
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
     model_config = ConfigDict(use_enum_values=True)

--- a/tests/unit/agentic/test_loop.py
+++ b/tests/unit/agentic/test_loop.py
@@ -632,6 +632,50 @@ class TestStreamChat:
         assert done.tools_used == ["tool_a", "tool_b"]
 
     @pytest.mark.asyncio
+    async def test_tool_round_conversation_carries_tool_call_contract(
+        self, loop, mock_context_builder, mock_reasoner, mock_executor
+    ) -> None:
+        """The conversation injected into context carries an assistant message
+        with the tool calls (internal shape) and a tool_result message with
+        the matching tool_call_id — provider-agnostic, no LLM wire shape."""
+        from cortex.tools.interfaces import ToolResult
+
+        session_id = uuid4()
+        call_a = ToolCall(id="call_a", name="tool_a", arguments={"x": 1})
+
+        ctx = Context(session_id=session_id)
+        mock_context_builder.build = AsyncMock(return_value=ctx)
+        mock_reasoner.reason = AsyncMock(side_effect=[
+            Decision.execute_tools([call_a], reasoning="need tools"),
+            Decision.respond("All done.", reasoning="finished"),
+        ])
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_a", tool_name="tool_a", success=True, output="out_a",
+        ))
+
+        events = [e async for e in loop.stream_chat(session_id, "Run tools")]
+
+        assert events[-1].event_type == "done"
+
+        # Assistant message records the tool calls in the internal shape
+        assistant_msgs = [
+            m for m in ctx.conversation
+            if m.role == MessageRole.ASSISTANT and m.tool_calls
+        ]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0].tool_calls == [{
+            "id": "call_a",
+            "name": "tool_a",
+            "arguments": {"x": 1},
+        }]
+
+        # Tool result message references the call it answers
+        tool_msgs = [m for m in ctx.conversation if m.role == MessageRole.TOOL_RESULT]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].tool_call_id == "call_a"
+        assert "out_a" in tool_msgs[0].content
+
+    @pytest.mark.asyncio
     async def test_empty_tool_calls_yields_fallback_response(
         self, loop, mock_context_builder, mock_reasoner
     ) -> None:

--- a/tests/unit/agentic/test_reasoner.py
+++ b/tests/unit/agentic/test_reasoner.py
@@ -236,6 +236,49 @@ class TestReasoner:
         assert decision.tool_calls[0].arguments == {"path": "/x"}
 
 
+    @pytest.mark.asyncio
+    async def test_reason_preserves_tool_call_ids_in_prompt(self, reasoner, mock_llm_client):
+        """Tool messages carry tool_call_id and assistant tool_calls (as
+        ToolCall objects) into the LLM prompt — provider-agnostic, no wire shape."""
+        from cortex.sessions.models import Message, MessageRole
+
+        mock_llm_client.chat = AsyncMock(return_value=MagicMock(content="ok", tool_calls=[]))
+        session_id = uuid4()
+        context = Context(session_id=session_id, conversation=[
+            Message(
+                session_id=session_id,
+                role=MessageRole.ASSISTANT,
+                content="",
+                tool_calls=[{
+                    "id": "call_x",
+                    "name": "shell",
+                    "arguments": {"command": "echo hi"},
+                }],
+            ),
+            Message(
+                session_id=session_id,
+                role=MessageRole.TOOL_RESULT,
+                content="output",
+                tool_call_id="call_x",
+            ),
+        ])
+
+        await reasoner.reason(context)
+
+        call_args = mock_llm_client.chat.call_args
+        messages = call_args[0][0] if call_args[0] else call_args[1]["messages"]
+        tool_msg = next(m for m in messages if m.role.value == "tool")
+        assistant_msg = next(
+            m for m in messages if m.role.value == "assistant" and m.tool_calls
+        )
+
+        assert tool_msg.tool_call_id == "call_x"
+        assert len(assistant_msg.tool_calls) == 1
+        assert assistant_msg.tool_calls[0].id == "call_x"
+        assert assistant_msg.tool_calls[0].name == "shell"
+        assert assistant_msg.tool_calls[0].arguments == {"command": "echo hi"}
+
+
 class TestReasonerEdgeCases:
     """Edge case tests for Reasoner."""
 

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -165,6 +165,33 @@ class TestOpenAIClient:
         assert tool_call.id == "call_abc123"
         assert tool_call.name == "read_file"
 
+    def test_to_openai_message_serializes_tool_call_contract(self):
+        """Tool messages carry tool_call_id; assistant tool_calls translate to
+        the OpenAI wire shape ONLY at the provider boundary."""
+        import json
+
+        client = OpenAIClient(api_key="test")
+
+        tool_msg = client._to_openai_message(ChatMessage(
+            role=Role.TOOL,
+            content="output",
+            tool_call_id="call_x",
+        ))
+        assert tool_msg["role"] == "tool"
+        assert tool_msg["tool_call_id"] == "call_x"
+
+        assistant_msg = client._to_openai_message(ChatMessage(
+            role=Role.ASSISTANT,
+            content="",
+            tool_calls=[ToolCall(id="call_x", name="shell", arguments={"command": "echo hi"})],
+        ))
+        assert assistant_msg["tool_calls"] == [{
+            "id": "call_x",
+            "type": "function",
+            "function": {"name": "shell", "arguments": json.dumps({"command": "echo hi"})},
+        }]
+        assert "content" not in assistant_msg  # falsy content omitted for tool-call turns
+
 
 class TestLLMClientFactory:
     """Test cases for LLM client factory."""


### PR DESCRIPTION
Closes #53

## Summary

Two defects found by the hello-world smoke test (real docker-compose stack + DeepSeek) that made the tool-execution path dead/broken in the deployed system:

1. **Tool registry empty at boot** — `initialize_app` created `InMemoryToolRegistry()` but never called `register_meta_tools()`, so the reasoner saw zero tool schemas and the model could never select `EXECUTE_TOOLS`. Now: `register_meta_tools(tool_registry)` at boot + `tool_registry` exposed in the app state dict.
2. **LLM tool-call contract violated** — the conversation sent to the LLM after a tool round (a) never included an assistant message with the `tool_calls` and (b) the `TOOL_RESULT` messages carried no `tool_call_id`, causing DeepSeek/OpenAI 400 `missing field 'tool_call_id'`. Now:
   - `Message` (sessions/models.py) gains `tool_call_id`;
   - `stream_chat` appends an assistant message with the tool calls (internal shape `{id, name, arguments}`) before the per-call `TOOL_RESULT` messages, each with `tool_call_id=call.id`;
   - `Reasoner._build_prompt` passes `tool_call_id` through and converts stored dicts to domain `ToolCall` objects on the new `ChatMessage.tool_calls` field;
   - the OpenAI wire shape (`type`/`function` nesting, JSON-string arguments) is translated **only** in `openai.py` via a new `translate_tool_calls` — matching the existing `translate_tools`/`translate_tool_call` provider-boundary pattern. No wire details rise above the provider.

## Verification

- New TDD tests (red → green): loop conversation contract (assistant tool_calls + tool_result tool_call_id), reasoner passthrough (tool_call_id + ToolCall objects), provider serialization (OpenAI wire shape only at the boundary). Full unit suite: **483 passed** (480 + 3 new), zero regressions.
- **Live on the docker-compose stack** (container rebuilt, real DeepSeek):
  - `shell` round: `thinking → tool_start → tool_done` (real `echo ciao-mondo` output, 1.3ms) → second `thinking` **no 400** → `text` citing the exact output → `done` (`tool_calls:["shell"]`, iterations 1).
  - `file_read` round: reads `/etc/hostname` → `94aac8368892`, answer cites the real content.
- pre-commit ruff + mypy: clean.

## Out of scope

Goal-mode tool rounds (`run_goal` uses batch `execute_tools` without conversation accumulation — separate concern); persisted session tool messages from the API (`MessageCreate.tool_calls` format is caller-provided).
