### PR TITLE
fix: goal loop persistence, double-start guard, ended-session writes, real goal results

### DIFF
--- a/migrations/006_message_tool_call_id.sql
+++ b/migrations/006_message_tool_call_id.sql
@@ -1,0 +1,5 @@
+-- 006_message_tool_call_id.sql
+-- Persist tool_call_id on messages so persisted goal/chat conversations
+-- keep the assistant-tool_call -> tool_result link required by LLM providers.
+
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS tool_call_id VARCHAR(255);

--- a/src/cortex/agentic/loop.py
+++ b/src/cortex/agentic/loop.py
@@ -25,13 +25,14 @@ from cortex.agentic.models import (
     Mode,
 )
 from cortex.events import EventEmitter
-from cortex.sessions.models import Message, MessageRole
+from cortex.sessions.models import Message, MessageRole, SessionState
 
 if TYPE_CHECKING:
     from cortex.agentic.context_builder import ContextBuilder
     from cortex.agentic.executor import LoopExecutor
     from cortex.agentic.reasoner import Reasoner
     from cortex.events import EventBus
+    from cortex.sessions.interfaces import SessionRepository
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +59,7 @@ class AgentLoop:
         reasoner: Reasoner,
         executor: LoopExecutor,
         event_bus: EventBus | None = None,
+        session_repository: SessionRepository | None = None,
         max_chat_iterations: int = 20,
         max_goal_iterations: int = 100,
     ):
@@ -65,6 +67,7 @@ class AgentLoop:
         self._reasoner = reasoner
         self._executor = executor
         self._emitter = EventEmitter(event_bus, source_module="agent_loop")
+        self._session_repository = session_repository
         self._max_chat_iterations = max_chat_iterations
         self._max_goal_iterations = max_goal_iterations
 
@@ -307,6 +310,13 @@ class AgentLoop:
         steps_completed: list[str] = []
         session_id = uuid4()  # Create session for goal
 
