### PR TITLE
refactor: delete dead PersonalityService (#26)

### DIFF
--- a/docs/ZOOM_OUT_MAP.md
+++ b/docs/ZOOM_OUT_MAP.md
@@ -95,7 +95,6 @@
 |--------|----------|---------------|-------|--------|
 | **ExecutionModule** | `src/cortex/execution/module.py` | `goal.created`, `recommendation.executed` | `goal.*` via EventEmitter | ✅ **UPDATED** |
 | **InteractionService** | `src/cortex/interaction/service.py` | (called by API) | Uses `SessionRepository` + `policy` module | ✅ **UPDATED** |
-| **PersonalityService** | `src/cortex/interaction/service.py` | (reads MemoryService) | Personality profile from MemoryContext | ✅ |
 | **API Gateway** | `src/cortex/api/` | FastAPI routes | HTTP → InteractionService | ✅ |
 
 ### Layer 6 — Integration
@@ -176,7 +175,7 @@ App Bootstrap (initialize_app)
         12. LoopExecutor (takes ToolExecutor, EventBus)
         13. AgentLoop (takes ContextBuilder, Reasoner, LoopExecutor, EventBus)
         14. ExecutionModule (takes AgentLoop, EventBus — no GoalStore)
-        15. PersonalityService + InteractionService
+        15. InteractionService
         16. API Gateway
         17. Subscribe services → EventBus
         18. MinionService (optional)
@@ -333,7 +332,7 @@ src/cortex/
 │
 ├── interaction/             # Wave 5 — Interaction Module
 │   ├── __init__.py
-│   └── service.py           # InteractionService, PersonalityService
+│   └── service.py           # InteractionService
 │
 ├── learning/                # Wave 7.1 — Learning Module (planned)
 │   ├── __init__.py          # (planned)

--- a/src/cortex/api/dependencies.py
+++ b/src/cortex/api/dependencies.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     import asyncpg
 
     from cortex.execution.module import ExecutionModule
-    from cortex.interaction.service import InteractionService, PersonalityService
+    from cortex.interaction.service import InteractionService
     from cortex.llm.base import LLMClient
     from cortex.services.memory_service import MemoryService
     from cortex.services.minion_service import MinionService
@@ -55,12 +55,6 @@ async def get_interaction_service() -> InteractionService:
     return cast("InteractionService", state["interaction_service"])
 
 
-async def get_personality_service() -> PersonalityService:
-    """Get the personality service."""
-    state = get_app_state()
-    return cast("PersonalityService", state["personality_service"])
-
-
 async def get_minion_service() -> MinionService | None:
     """Get the minion service."""
     state = get_app_state()
@@ -89,7 +83,6 @@ async def get_llm_client() -> LLMClient | None:
 SessionRepositoryDep = Depends(get_session_repository)
 ExecutionModuleDep = Depends(get_execution_module)
 InteractionServiceDep = Depends(get_interaction_service)
-PersonalityServiceDep = Depends(get_personality_service)
 MinionServiceDep = Depends(get_minion_service)
 MemoryServiceDep = Depends(get_memory_service)
 DbPoolDep = Depends(get_db_pool)

--- a/src/cortex/api/main.py
+++ b/src/cortex/api/main.py
@@ -125,7 +125,6 @@ def bootstrap_app(state: dict[str, Any]) -> FastAPI:
             - session_service
             - execution_module
             - interaction_service
-            - personality_service
             - minion_service
             - memory_service
             - llm_client

--- a/src/cortex/interaction/__init__.py
+++ b/src/cortex/interaction/__init__.py
@@ -1,5 +1,5 @@
 """Cortex Interaction Module."""
 
-from cortex.interaction.service import InteractionService, PersonalityService
+from cortex.interaction.service import InteractionService
 
-__all__ = ["InteractionService", "PersonalityService"]
+__all__ = ["InteractionService"]

--- a/src/cortex/interaction/service.py
+++ b/src/cortex/interaction/service.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from uuid import UUID
 
-from cortex.agentic.models import PersonalityContext
 from cortex.sessions import policy
 
 if TYPE_CHECKING:
@@ -14,121 +12,11 @@ if TYPE_CHECKING:
     from cortex.sessions.interfaces import SessionRepository
     from cortex.sessions.models import Session
 
-logger = logging.getLogger(__name__)
-
-
-class PersonalityService:
-    """
-    Service for managing personality traits and response formatting.
-
-    Derives personality from memory and applies it to responses.
-    """
-
-    def __init__(self, memory_service: Any | None = None):
-        self._memory = memory_service
-
-    async def get_personality(
-        self,
-        session_id: UUID | None = None,
-    ) -> PersonalityContext:
-        """
-        Get personality context for a session.
-
-        Args:
-            session_id: Current session
-
-        Returns:
-            PersonalityContext with formatting traits
-        """
-        if self._memory and hasattr(self._memory, 'get_personality_context'):
-            try:
-                personality = await self._memory.get_personality_context(session_id)
-                if isinstance(personality, PersonalityContext):
-                    return personality
-            except Exception as e:
-                logger.warning(f"Failed to get personality: {e}")
-
-        # Return default personality
-        return PersonalityContext()
-
-    def format_response(
-        self,
-        text: str,
-        *,
-        formality: float | None = None,
-        verbosity: float | None = None,
-    ) -> str:
-        """
-        Format response text based on personality.
-
-        Args:
-            text: Raw response text
-            formality: 0-1, higher = more formal
-            verbosity: 0-1, higher = longer
-
-        Returns:
-            Formatted text
-        """
-        # Simple formatting rules
-        if formality is not None:
-            if formality > 0.8:
-                # Very formal: expand contractions
-                text = text.replace("n't", " not")
-                text = text.replace("'re", " are")
-                text = text.replace("'ve", " have")
-            elif formality < 0.3:
-                # Very casual: can use more relaxed language
-                pass  # Keep as-is
-
-        return text
-
-    async def update_preferences(
-        self,
-        session_id: UUID,
-        *,
-        formality: float | None = None,
-        verbosity: float | None = None,
-        technical_level: float | None = None,
-    ) -> None:
-        """
-        Update personality preferences based on user feedback.
-
-        Stores in memory for future sessions.
-        """
-        if not self._memory:
-            return
-
-        try:
-            from cortex.memory.models import Fact, FactMutability, FactType
-
-            updates = {}
-            if formality is not None:
-                updates["formality"] = formality
-            if verbosity is not None:
-                updates["verbosity"] = verbosity
-            if technical_level is not None:
-                updates["technical_level"] = technical_level
-
-            for key, value in updates.items():
-                fact = Fact(
-                    type=FactType.USER_PREFERENCE,
-                    mutability=FactMutability.MUTABLE,
-                    symbolic_repr=f"preference.{key}",
-                    natural_lang_repr=f"User prefers {key}={value}",
-                    payload={key: value, "session_id": str(session_id)},
-                    confidence=0.8,
-                )
-                await self._memory.store_fact(fact)
-
-        except Exception as e:
-            logger.warning(f"Failed to update preferences: {e}")
-
 
 class InteractionService:
     """
     Thin facade used by the chat route to look up or create a session.
 
-    Holds the personality service and a reference to the session repository.
     The agentic loop is invoked directly via ExecutionModule from the route.
     """
 
@@ -136,11 +24,9 @@ class InteractionService:
         self,
         execution_module: ExecutionModule,
         session_repository: SessionRepository,
-        personality_service: PersonalityService | None = None,
     ):
         self._execution = execution_module
         self._session_repository = session_repository
