### PR TITLE
feat: public get_or_create_session on InteractionService (#36)

### DIFF
--- a/src/cortex/api/routes/chat.py
+++ b/src/cortex/api/routes/chat.py
@@ -64,7 +64,7 @@ async def chat(
         ChatResponse with message, iterations, tools_used
     """
     try:
-        # Get or create session
+        # Get or create session; a provided-but-unknown session_id is a 404
         if request.session_id:
             session = await interaction_service.get_session(request.session_id)
             if not session:
@@ -72,11 +72,8 @@ async def chat(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail={"error": "not_found", "detail": "Session not found"},
                 )
-            session_id = request.session_id
-        else:
-            # Create new session
-            session = await interaction_service._get_or_create_session(None)
-            session_id = session.id
+        session = await interaction_service.get_or_create_session(request.session_id)
+        session_id = session.id
 
         # Run chat
         max_iterations = request.max_iterations or 20
@@ -132,7 +129,8 @@ async def chat_stream(
     - done: Response complete
     - error: Error occurred
     """
-    # Get or create session (before the stream, same policy as non-streaming)
+    # Get or create session (before the stream, same policy as non-streaming);
+    # a provided-but-unknown session_id is a 404
     if request.session_id:
         session = await interaction_service.get_session(request.session_id)
         if not session:
@@ -140,10 +138,8 @@ async def chat_stream(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail={"error": "not_found", "detail": "Session not found"},
             )
-        session_id = request.session_id
-    else:
-        session = await interaction_service._get_or_create_session(None)
-        session_id = session.id
+    session = await interaction_service.get_or_create_session(request.session_id)
+    session_id = session.id
 
     max_iterations = request.max_iterations or 20
 

--- a/src/cortex/interaction/service.py
+++ b/src/cortex/interaction/service.py
@@ -146,6 +146,6 @@ class InteractionService:
         """Get a session by ID."""
         return await self._session_repository.get(session_id)
 
-    async def _get_or_create_session(self, session_id: UUID | None) -> Session:
+    async def get_or_create_session(self, session_id: UUID | None) -> Session:
         """Get existing session or create a new ACTIVE one."""
         return await policy.get_or_create_session(self._session_repository, session_id)

--- a/tests/unit/api/test_chat_stream.py
+++ b/tests/unit/api/test_chat_stream.py
@@ -25,7 +25,7 @@ from cortex.agentic.events import (
 from cortex.api.auth import get_api_key
 from cortex.api.dependencies import get_execution_module, get_interaction_service
 from cortex.main import create_app
-from cortex.sessions.models import Session
+from cortex.sessions.models import Session, SessionState
 
 AUTH_HEADERS = {"Authorization": "Bearer dummy-key"}
 
@@ -87,7 +87,11 @@ class FakeInteractionService:
             return self._existing_session
         return None
 
-    async def _get_or_create_session(self, session_id: UUID | None) -> Session:
+    async def get_or_create_session(self, session_id: UUID | None) -> Session:
+        if session_id is not None:
+            existing = await self.get_session(session_id)
+            if existing is not None and existing.state != SessionState.ENDED:
+                return existing
         session = Session()
         self.created_sessions.append(session)
         return session
@@ -340,6 +344,44 @@ class TestChatStreamSSE:
         assert fake_exec.calls[0][2] == 20  # max_iterations default
         assert parse_sse(response.text) == [
             ("thinking", {"message": "Fresh session."}),
+            ("done", {"final_message": "Done.", "tool_calls": [], "iterations": 1}),
+        ]
+
+    def test_provided_ended_session_creates_fresh_session_and_streams(self):
+        """A provided-but-ENDED session_id is not handed back: the policy
+        treats ENDED as absent, so get_or_create_session creates a fresh
+        session and the route runs the stream against it — never the ENDED
+        id, and never a 404 (the session does exist)."""
+        ended_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            TextDeltaEvent(session_id=ended_id, delta="Fresh session."),
+            ResponseDoneEvent(
+                session_id=ended_id,
+                message="Done.",
+                tools_used=[],
+                iterations=1,
+            ),
+        ])
+        fake_interaction = FakeInteractionService(
+            existing_session=Session(id=ended_id, state=SessionState.ENDED)
+        )
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(ended_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        assert response.status_code == 200  # no 404: the ENDED session exists
+        assert len(fake_interaction.created_sessions) == 1
+        created = fake_interaction.created_sessions[0]
+        assert created.id != ended_id
+        # the stream runs against the fresh session, not the ENDED id
+        assert fake_exec.calls[0][0] == created.id
+        assert fake_exec.calls[0][2] == 20  # max_iterations default
+        assert parse_sse(response.text) == [
+            ("text", {"delta": "Fresh session."}),
             ("done", {"final_message": "Done.", "tool_calls": [], "iterations": 1}),
         ]
 

--- a/tests/unit/interaction/test_service.py
+++ b/tests/unit/interaction/test_service.py
@@ -123,6 +123,11 @@ class TestInteractionService:
         await service.get_session(session_id)
         mock_session_repository.get.assert_called_with(session_id)
 
+    def test_session_get_or_create_is_public(self, service):
+        """get_or_create_session is exposed as a public callable."""
+        assert callable(service.get_or_create_session)
+        assert not service.get_or_create_session.__name__.startswith("_")
+
     @pytest.mark.asyncio
     async def test_get_or_create_returns_existing_session_when_found(
         self, service, mock_session_repository
@@ -131,7 +136,7 @@ class TestInteractionService:
         existing = MagicMock(id=session_id)
         mock_session_repository.get = AsyncMock(return_value=existing)
 
-        result = await service._get_or_create_session(session_id)
+        result = await service.get_or_create_session(session_id)
 
         assert result is existing
         mock_session_repository.create.assert_not_called()
@@ -145,7 +150,7 @@ class TestInteractionService:
         mock_session_repository.create = AsyncMock(return_value=new_session)
         mock_session_repository.update_state = AsyncMock(return_value=active_session)
 
-        result = await service._get_or_create_session(None)
+        result = await service.get_or_create_session(None)
 
         assert result is active_session
         mock_session_repository.create.assert_called_once()


### PR DESCRIPTION
Closes #36

## Changes
- Rename `_get_or_create_session` → public `get_or_create_session` on `InteractionService` (same signature, still backed by `sessions/policy.py`)
- Both chat routes (POST /chat, POST /chat/stream) now call `get_or_create_session(request.session_id)` — the manual get_session/_get_or_create_session dispatch is gone
- Route-seam test pinning ENDED-session behavior; fake mirrors the policy's ENDED filter; is-public test checks the underscore

## Deviations from the issue body (user-approved)
- **404 guard kept**: the issue's `After` snippet dropped the 404 for a provided-but-unknown session_id; user decided to keep it. Routes still 404 on an unresolvable provided id, then delegate to `get_or_create_session`.
- **ENDED behavior change (policy-aligned)**: a provided ENDED session_id previously flowed through unchanged; now policy treats ENDED as terminal (SP1) and creates a fresh ACTIVE session — pinned by `test_provided_ended_session_creates_fresh_session_and_streams`.

## Verification
- `uv run pytest tests/unit -q`: 519 passed
- `uv run ruff check src tests`: clean
- `uv run mypy src/cortex`: clean
- Two-axis review (Standards + Spec): zero findings

Note: `docs/IMPLEMENTATION_PLAN.md:966` still references `_get_or_create_session` inside an aspirational `SessionService` design sketch (never-implemented interface) — left untouched as out of scope.