+        # Persist a real session when a repository is wired, so tool
+        # results feed back into context across iterations (mirrors chat).
+        if self._session_repository is not None:
+            session = await self._session_repository.create()
+            await self._session_repository.update_state(session.id, SessionState.ACTIVE)
+            session_id = session.id
+
         # Emit start event
         await self._emit_goal_event(goal_id, "started", {
             "description": description,
@@ -362,7 +372,39 @@ class AgentLoop:
                 case DecisionType.EXECUTE_TOOLS:
                     # Execute and track
                     if decision.tool_calls:
-                        await self._executor.execute_tools(decision.tool_calls)
+                        # Persist the assistant's tool-call decision before the
+                        # tool messages that answer them (same shape as chat).
+                        if self._session_repository is not None:
+                            await self._session_repository.add_message(
+                                session_id,
+                                MessageRole.ASSISTANT,
+                                "",
+                                tool_calls=[
+                                    {
+                                        "id": call.id,
+                                        "name": call.name,
+                                        "arguments": call.arguments,
+                                    }
+                                    for call in decision.tool_calls
+                                ],
+                            )
+
+                        results = await self._executor.execute_tools(decision.tool_calls)
+
+                        # Persist tool results, linked to their calls, so the
+                        # next context build sees them.
+                        if self._session_repository is not None:
+                            for call, result in zip(decision.tool_calls, results):
+                                await self._session_repository.add_message(
+                                    session_id,
+                                    MessageRole.TOOL_RESULT,
+                                    (
+                                        result.output or ""
+                                        if result.success
+                                        else f"Error: {result.error}"
+                                    ),
+                                    tool_call_id=call.id,
+                                )
 
                         # Track steps
                         for call in decision.tool_calls:

--- a/src/cortex/api/routes/goals.py
+++ b/src/cortex/api/routes/goals.py
@@ -130,11 +130,13 @@ async def get_goal(
 
     # If completed or failed, return the result
     if goal.status.value in ("completed", "failed"):
+        result = await execution_module.get_goal_result(goal_id)
         return GoalResultResponse(
             goal_id=goal.id,
             success=goal.status.value == "completed",
-            message=goal.description,
-            error=goal.error,
+            message=result.message if result else goal.description,
+            iterations=result.iterations if result else 0,
+            error=result.error if result else goal.error,
         )
 
     return GoalResponse(

--- a/src/cortex/api/routes/sessions.py
+++ b/src/cortex/api/routes/sessions.py
@@ -12,7 +12,7 @@ from cortex.api.auth import get_api_key
 from cortex.api.dependencies import get_session_repository
 from cortex.api.schemas import MessageCreate, MessageResponse, SessionResponse, SessionWithMessages
 from cortex.sessions import policy
-from cortex.sessions.models import MessageRole
+from cortex.sessions.models import MessageRole, SessionState
 
 if TYPE_CHECKING:
     from cortex.sessions.interfaces import SessionRepository
@@ -120,12 +120,17 @@ async def create_message(
     session_repo: SessionRepository = Depends(get_session_repository),
 ) -> MessageResponse:
     """Add a message to a session."""
-    # Verify session exists
+    # Verify session exists and is writable (ENDED is terminal — SP1)
     session = await session_repo.get(session_id)
     if session is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail={"error": "not_found", "detail": "Session not found"},
+        )
+    if session.state == SessionState.ENDED:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={"error": "session_ended", "detail": "Session is ended"},
         )
 
     # Add message based on role

--- a/src/cortex/execution/module.py
+++ b/src/cortex/execution/module.py
@@ -61,6 +61,7 @@ class ExecutionModule:
         self._event_bus = event_bus
         self._emitter = EventEmitter(event_bus, source_module="execution_module")
         self._goals: dict[UUID, Goal] = {}
+        self._goal_results: dict[UUID, GoalResult] = {}
 
     async def run_chat(
         self,
@@ -162,6 +163,10 @@ class ExecutionModule:
         """Get a goal by ID."""
         return self._goals.get(goal_id)
 
+    async def get_goal_result(self, goal_id: UUID) -> GoalResult | None:
+        """Get the terminal result of a finished goal, if any."""
+        return self._goal_results.get(goal_id)
+
     async def list_active_goals(self) -> list[Goal]:
         """List active goals (pending, running, or paused)."""
         return [g for g in self._goals.values() if g.status in _ACTIVE_STATUSES]
@@ -233,6 +238,10 @@ class ExecutionModule:
                 "timestamp": goal.completed_at,
             })
 
+            # Keep the terminal result so GET /goals/{id} can report the
+            # actual message/iterations, not just the goal metadata.
+            self._goal_results[goal_id] = result
+
             return result
 
         except MaxIterationsError:
@@ -245,12 +254,15 @@ class ExecutionModule:
                 "timestamp": goal.completed_at,
             })
 
-            return GoalResult(
+            result = GoalResult(
                 goal_id=goal_id,
                 success=False,
                 message="Goal exceeded maximum iterations",
                 error="MaxIterationsError",
             )
+            self._goal_results[goal_id] = result
+
+            return result
 
         except Exception as e:
             goal.status = GoalStatus.FAILED
@@ -262,12 +274,15 @@ class ExecutionModule:
                 "timestamp": goal.completed_at,
             })
 