-        self._personality = personality_service or PersonalityService()
 
     async def get_session(self, session_id: UUID) -> Session | None:
         """Get a session by ID."""

--- a/src/cortex/main.py
+++ b/src/cortex/main.py
@@ -40,7 +40,6 @@ class CortexApp:
     session_repository: Any = field(default=None)
     execution_module: Any = field(default=None)
     interaction_service: Any = field(default=None)
-    personality_service: Any = field(default=None)
     memory_service: Any = field(default=None)
     minion_service: Any = field(default=None)
     llm_client: Any = field(default=None)
@@ -235,16 +234,11 @@ async def initialize_app() -> CortexApp:
     # direct call, not routed through the event bus.
     await cortex.execution_module.resume_in_flight()
 
-    # 5f. Create personality service
-    from cortex.interaction.service import PersonalityService
-    cortex.personality_service = PersonalityService(memory_service=cortex.memory_service)
-
-    # 5g. Create interaction service
+    # 5f. Create interaction service
     from cortex.interaction.service import InteractionService
     cortex.interaction_service = InteractionService(
         execution_module=cortex.execution_module,
         session_repository=cortex.session_repository,
-        personality_service=cortex.personality_service,
     )
 
     # 7. Create state dict for API
@@ -254,7 +248,6 @@ async def initialize_app() -> CortexApp:
         "session_repository": cortex.session_repository,
         "execution_module": cortex.execution_module,
         "interaction_service": cortex.interaction_service,