-            return GoalResult(
+            result = GoalResult(
                 goal_id=goal_id,
                 success=False,
                 message="Goal failed",
                 error=str(e),
             )
+            self._goal_results[goal_id] = result
+
+            return result
 
     async def handle_event(self, event: Any) -> None:
         """

--- a/src/cortex/execution/module.py
+++ b/src/cortex/execution/module.py
@@ -150,12 +150,10 @@ class ExecutionModule:
         )
         self._goals[goal.id] = goal
 
-        await self._emit_goal_event(goal.id, "created", {
-            "description": description,
-            "priority": priority,
-            "timestamp": goal.created_at,
-        })
-
+        # Start the goal in the background. No "goal.created" event is
+        # emitted here: this module subscribes to it, so emitting would
+        # start the goal twice (once synchronously via handle_event while
+        # the POST is still in flight, once via the task below).
         asyncio.create_task(self._run_goal_async(goal))
 
         return goal
@@ -199,6 +197,17 @@ class ExecutionModule:
                 created_at=time.time(),
             )
             self._goals[goal_id] = goal
+
+        # Guard against concurrent starts (e.g. an external goal.created
+        # event racing the background task): a goal already running is
+        # never started twice.
+        if goal.status == GoalStatus.RUNNING:
+            return GoalResult(
+                goal_id=goal_id,
+                success=False,
+                message="Goal already running",
+                error="AlreadyRunning",
+            )
 
         goal.status = GoalStatus.RUNNING
         goal.started_at = time.time()

--- a/src/cortex/main.py
+++ b/src/cortex/main.py
@@ -215,6 +215,7 @@ async def initialize_app() -> CortexApp:
         reasoner=reasoner,
         executor=loop_executor,
         event_bus=cortex.event_bus,
+        session_repository=cortex.session_repository,
     )
 
     # Create execution module

--- a/src/cortex/sessions/interfaces.py
+++ b/src/cortex/sessions/interfaces.py
@@ -44,6 +44,7 @@ class SessionRepository(ABC):
         role: MessageRole,
         content: str,
         tool_calls: list[dict[str, Any]] | None = None,
+        tool_call_id: str | None = None,
     ) -> Message:
         """Add a message to a session."""
         ...

--- a/src/cortex/sessions/repository.py
+++ b/src/cortex/sessions/repository.py
@@ -86,19 +86,21 @@ class PostgresSessionRepository(SessionRepository):
         role: MessageRole,
         content: str,
         tool_calls: list[dict[str, Any]] | None = None,
+        tool_call_id: str | None = None,
     ) -> Message:
         """Add a message to a session."""
         async with DbSession() as db:
             row = await db.fetchrow(
                 """
-                INSERT INTO messages (session_id, role, content, tool_calls)
-                VALUES ($1, $2, $3, $4)
-                RETURNING id, session_id, role, content, tool_calls, created_at
+                INSERT INTO messages (session_id, role, content, tool_calls, tool_call_id)
+                VALUES ($1, $2, $3, $4, $5)
+                RETURNING id, session_id, role, content, tool_calls, tool_call_id, created_at
                 """,
                 session_id,
                 role.value,
                 content,
                 tool_calls,
+                tool_call_id,
             )
             # Also update session activity
             await db.execute(
@@ -119,7 +121,7 @@ class PostgresSessionRepository(SessionRepository):
             if before:
                 rows = await db.fetch(
                     """
-                    SELECT id, session_id, role, content, tool_calls, created_at
+                    SELECT id, session_id, role, content, tool_calls, tool_call_id, created_at
                     FROM messages
                     WHERE session_id = $1 AND created_at < $2
                     ORDER BY created_at DESC
@@ -132,7 +134,7 @@ class PostgresSessionRepository(SessionRepository):
             else:
                 rows = await db.fetch(
                     """
-                    SELECT id, session_id, role, content, tool_calls, created_at
+                    SELECT id, session_id, role, content, tool_calls, tool_call_id, created_at
                     FROM messages
                     WHERE session_id = $1
                     ORDER BY created_at DESC
@@ -178,5 +180,6 @@ class PostgresSessionRepository(SessionRepository):
             role=row["role"],
             content=row["content"],
             tool_calls=row["tool_calls"],
+            tool_call_id=row["tool_call_id"],
             created_at=row["created_at"],
         )

--- a/tests/unit/agentic/test_loop.py
+++ b/tests/unit/agentic/test_loop.py
@@ -22,7 +22,7 @@ from cortex.agentic.models import (
     MaxIterationsError,
 )
 from cortex.sessions.models import Message, MessageRole
-from cortex.tools.interfaces import ToolCall
+from cortex.tools.interfaces import ToolCall, ToolResult
 
 
 class TestAgentLoop:
@@ -368,6 +368,97 @@ class TestAgentLoopGoalMode:
 
         # Should emit goal status events
         assert mock_event_bus.publish.called
+
+    @pytest.mark.asyncio
+    async def test_run_goal_persists_tool_results_when_repository_wired(
+        self, mock_context_builder, mock_executor, mock_event_bus
+    ):
+        """With a session repository wired, run_goal creates a real session
+        and persists assistant tool-calls plus tool results (linked by
+        tool_call_id) so the next context build sees them."""
+        goal_id = uuid4()
+        session_id = uuid4()
+        call_id = "call_abc123"
+
+        repo = MagicMock()
+        repo.create = AsyncMock(return_value=MagicMock(id=session_id))
+        repo.update_state = AsyncMock(return_value=MagicMock(id=session_id))
+        repo.add_message = AsyncMock(return_value=MagicMock())
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_executor.execute_tools = AsyncMock(return_value=[
+            ToolResult(
+                tool_call_id=call_id,
+                tool_name="shell",
+                success=True,
+                output="hello from tool",
+            )
+        ])
+
+        reasoner = MagicMock()
+        reasoner.reason = AsyncMock(side_effect=[
+            Decision.execute_tools(
+                tool_calls=[ToolCall(id=call_id, name="shell", arguments={"command": "echo hi"})],
+                reasoning="need output",
+            ),
+            Decision.respond("done", reasoning="have output"),
+        ])
+
+        loop = AgentLoop(
+            context_builder=mock_context_builder,
+            reasoner=reasoner,
+            executor=mock_executor,
+            event_bus=mock_event_bus,
+            session_repository=repo,
+        )
+
+        result = await loop.run_goal(goal_id, "Run a command")
+
+        assert result.success is True
+        repo.create.assert_awaited_once()
+        repo.update_state.assert_awaited_once()
+        # assistant tool-call message
+        assistant_call = repo.add_message.await_args_list[0]
+        assert assistant_call.args[1] == MessageRole.ASSISTANT
+        assert assistant_call.kwargs["tool_calls"] == [
+            {"id": call_id, "name": "shell", "arguments": {"command": "echo hi"}}
+        ]
+        # tool result message, linked by id
+        result_call = repo.add_message.await_args_list[1]
+        assert result_call.args[1] == MessageRole.TOOL_RESULT
+        assert result_call.kwargs["tool_call_id"] == call_id
+        assert result_call.args[2] == "hello from tool"
+
+    @pytest.mark.asyncio
+    async def test_run_goal_without_repository_keeps_legacy_behavior(
+        self, mock_context_builder, mock_executor, mock_event_bus
+    ):
+        """Without a repository wired, run_goal still completes and never
+        touches persistence (backward-compatible path)."""
+        goal_id = uuid4()
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=uuid4()))
+        mock_executor.execute_tools = AsyncMock(return_value=[])
+
+        reasoner = MagicMock()
+        reasoner.reason = AsyncMock(side_effect=[
+            Decision.execute_tools(
+                tool_calls=[ToolCall(id="call_1", name="shell", arguments={})],
+                reasoning="need output",
+            ),
+            Decision.respond("done", reasoning="have output"),
+        ])
+
+        loop = AgentLoop(
+            context_builder=mock_context_builder,
+            reasoner=reasoner,
+            executor=mock_executor,
+            event_bus=mock_event_bus,
+        )
+
+        result = await loop.run_goal(goal_id, "Run a command")
+
+        assert result.success is True
 
 
 class TestAgentLoopEdgeCases:

--- a/tests/unit/api/test_goals_routes.py
+++ b/tests/unit/api/test_goals_routes.py
@@ -1,0 +1,116 @@
+"""Route-level tests for GET /goals/{id} result reporting.
+
+The seam is the full HTTP path: auth, execution-module dependency, and the
+terminal-result payload (message/iterations must come from the stored
+GoalResult, not from goal metadata).
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from cortex.agentic.models import Goal, GoalResult, GoalStatus
+from cortex.api.auth import get_api_key
+from cortex.api.dependencies import get_execution_module
+from cortex.main import create_app
+
+AUTH_HEADERS = {"Authorization": "Bearer dummy-key"}
+
+
+def _goal(status: GoalStatus, description: str = "Find TODOs") -> Goal:
+    now = datetime.now(UTC).timestamp()
+    return Goal(
+        id=uuid4(),
+        description=description,
+        status=status,
+        created_at=now,
+        started_at=now,
+        completed_at=now if status in (GoalStatus.COMPLETED, GoalStatus.FAILED) else None,
+        error=None,
+    )
+
+
+def build_client(execution_module) -> TestClient:
+    """App with execution-module and auth dependencies overridden."""
+    settings = MagicMock()
+    settings.version = "0.1.0"
+    with patch("cortex.main.get_settings", return_value=settings):
+        app = create_app()
+    app.dependency_overrides[get_api_key] = lambda: "dummy-key"
+    app.dependency_overrides[get_execution_module] = lambda: execution_module
+    return TestClient(app)
+
+
+class TestGetGoalResult:
+    """GET /goals/{id} reports the stored terminal result."""
+
+    def test_completed_goal_returns_actual_message_and_iterations(self):
+        goal = _goal(GoalStatus.COMPLETED)
+        result = GoalResult(
+            goal_id=goal.id,
+            success=True,
+            message="Found 3 TODOs in 2 files",
+            iterations=4,
+            steps_completed=["grep", "file_read"],
+        )
+
+        module = MagicMock()
+        module.get_goal = AsyncMock(return_value=goal)
+        module.get_goal_result = AsyncMock(return_value=result)
+        client = build_client(module)
+
+        response = client.get(f"/goals/{goal.id}", headers=AUTH_HEADERS)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is True
+        assert body["message"] == "Found 3 TODOs in 2 files"
+        assert body["iterations"] == 4
+
+    def test_failed_goal_reports_error(self):
+        goal = _goal(GoalStatus.FAILED, description="Doomed")
+        result = GoalResult(
+            goal_id=goal.id,
+            success=False,
+            message="Goal failed",
+            iterations=2,
+            error="boom",
+        )
+
+        module = MagicMock()
+        module.get_goal = AsyncMock(return_value=goal)
+        module.get_goal_result = AsyncMock(return_value=result)
+        client = build_client(module)
+
+        response = client.get(f"/goals/{goal.id}", headers=AUTH_HEADERS)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is False
+        assert body["error"] == "boom"
+        assert body["iterations"] == 2
+
+    def test_running_goal_returns_status_not_result(self):
+        goal = _goal(GoalStatus.RUNNING)
+
+        module = MagicMock()
+        module.get_goal = AsyncMock(return_value=goal)
+        client = build_client(module)
+
+        response = client.get(f"/goals/{goal.id}", headers=AUTH_HEADERS)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "running"
+        assert "success" not in body
+
+    def test_missing_goal_returns_404(self):
+        module = MagicMock()
+        module.get_goal = AsyncMock(return_value=None)
+        client = build_client(module)
+
+        response = client.get(f"/goals/{uuid4()}", headers=AUTH_HEADERS)
+
+        assert response.status_code == 404

--- a/tests/unit/api/test_sessions_routes.py
+++ b/tests/unit/api/test_sessions_routes.py
@@ -1,0 +1,85 @@
+"""Route-level tests for /sessions message creation (issue: ENDED sessions).
+
+The seam is the full HTTP path: auth, session state policy, and the 409 on
+ended sessions. The repository is a fake so no DB is touched.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from fastapi.testclient import TestClient
+
+from cortex.api.auth import get_api_key
+from cortex.api.dependencies import get_session_repository
+from cortex.main import create_app
+from cortex.sessions.models import Session, SessionState
+
+AUTH_HEADERS = {"Authorization": "Bearer dummy-key"}
+
+
+def build_client(repo) -> TestClient:
+    """App with session-repository and auth dependencies overridden."""
+    settings = MagicMock()
+    settings.version = "0.1.0"
+    with patch("cortex.main.get_settings", return_value=settings):
+        app = create_app()
+    app.dependency_overrides[get_api_key] = lambda: "dummy-key"
+    app.dependency_overrides[get_session_repository] = lambda: repo
+    return TestClient(app)
+
+
+def _fake_repo(state: SessionState) -> MagicMock:
+    session = Session(
+        id=uuid4(),
+        state=state,
+        created_at=datetime.now(UTC),
+        last_activity_at=datetime.now(UTC),
+    )
+    repo = MagicMock()
+    repo.get = AsyncMock(return_value=session)
+    return repo
+
+
+class TestCreateMessageOnEndedSession:
+    """POST /sessions/{id}/messages must reject ENDED sessions (SP1)."""
+
+    def test_message_on_ended_session_returns_409(self):
+        """A message targeting an ENDED session is rejected with 409 and a
+        session_ended error, for every role."""
+        repo = _fake_repo(SessionState.ENDED)
+        client = build_client(repo)
+        session_id = repo.get.return_value.id
+
+        for role in ("user", "assistant", "tool_result"):
+            response = client.post(
+                f"/sessions/{session_id}/messages",
+                headers=AUTH_HEADERS,
+                json={"role": role, "content": "should be rejected"},
+            )
+
+            assert response.status_code == 409, f"role={role}: {response.text}"
+            assert response.json()["detail"]["error"] == "session_ended"
+
+    def test_message_on_active_session_is_accepted(self):
+        """The 409 must not break the normal active-session path."""
+        repo = _fake_repo(SessionState.ACTIVE)
+        repo.add_message = AsyncMock(
+            return_value=MagicMock(
+                id=uuid4(),
+                role="user",
+                content="hi",
+                tool_calls=None,
+                created_at=datetime.now(UTC),
+            )
+        )
+        client = build_client(repo)
+        session_id = repo.get.return_value.id
+
+        response = client.post(
+            f"/sessions/{session_id}/messages",
+            headers=AUTH_HEADERS,
+            json={"role": "user", "content": "hi"},
+        )
+
+        assert response.status_code == 200

--- a/tests/unit/execution/test_module.py
+++ b/tests/unit/execution/test_module.py
@@ -134,6 +134,65 @@ class TestExecutionModule:
         assert fetched.completed_at is not None
 
     @pytest.mark.asyncio
+    async def test_run_goal_keeps_terminal_result(self, mock_event_bus):
+        """run_goal stores the terminal GoalResult so the API can report the
+        actual message and iterations, not just goal metadata."""
+        mock_loop = MagicMock()
+        mock_loop.run_goal = AsyncMock(return_value=GoalResult(
+            goal_id=uuid4(),
+            success=True,
+            message="Found 3 TODOs",
+            iterations=4,
+            steps_completed=["grep", "file_read"],
+        ))
+
+        module = ExecutionModule(
+            agent_loop=mock_loop,
+            event_bus=mock_event_bus,
+        )
+
+        goal = await module.create_goal(description="Find TODOs")
+        await module.run_goal(goal.id, "Find TODOs")
+
+        result = await module.get_goal_result(goal.id)
+
+        assert result is not None
+        assert result.success is True
+        assert result.message == "Found 3 TODOs"
+        assert result.iterations == 4
+        assert result.steps_completed == ["grep", "file_read"]
+
+    @pytest.mark.asyncio
+    async def test_run_goal_keeps_failed_result(self, mock_event_bus):
+        """A failed goal also keeps its result (with the error)."""
+        mock_loop = MagicMock()
+        mock_loop.run_goal = AsyncMock(side_effect=RuntimeError("boom"))
+
+        module = ExecutionModule(
+            agent_loop=mock_loop,
+            event_bus=mock_event_bus,
+        )
+
+        goal = await module.create_goal(description="Doomed")
+        await module.run_goal(goal.id, "Doomed")
+
+        result = await module.get_goal_result(goal.id)
+
+        assert result is not None
+        assert result.success is False
+        assert result.error == "boom"
+
+    @pytest.mark.asyncio
+    async def test_get_goal_result_none_for_unknown(self, mock_event_bus):
+        """get_goal_result returns None for a goal that never ran."""
+        module = ExecutionModule(
+            agent_loop=MagicMock(),
+            event_bus=mock_event_bus,
+        )
+
+        assert await module.get_goal_result(uuid4()) is None
+
+    @pytest.mark.asyncio
     async def test_run_goal_marks_failed_on_exception(self, mock_event_bus):
         mock_loop = MagicMock()
         mock_loop.run_goal = AsyncMock(side_effect=RuntimeError("boom"))

--- a/tests/unit/execution/test_module.py
+++ b/tests/unit/execution/test_module.py
@@ -249,6 +249,55 @@ class TestExecutionModuleEdgeCases:
         # Should not raise
         await module.handle_event(mock_event)
 
+    @pytest.mark.asyncio
+    async def test_create_goal_does_not_emit_goal_created(self, mock_event_bus):
+        """create_goal must not publish goal.created: this module subscribes
+        to that type, so emitting would start the goal twice."""
+        mock_loop = MagicMock()
+        mock_loop.run_goal = AsyncMock(return_value=GoalResult(
+            goal_id=uuid4(),
+            success=True,
+            message="Done",
+        ))
+        module = ExecutionModule(
+            agent_loop=mock_loop,
+            event_bus=mock_event_bus,
+        )
+
+        await module.create_goal(description="Test goal")
+
+        published_types = [
+            call.args[0].type if hasattr(call.args[0], "type") else None
+            for call in mock_event_bus.publish.call_args_list
+        ]
+        assert "goal.created" not in published_types
+
+    @pytest.mark.asyncio
+    async def test_run_goal_guard_skips_running_goal(self, mock_event_bus):
+        """run_goal on an already-RUNNING goal returns without re-running:
+        the background task owns the execution."""
+        mock_loop = MagicMock()
+        mock_loop.run_goal = AsyncMock(return_value=GoalResult(
+            goal_id=uuid4(),
+            success=True,
+            message="Done",
+        ))
+
+        module = ExecutionModule(
+            agent_loop=mock_loop,
+            event_bus=mock_event_bus,
+        )
+
+        goal = await module.create_goal(description="Task")
+        goal.status = GoalStatus.RUNNING  # simulate a task already in flight
+
+        result = await module.run_goal(goal.id, "Task")
+
+        assert result.success is False
+        assert result.error == "AlreadyRunning"
+        # The loop must not have been asked to run a second time.
+        mock_loop.run_goal.assert_not_called()
+
 
 class TestExecutionModuleStreamChat:
     """ExecutionModule.stream_chat transparent passthrough (user story 7)."""

--- a/tests/unit/test_sessions_repository.py
+++ b/tests/unit/test_sessions_repository.py
@@ -117,6 +117,7 @@ class TestPostgresSessionRepository:
             "role": "user",
             "content": "Hello!",
             "tool_calls": None,
+            "tool_call_id": None,
             "created_at": now,
         }
 
@@ -144,6 +145,7 @@ class TestPostgresSessionRepository:
             "role": "assistant",
             "content": "Running command...",
             "tool_calls": tool_calls,
+            "tool_call_id": None,
             "created_at": now,
         }
 
@@ -155,6 +157,33 @@ class TestPostgresSessionRepository:
         )
 
         assert result.tool_calls == tool_calls
+
+    @pytest.mark.asyncio
+    async def test_add_message_with_tool_call_id(self, repo_with_mock):
+        """Tool results persist their tool_call_id so the assistant
+        tool_call -> tool_result link survives a reload."""
+        repo, mock_db_session = repo_with_mock
+        session_id = uuid4()
+        message_id = uuid4()
+        now = datetime.now(UTC)
+        mock_db_session.fetchrow.return_value = {
+            "id": message_id,
+            "session_id": session_id,
+            "role": "tool_result",
+            "content": "output",
+            "tool_calls": None,
+            "tool_call_id": "call_123",
+            "created_at": now,
+        }
+
+        result = await repo.add_message(
+            session_id=session_id,
+            role=MessageRole.TOOL_RESULT,
+            content="output",
+            tool_call_id="call_123",
+        )
+
+        assert result.tool_call_id == "call_123"
 
     @pytest.mark.asyncio
     async def test_get_messages(self, repo_with_mock):
@@ -169,6 +198,7 @@ class TestPostgresSessionRepository:
                 "role": "user",
                 "content": "Hello!",
                 "tool_calls": None,
+                "tool_call_id": None,
                 "created_at": now,
             },
             {
@@ -177,6 +207,7 @@ class TestPostgresSessionRepository:
                 "role": "assistant",
                 "content": "Hi there!",
                 "tool_calls": None,
+                "tool_call_id": None,
                 "created_at": now,
             },
         ]


### PR DESCRIPTION
## Summary

Four functional bugs found in manual testing (A–E + G suite against the real docker stack):

### 1. Goal loop never saw tool results (`loop.py:run_goal`)
The goal's `session_id` was a throwaway `uuid4` that nothing ever wrote to, so the reasoner never saw tool output and every goal hit `MaxIterationsError`. Wire `session_repository` into `AgentLoop`; `run_goal` now creates a real session and persists assistant tool-calls and tool results (linked by `tool_call_id`) so context rebuilds see the conversation. Adds migration `006_message_tool_call_id.sql` + repository roundtrip.

### 2. Every goal started twice (`execution/module.py:create_goal`)
`create_goal` emitted `goal.created` (which this module itself subscribes to) **and** spawned a background task: `publish()` blocked the POST for the whole run (~128s) and two coroutines raced on the same `Goal` object (`running` + `error` + `completed_at` together). Dropped the emit; added a RUNNING guard in `run_goal`.

### 3. Messages accepted on ENDED sessions (`api/routes/sessions.py`)
`POST /sessions/{id}/messages` wrote to ENDED sessions, contradicting the SP1 terminal-state invariant. Now 409 `session_ended` for all roles.

### 4. GET /goals/{id} reported goal.description instead of the result
The terminal `GoalResult` (message/iterations) was discarded by the background task. `ExecutionModule` now keeps it; the route serves the real values.

## Verification
- Unit: **497 passed** (was 483; +14 new tests across loop persistence, RUNNING guard, no-emit, tool_call_id roundtrip, route 409s, goal result reporting).
- Live (docker stack, real DeepSeek): POST /goals returns in ~80ms (was 128s blocked); goals complete with `success: true` and real message/iterations; persisted session shows assistant → tool_result linked by `tool_call_id`; ENDED session write → 409.

## Follow-up (out of scope)
- Goals are held in-memory (`ExecutionModule._goals`) — ADR-0004 persistence/resume not actually implemented.
- `/health` reports `mqtt: unknown` despite a live connection.

---

Tracking issue: #103 (retroactive, closed by this PR).