-        "personality_service": cortex.personality_service,
         "memory_service": cortex.memory_service,
         "minion_service": None,  # Will be initialized separately
         "llm_client": cortex.llm_client,

--- a/tests/unit/interaction/test_service.py
+++ b/tests/unit/interaction/test_service.py
@@ -5,88 +5,7 @@ from uuid import uuid4
 
 import pytest
 
-from cortex.interaction.service import InteractionService, PersonalityService
-
-
-class TestPersonalityService:
-    """Tests for PersonalityService."""
-
-    @pytest.fixture
-    def mock_memory_service(self):
-        """Create a mock memory service."""
-        service = MagicMock()
-        service.get_personality_context = AsyncMock()
-        service.get_relevant = AsyncMock(return_value=[])
-        return service
-
-    @pytest.fixture
-    def service(self, mock_memory_service):
-        """Create a PersonalityService."""
-        return PersonalityService(memory_service=mock_memory_service)
-
-    @pytest.mark.asyncio
-    async def test_get_personality(self, service, mock_memory_service):
-        """Get personality should delegate to memory service."""
-        from cortex.agentic.models import PersonalityContext
-
-        mock_memory_service.get_personality_context = AsyncMock(
-            return_value=PersonalityContext(formality=0.7)
-        )
-
-        personality = await service.get_personality(session_id=uuid4())
-
-        assert personality is not None
-        assert personality.formality == 0.7
-
-    @pytest.mark.asyncio
-    async def test_get_personality_default(self, service, mock_memory_service):
-        """Get personality returns default when not available."""
-        mock_memory_service.get_personality_context = AsyncMock(return_value=None)
-
-        personality = await service.get_personality(session_id=uuid4())
-
-        # Should return default
-        assert personality is not None or mock_memory_service.get_personality_context.called
-
-    @pytest.mark.asyncio
-    async def test_format_response(self, service):
-        """Format response should apply personality to text."""
-        text = "Hello, how can I help you?"
-
-        formatted = service.format_response(text, formality=0.5)
-
-        assert formatted is not None
-        assert len(formatted) > 0
-
-    @pytest.mark.asyncio
-    async def test_format_response_formal(self, service):
-        """Format response should handle formal personality."""
-        text = "Hi there buddy!"
-
-        formatted = service.format_response(text, formality=0.9)
-
-        assert formatted is not None
-
-    @pytest.mark.asyncio
-    async def test_format_response_casual(self, service):
-        """Format response should handle casual personality."""
-        text = "Good morning. I hope you are well."
-
-        formatted = service.format_response(text, formality=0.2)
-
-        assert formatted is not None
-
-    @pytest.mark.asyncio
-    async def test_update_preferences(self, service, mock_memory_service):
-        """Update preferences should store in memory."""
-        mock_memory_service.store_fact = AsyncMock()
-
-        await service.update_preferences(
-            session_id=uuid4(),
-            formality=0.8,
-        )
-
-        assert mock_memory_service.store_fact.called
+from cortex.interaction.service import InteractionService
 
 
 class TestInteractionService:
@@ -106,15 +25,10 @@ class TestInteractionService:
         return repo
 
     @pytest.fixture
-    def mock_personality_service(self):
-        return MagicMock()
-
-    @pytest.fixture
-    def service(self, mock_execution_module, mock_session_repository, mock_personality_service):
+    def service(self, mock_execution_module, mock_session_repository):
         return InteractionService(
             execution_module=mock_execution_module,
             session_repository=mock_session_repository,
-            personality_service=mock_personality_service,
         )
 
     @pytest.mark.asyncio
@@ -154,23 +68,3 @@ class TestInteractionService:
 
         assert result is active_session
         mock_session_repository.create.assert_called_once()
-
-
-class TestPersonalityFormatting:
-    """Personality should affect response formatting end-to-end."""
-
-    @pytest.mark.asyncio
-    async def test_personality_affects_formatting(self):
-        from cortex.agentic.models import PersonalityContext
-
-        mock_memory = MagicMock()
-        mock_memory.get_personality_context = AsyncMock(
-            return_value=PersonalityContext(formality=0.9)
-        )
-
-        service = PersonalityService(memory_service=mock_memory)
-
-        personality = await service.get_personality(uuid4())
-        formatted = service.format_response("hi there!", formality=personality.formality)
-
-        assert formatted is not None

--- a/tests/unit/test_app/test_bootstrap.py
+++ b/tests/unit/test_app/test_bootstrap.py
@@ -94,7 +94,6 @@ class TestCortexAppBootstrap:
         mock_session_repository = MagicMock()
         mock_execution_module = MagicMock()
         mock_interaction_service = MagicMock()
-        mock_personality_service = MagicMock()
         mock_memory_service = MagicMock()
         mock_minion_service = MagicMock()
         mock_llm_client = MagicMock()
@@ -105,7 +104,6 @@ class TestCortexAppBootstrap:
             "session_repository": mock_session_repository,
             "execution_module": mock_execution_module,
             "interaction_service": mock_interaction_service,
-            "personality_service": mock_personality_service,
             "memory_service": mock_memory_service,
             "minion_service": mock_minion_service,
             "llm_client": mock_llm_client,
@@ -159,7 +157,6 @@ class TestStartupShutdown:
         assert hasattr(app, 'session_repository')
         assert hasattr(app, 'execution_module')
         assert hasattr(app, 'interaction_service')
-        assert hasattr(app, 'personality_service')
         assert hasattr(app, 'memory_service')
         assert hasattr(app, 'minion_service')
         assert hasattr(app, 'llm_client')


### PR DESCRIPTION
Closes #26

Carry the #26 work to master: PR #59 merged onto the feat-36 branch (its base); master already has the #36 side via PR #58. This PR's diff is exactly the #26 commits (40b23f1, c3f5819) — same content already reviewed (Standards + Spec, zero findings) and CI-validated on PR #59.

## Changes
- Delete `PersonalityService` (dead wrapper; real pipeline `MemoryService.get_personality_context` → `MemoryContext.personality` → `Reasoner._build_prompt` untouched)
- Remove constructor param, exports, `get_personality_service`/`PersonalityServiceDep`, all `cortex.personality_service` wiring
- `docs/ZOOM_OUT_MAP.md` status map updated

## Verification
- `uv run pytest tests/unit -q`: 512 passed; ruff clean; mypy clean