### PR TITLE
feat: LearningModule event-bus integration (#11)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2115,6 +2115,8 @@ cortex/
 │       │   ├── __init__.py
 │       │   ├── reservoir.py          # ESN core: Reservoir, Readout, EchoStateNetwork
 │       │   ├── readouts.py           # Salience/Anomaly/Pattern readouts
+│       │   ├── encoding.py           # MinionEventEncoder: event → reservoir input
+│       │   ├── module.py             # LearningModule: event-bus consumer
 │       │   ├── patterns.py
 │       │   ├── preferences.py
 │       │   ├── recommender.py

--- a/src/cortex/learning/__init__.py
+++ b/src/cortex/learning/__init__.py
@@ -1,4 +1,6 @@
 """Learning module: echo state network core types and specialized readouts."""
+from .encoding import MinionEventEncoder
+from .module import LearningModule
 from .readouts import AnomalyReadout, PatternReadout, SalienceReadout
 from .reservoir import (
     EchoStateNetwork,
@@ -9,6 +11,8 @@ from .reservoir import (
 __all__ = [
     "AnomalyReadout",
     "EchoStateNetwork",
+    "LearningModule",
+    "MinionEventEncoder",
     "PatternReadout",
     "Readout",
     "Reservoir",

--- a/src/cortex/learning/encoding.py
+++ b/src/cortex/learning/encoding.py
@@ -1,0 +1,102 @@
+"""Encoding of minion bus events into fixed-size ESN input vectors.
+
+Each vector is ``len(MINION_EVENT_TYPES) + len(NUMERIC_FIELDS)`` float64 values
+in [-1, 1]: a one-hot block marking the event type followed by a numeric block
+with normalized payload fields. Unknown event types encode as an all-zero
+one-hot block, which is still a valid input vector.
+"""
+
+import math
+from collections.abc import Sequence
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from cortex.events.base import BaseEvent
+
+#: Minion event types published on the bus by the minion event processor.
+MINION_EVENT_TYPES: tuple[str, ...] = (
+    "minion.location",
+    "minion.activity",
+    "minion.battery",
+    "minion.app_usage",
+    "minion.calendar",
+    "minion.payment",
+    "minion.screen_activity",
+    "minion.application_focus",
+    "minion.keyboard_activity",
+    "minion.network_status",
+)
+
+#: Numeric payload fields with their normalization ranges, in fixed order.
+#: This order defines the layout of the numeric block of every encoded vector:
+#: latitude, longitude, accuracy, speed, heading, level, confidence,
+#: duration_seconds.
+NUMERIC_FIELDS: tuple[tuple[str, float, float], ...] = (
+    ("latitude", -90.0, 90.0),
+    ("longitude", -180.0, 180.0),
+    ("accuracy", 0.0, 500.0),
+    ("speed", 0.0, 100.0),
+    ("heading", 0.0, 360.0),
+    ("level", 0.0, 1.0),
+    ("confidence", 0.0, 1.0),
+    ("duration_seconds", 0.0, 86400.0),
+)
+
+
+def _normalize(value: float, lo: float, hi: float) -> float:
+    """Linearly map ``value`` from [lo, hi] to [-1, 1], clamped.
+
+    A degenerate zero-width range maps to 0.0.
+    """
+    if hi == lo:
+        return 0.0
+    scaled = 2.0 * (value - lo) / (hi - lo) - 1.0
+    return max(-1.0, min(1.0, scaled))
+
+
+class MinionEventEncoder:
+    """Convert minion events into fixed-size reservoir input vectors."""
+
+    def __init__(self, event_types: Sequence[str] = MINION_EVENT_TYPES) -> None:
+        self._event_types = tuple(event_types)
+
+    @property
+    def n_features(self) -> int:
+        """Total vector length: the one-hot block plus the numeric block."""
+        return len(self._event_types) + len(NUMERIC_FIELDS)
+
+    def encode(self, event: BaseEvent) -> NDArray[np.float64]:
+        """Encode an event as a float64 vector of ``n_features`` values in [-1, 1].
+
+        The one-hot bit is set for the matching event type (all-zero for unknown
+        types). Numeric fields are read from the nested ``payload["payload"]``
+        dict when present, falling back to ``event.payload`` itself; missing
+        fields normalize to 0.0.
+        """
+        vector = np.zeros(self.n_features, dtype=np.float64)
+        try:
+            hot_index = self._event_types.index(event.type)
+        except ValueError:
+            pass
+        else:
+            vector[hot_index] = 1.0
+
+        nested = event.payload.get("payload")
+        data: dict[str, Any] = nested if isinstance(nested, dict) else event.payload
+
+        offset = len(self._event_types)
+        for i, (field, lo, hi) in enumerate(NUMERIC_FIELDS):
+            value = data.get(field)
+            if value is None:
+                continue  # missing field stays 0.0
+            try:
+                value = float(value)
+            except (TypeError, ValueError):
+                continue  # non-numeric field stays 0.0
+            if not math.isfinite(value):
+                continue  # non-finite (NaN, +inf, -inf) field stays 0.0
+            vector[offset + i] = _normalize(value, lo, hi)
+
+        return vector

--- a/src/cortex/learning/module.py
+++ b/src/cortex/learning/module.py
@@ -1,0 +1,99 @@
+"""LearningModule: subscribes to minion events and drives the echo state network.
+
+Pure event -> state -> readout wiring: no training, no storage. Readouts are
+expected to be registered on the ESN before the getters are called; they are
+resolved lazily by name so late registration stays supported.
+"""
+
+from typing import TypeVar
+
+from cortex.events.base import BaseEvent
+from cortex.events.bus import EventBus
+from cortex.learning.encoding import MINION_EVENT_TYPES, MinionEventEncoder
+from cortex.learning.readouts import AnomalyReadout, PatternReadout, SalienceReadout
+from cortex.learning.reservoir import EchoStateNetwork, Readout
+
+_ReadoutT = TypeVar("_ReadoutT", bound=Readout)
+
+#: Names under which the three readouts are expected on the ESN.
+SALIENCE_READOUT = "salience"
+ANOMALY_READOUT = "anomaly"
+PATTERN_READOUT = "pattern"
+
+
+class LearningModule:
+    """Advance an ESN one step per minion event and expose readout scores."""
+
+    def __init__(
+        self,
+        event_bus: EventBus,
+        esn: EchoStateNetwork,
+        *,
+        encoder: MinionEventEncoder | None = None,
+    ) -> None:
+        self._event_bus = event_bus
+        self._esn = esn
+        self._encoder = encoder if encoder is not None else MinionEventEncoder()
+        if self._encoder.n_features != self._esn.reservoir.n_input:
+            raise ValueError(
+                f"encoder.n_features ({self._encoder.n_features}) does not match "
+                f"esn.reservoir.n_input ({self._esn.reservoir.n_input})"
+            )
+        self._subscribed = False
+
+    async def subscribe(self) -> None:
+        """Subscribe to every minion event type (one subscription each).
+
+        Idempotent: repeated calls are no-ops, so a published event always
+        advances the reservoir exactly once per bus dispatch.
+        """
+        if self._subscribed:
+            return
+        for event_type in MINION_EVENT_TYPES:
+            await self._event_bus.subscribe(event_type, self.on_minion_event)
+        self._subscribed = True
+
+    async def on_minion_event(self, event: BaseEvent) -> None:
+        """Advance the ESN by one step with the encoded event vector."""
+        self._esn.step(self._encoder.encode(event))
+
+    def _resolve_readout(self, name: str, readout_type: type[_ReadoutT]) -> _ReadoutT:
+        """Return the readout registered under ``name``, typed as ``readout_type``."""
+        try:
+            readout = self._esn.get_readout(name)
+        except KeyError:
+            raise RuntimeError(
+                f"Readout '{name}' is not registered on the ESN"
+            ) from None
+        if not isinstance(readout, readout_type):
+            raise RuntimeError(
+                f"Readout '{name}' is registered but is not a {readout_type.__name__}"
+            )
+        return readout
+
+    def get_salience(self) -> float:
+        """Salience score of the current reservoir state, clamped to [0, 1].
+
+        Ridge regression on 0/1 targets can overshoot the unit range by a tiny
+        margin, so the module guarantees the domain invariant that salience is
+        a unit-range score. Raises RuntimeError if the ``salience`` readout is
+        missing or untrained.
+        """
+        readout = self._resolve_readout(SALIENCE_READOUT, SalienceReadout)
+        return min(1.0, max(0.0, readout.score(self._esn.reservoir.state)))
+
+    def get_anomaly_score(self) -> float:
+        """Reconstruction error of the current reservoir state.
+
+        Raises RuntimeError if the ``anomaly`` readout is missing or untrained.
+        """
+        readout = self._resolve_readout(ANOMALY_READOUT, AnomalyReadout)
+        return readout.reconstruction_error(self._esn.reservoir.state)
+
+    def get_pattern_probabilities(self) -> dict[str, float]:
+        """Pattern-class probabilities for the current reservoir state.
+
+        Raises RuntimeError if the ``pattern`` readout is missing or untrained.
+        """
+        readout = self._resolve_readout(PATTERN_READOUT, PatternReadout)
+        return readout.get_pattern_probabilities(self._esn.reservoir.state)

--- a/src/cortex/learning/reservoir.py
+++ b/src/cortex/learning/reservoir.py
@@ -115,6 +115,10 @@ class EchoStateNetwork:
             raise ValueError(f"Readout already registered: {name}")
         self._readouts[name] = readout
 
+    def get_readout(self, name: str) -> Readout:
+        """Return the readout registered under ``name``; KeyError on unknown names."""
+        return self._readouts[name]
+
     def read(self, name: str) -> NDArray[np.float64]:
         """Predict from the current reservoir state; KeyError on unknown names."""
         return self._readouts[name].predict(self.reservoir.state)

--- a/tests/learning/test_module.py
+++ b/tests/learning/test_module.py
@@ -1,0 +1,502 @@
+"""Tests for the learning module's event-bus integration.
+
+Covers MinionEventEncoder (one-hot event-type block plus a normalized numeric
+block) and LearningModule (subscriptions, event-driven ESN stepping, and
+readout-backed getters) against a live in-memory EventBus.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from cortex.events.base import BaseEvent
+from cortex.events.bus import EventBus
+from cortex.learning import LearningModule, MinionEventEncoder
+from cortex.learning.encoding import MINION_EVENT_TYPES
+from cortex.learning.readouts import AnomalyReadout, PatternReadout, SalienceReadout
+from cortex.learning.reservoir import EchoStateNetwork, Reservoir
+
+N_FEATURES = MinionEventEncoder().n_features
+
+
+def _make_esn(n_reservoir: int = 60, seed: int = 7) -> EchoStateNetwork:
+    """An ESN sized for default encoder vectors, with a deterministic seed."""
+    return EchoStateNetwork(
+        Reservoir(
+            n_input=N_FEATURES,
+            n_reservoir=n_reservoir,
+            alpha=0.5,
+            spectral_radius=0.9,
+            seed=seed,
+        )
+    )
+
+
+def _drive(seqs, *, n_input, n_reservoir=60, seed=7):
+    """Return the reservoir state after each input sequence (mirrors readouts tests)."""
+    reservoir = Reservoir(
+        n_input=n_input,
+        n_reservoir=n_reservoir,
+        alpha=0.5,
+        spectral_radius=0.9,
+        seed=seed,
+    )
+    states = []
+    for seq in seqs:
+        for u in seq:
+            reservoir.update(u)
+        states.append(reservoir.state.copy())
+    return np.stack(states)
+
+
+class TestMinionEventEncoder:
+    """Type one-hot block + normalized numeric block produce valid inputs."""
+
+    def test_default_feature_count_matches_contract(self):
+        encoder = MinionEventEncoder()
+        assert encoder.n_features == len(MINION_EVENT_TYPES) + 8
+
+    def test_encode_returns_float64_vector_of_n_features(self):
+        encoder = MinionEventEncoder()
+        for event_type in MINION_EVENT_TYPES:
+            event = BaseEvent.create(event_type, source_module="test")
+            vector = encoder.encode(event)
+            assert vector.shape == (encoder.n_features,)
+            assert vector.dtype == np.float64
+
+    def test_one_hot_bit_marks_exactly_the_matching_type(self):
+        encoder = MinionEventEncoder()
+        for i, event_type in enumerate(MINION_EVENT_TYPES):
+            vector = encoder.encode(BaseEvent.create(event_type, source_module="test"))
+            assert vector[i] == 1.0
+            assert np.count_nonzero(vector[: len(MINION_EVENT_TYPES)]) == 1
+
+    def test_unknown_type_is_zero_hot(self):
+        encoder = MinionEventEncoder()
+        vector = encoder.encode(BaseEvent.create("minion.unknown", source_module="test"))
+        assert np.count_nonzero(vector[: len(MINION_EVENT_TYPES)]) == 0
+        assert vector.shape == (encoder.n_features,)
+
+    def test_unknown_type_never_raises(self):
+        encoder = MinionEventEncoder()
+        for payload in ({}, {"payload": {"level": 0.5}}, {"latitude": 10.0}):
+            vector = encoder.encode(
+                BaseEvent.create("minion.unknown", payload=payload, source_module="test")
+            )
+            assert vector.shape == (encoder.n_features,)
+
+    def test_mid_range_numeric_fields_normalize_to_zero(self):
+        encoder = MinionEventEncoder()
+        event = BaseEvent.create(
+            "minion.location",
+            payload={
+                "minion_id": "m-1",
+                "event_type": "location",
+                "payload": {
+                    "latitude": 0.0,
+                    "longitude": 0.0,
+                    "accuracy": 250.0,
+                    "speed": 50.0,
+                    "heading": 180.0,
+                },
+                "timestamp": "2026-01-01T00:00:00Z",
+            },
+            source_module="minion_event_processor",
+        )
+        vector = encoder.encode(event)
+        offset = len(MINION_EVENT_TYPES)
+        np.testing.assert_allclose(vector[offset : offset + 5], 0.0, atol=1e-12)
+
+    def test_range_extremes_map_to_unit_bounds(self):
+        encoder = MinionEventEncoder()
+        event = BaseEvent.create(
+            "minion.location",
+            payload={
+                "payload": {
+                    "latitude": -90.0,
+                    "longitude": 180.0,
+                    "accuracy": 0.0,
+                    "speed": 100.0,
+                    "heading": 360.0,
+                }
+            },
+            source_module="test",
+        )
+        vector = encoder.encode(event)
+        offset = len(MINION_EVENT_TYPES)
+        assert vector[offset] == -1.0  # latitude at min
+        assert vector[offset + 1] == 1.0  # longitude at max
+        assert vector[offset + 2] == -1.0  # accuracy at min
+        assert vector[offset + 3] == 1.0  # speed at max
+        assert vector[offset + 4] == 1.0  # heading at max
+
+    def test_out_of_range_values_are_clamped(self):
+        encoder = MinionEventEncoder()
+        vector = encoder.encode(
+            BaseEvent.create(
+                "minion.battery",
+                payload={"payload": {"level": 2.0, "confidence": -1.0}},
+                source_module="test",
+            )
+        )
+        offset = len(MINION_EVENT_TYPES)
+        assert vector[offset + 5] == 1.0  # level 2.0 clamped to +1
+        assert vector[offset + 6] == -1.0  # confidence -1.0 clamped to -1
+
+    def test_missing_numeric_fields_default_to_zero(self):
+        encoder = MinionEventEncoder()
+        vector = encoder.encode(
+            BaseEvent.create("minion.battery", payload={"payload": {}}, source_module="test")
+        )
+        offset = len(MINION_EVENT_TYPES)
+        assert vector[offset + 5] == 0.0  # level missing -> 0.0
+
+    def test_flat_payload_fallback_without_nested_payload_key(self):
+        encoder = MinionEventEncoder()
+        vector = encoder.encode(
+            BaseEvent.create("minion.battery", payload={"level": 0.75}, source_module="test")
+        )
+        offset = len(MINION_EVENT_TYPES)
+        assert vector[offset + 5] == pytest.approx(0.5)
+
+    def test_non_numeric_numeric_field_defaults_to_zero(self):
+        encoder = MinionEventEncoder()
+        vector = encoder.encode(
+            BaseEvent.create(
+                "minion.location",
+                payload={"payload": {"latitude": "abc", "longitude": 10.0}},
+                source_module="test",
+            )
+        )
+        offset = len(MINION_EVENT_TYPES)
+        assert vector[offset] == 0.0  # latitude "abc" -> 0.0
+        assert vector[offset + 1] == pytest.approx(
+            2.0 * (10.0 - (-180.0)) / 360.0 - 1.0
+        )  # longitude 10.0 still normalized
+
+    def test_non_finite_numeric_fields_default_to_zero(self):
+        encoder = MinionEventEncoder()
+        vector = encoder.encode(
+            BaseEvent.create(
+                "minion.battery",
+                payload={"payload": {"level": float("nan"), "confidence": float("inf")}},
+                source_module="test",
+            )
+        )
+        offset = len(MINION_EVENT_TYPES)
+        assert vector[offset + 5] == 0.0  # NaN -> 0.0
+        assert vector[offset + 6] == 0.0  # inf -> 0.0
+
+    def test_all_encoded_values_stay_within_unit_range(self):
+        encoder = MinionEventEncoder()
+        event = BaseEvent.create(
+            "minion.location",
+            payload={
+                "payload": {
+                    "latitude": 45.5,
+                    "longitude": -123.4,
+                    "accuracy": 1000.0,
+                    "speed": -10.0,
+                    "heading": 500.0,
+                    "level": 0.75,
+                    "confidence": 0.2,
+                    "duration_seconds": 43200,
+                }
+            },
+            source_module="test",
+        )
+        vector = encoder.encode(event)
+        assert np.all(vector >= -1.0)
+        assert np.all(vector <= 1.0)
+
+    def test_custom_event_types_resize_one_hot_block(self):
+        encoder = MinionEventEncoder(event_types=("minion.location", "minion.battery"))
+        assert encoder.n_features == 2 + 8
+        location = encoder.encode(
+            BaseEvent.create(
+                "minion.location", payload={"payload": {"latitude": 0.0}}, source_module="test"
+            )
+        )
+        assert location[0] == 1.0 and location[1] == 0.0
+        battery = encoder.encode(
+            BaseEvent.create(
+                "minion.battery", payload={"payload": {"level": 0.5}}, source_module="test"
+            )
+        )
+        assert battery[0] == 0.0 and battery[1] == 1.0
+        # unknown relative to the custom list is zero-hot too
+        unknown = encoder.encode(BaseEvent.create("minion.activity", source_module="test"))
+        assert np.count_nonzero(unknown[:2]) == 0
+
+
+class TestLearningModuleSubscribe:
+    """subscribe() registers exactly one handler per minion event type."""
+
+    async def test_one_subscription_per_minion_event_type(self):
+        bus = EventBus()
+        await bus.start()
+        module = LearningModule(bus, _make_esn())
+        try:
+            await module.subscribe()
+            for event_type in MINION_EVENT_TYPES:
+                assert await bus.get_subscription_count(event_type) == 1
+        finally:
+            await bus.stop()
+
+    async def test_subscribe_twice_is_idempotent(self):
+        bus = EventBus()
+        await bus.start()
+        encoder = MinionEventEncoder()
+        reservoir = Reservoir(n_input=N_FEATURES, n_reservoir=50, seed=3)
+        esn = EchoStateNetwork(reservoir)
+        module = LearningModule(bus, esn)
+        try:
+            await module.subscribe()
+            await module.subscribe()
+            for event_type in MINION_EVENT_TYPES:
+                assert await bus.get_subscription_count(event_type) == 1
+            event = BaseEvent.create(
+                "minion.location",
+                payload={"payload": {"latitude": 10.0}},
+                source_module="test",
+            )
+            await bus.publish(event)
+            # A doubled subscription would step the reservoir twice; the state
+            # must equal a single-step reference on the same reservoir config.
+            reference = Reservoir(n_input=N_FEATURES, n_reservoir=50, seed=3)
+            reference.update(encoder.encode(event))
+            np.testing.assert_array_equal(reservoir.state, reference.state)
+        finally:
+            await bus.stop()
+
+    async def test_no_wildcard_subscription_is_created(self):
+        bus = EventBus()
+        await bus.start()
+        module = LearningModule(bus, _make_esn())
+        try:
+            await module.subscribe()
+            assert await bus.get_subscription_count("*") == 0
+        finally:
+            await bus.stop()
+
+
+class TestLearningModuleOnEvent:
+    """Published minion events advance the ESN via the encoder."""
+
+    async def test_published_event_advances_reservoir_state(self):
+        bus = EventBus()
+        await bus.start()
+        reservoir = Reservoir(n_input=N_FEATURES, n_reservoir=50, seed=2)
+        esn = EchoStateNetwork(reservoir)
+        module = LearningModule(bus, esn)
+        try:
+            await module.subscribe()
+            await bus.publish(
+                BaseEvent.create(
+                    "minion.location",
+                    payload={"payload": {"latitude": 10.0, "longitude": 20.0}},
+                    source_module="minion_event_processor",
+                )
+            )
+            first_state = reservoir.state.copy()
+            assert not np.all(first_state == 0.0)
+            await bus.publish(
+                BaseEvent.create(
+                    "minion.battery",
+                    payload={"payload": {"level": 0.8}},
+                    source_module="minion_event_processor",
+                )
+            )
+            assert not np.array_equal(reservoir.state, first_state)
+        finally:
+            await bus.stop()
+
+    async def test_unknown_event_type_does_not_crash_or_corrupt(self):
+        bus = EventBus()
+        await bus.start()
+        esn = _make_esn(n_reservoir=50, seed=2)
+        module = LearningModule(bus, esn)
+        try:
+            await module.subscribe()
+            await bus.publish(BaseEvent.create("minion.unknown", source_module="test"))
+            await bus.publish(BaseEvent.create("custom.thing", source_module="test"))
+            # a known event still flows afterwards
+            await bus.publish(
+                BaseEvent.create(
+                    "minion.location",
+                    payload={"payload": {"latitude": 5.0}},
+                    source_module="test",
+                )
+            )
+            assert not np.all(esn.reservoir.state == 0.0)
+        finally:
+            await bus.stop()
+
+    async def test_direct_call_with_unknown_type_is_safe(self):
+        module = LearningModule(EventBus(), _make_esn(n_reservoir=50, seed=2))
+        await module.on_minion_event(BaseEvent.create("minion.unknown", source_module="test"))
+        await module.on_minion_event(BaseEvent.create("custom.x", source_module="test"))
+
+    async def test_custom_encoder_drives_smaller_input_vectors(self):
+        bus = EventBus()
+        await bus.start()
+        encoder = MinionEventEncoder(event_types=("minion.location",))
+        reservoir = Reservoir(n_input=encoder.n_features, n_reservoir=50, seed=1)
+        esn = EchoStateNetwork(reservoir)
+        module = LearningModule(bus, esn, encoder=encoder)
+        try:
+            await module.subscribe()
+            await bus.publish(
+                BaseEvent.create(
+                    "minion.location",
+                    payload={"payload": {"latitude": 10.0}},
+                    source_module="minion_event_processor",
+                )
+            )
+            # 9-dim vector (1 hot + 8 numeric) matches the reservoir input size;
+            # a dimension mismatch would raise inside the handler, leaving state zero.
+            assert not np.all(reservoir.state == 0.0)
+        finally:
+            await bus.stop()
+
+
+class TestLearningModuleConstruction:
+    """LearningModule validates the encoder/reservoir contract at init."""
+
+    def test_mismatched_encoder_and_reservoir_raise_value_error(self):
+        encoder = MinionEventEncoder(event_types=("minion.location",))
+        esn = _make_esn()  # reservoir input sized for the default encoder
+        with pytest.raises(ValueError) as excinfo:
+            LearningModule(EventBus(), esn, encoder=encoder)
+        message = str(excinfo.value)
+        assert f"encoder.n_features ({encoder.n_features})" in message
+        assert f"esn.reservoir.n_input ({esn.reservoir.n_input})" in message
+
+
+class TestLearningModuleReadouts:
+    """Getters resolve the registered readouts and score the current state."""
+
+    @staticmethod
+    def _trained_esn(n_reservoir=60, seed=7):
+        esn = _make_esn(n_reservoir=n_reservoir, seed=seed)
+
+        def drive(seqs):
+            return _drive(seqs, n_input=N_FEATURES, n_reservoir=n_reservoir, seed=seed)
+
+        n_samples = 100
+        quiet = [np.zeros(N_FEATURES)] * 4
+        active = [np.ones(N_FEATURES)] * 4
+        salience = SalienceReadout()
+        sal_states = drive([quiet if i % 2 == 0 else active for i in range(n_samples)])
+        salience.train(
+            sal_states,
+            np.array([0.0 if i % 2 == 0 else 1.0 for i in range(n_samples)]),
+        )
+
+        rng = np.random.default_rng(11)
+        anomaly = AnomalyReadout()
+        normal = drive([[rng.uniform(-0.5, 0.5, N_FEATURES)] for _ in range(60)])
+        anomaly.train(normal)
+
+        directions = [np.eye(N_FEATURES)[0], np.eye(N_FEATURES)[1], np.eye(N_FEATURES)[2]]
+        pattern = PatternReadout(["location", "battery", "activity"])
+        pattern_states = drive([[directions[i % 3]] * 4 for i in range(150)])
+        pattern.train(pattern_states, (np.arange(150) % 3).astype(np.int64))
+
+        esn.register_readout("salience", salience)
+        esn.register_readout("anomaly", anomaly)
+        esn.register_readout("pattern", pattern)
+        return esn
+
+    def test_get_salience_returns_unit_range_float_after_training(self):
+        esn = self._trained_esn()
+        module = LearningModule(EventBus(), esn)
+        for _ in range(4):
+            esn.reservoir.update(np.ones(N_FEATURES))
+        active = module.get_salience()
+        esn.reservoir.reset()
+        for _ in range(4):
+            esn.reservoir.update(np.zeros(N_FEATURES))
+        quiet = module.get_salience()
+        assert isinstance(active, float)
+        assert isinstance(quiet, float)
+        assert 0.0 <= active <= 1.0
+        assert 0.0 <= quiet <= 1.0
+        assert active > quiet
+
+    def test_get_anomaly_score_returns_finite_float_after_training(self):
+        esn = self._trained_esn()
+        module = LearningModule(EventBus(), esn)
+        rng = np.random.default_rng(21)
+        for _ in range(4):
+            esn.reservoir.update(rng.uniform(-0.5, 0.5, N_FEATURES))
+        score = module.get_anomaly_score()
+        assert isinstance(score, float)
+        assert math.isfinite(score)
+        assert score >= 0.0
+
+    def test_get_pattern_probabilities_form_distribution_after_training(self):
+        esn = self._trained_esn()
+        module = LearningModule(EventBus(), esn)
+        for _ in range(4):
+            esn.reservoir.update(np.eye(N_FEATURES)[0])
+        probabilities = module.get_pattern_probabilities()
+        assert set(probabilities) == {"location", "battery", "activity"}
+        assert all(0.0 <= p <= 1.0 for p in probabilities.values())
+        assert sum(probabilities.values()) == pytest.approx(1.0)
+        assert max(probabilities, key=probabilities.get) == "location"
+
+    def test_get_readout_raises_key_error_for_unknown_name(self):
+        esn = _make_esn(seed=1)
+        with pytest.raises(KeyError, match="missing"):
+            esn.get_readout("missing")
+
+    def test_getters_raise_when_readout_not_registered(self):
+        module = LearningModule(EventBus(), _make_esn(seed=1))
+        with pytest.raises(RuntimeError, match="salience"):
+            module.get_salience()
+        with pytest.raises(RuntimeError, match="anomaly"):
+            module.get_anomaly_score()
+        with pytest.raises(RuntimeError, match="pattern"):
+            module.get_pattern_probabilities()
+
+    def test_getters_raise_when_readout_untrained(self):
+        esn = _make_esn(seed=1)
+        esn.register_readout("salience", SalienceReadout())
+        esn.register_readout("anomaly", AnomalyReadout())
+        esn.register_readout("pattern", PatternReadout(["a", "b"]))
+        module = LearningModule(EventBus(), esn)
+        with pytest.raises(RuntimeError, match="not trained"):
+            module.get_salience()
+        with pytest.raises(RuntimeError, match="not trained"):
+            module.get_anomaly_score()
+        with pytest.raises(RuntimeError, match="not trained"):
+            module.get_pattern_probabilities()
+
+    def test_getters_reject_wrong_readout_type(self):
+        esn = _make_esn(seed=1)
+        esn.register_readout("salience", AnomalyReadout())
+        module = LearningModule(EventBus(), esn)
+        with pytest.raises(RuntimeError, match="SalienceReadout"):
+            module.get_salience()
+
+    async def test_bus_events_drive_readout_scoring(self):
+        bus = EventBus()
+        await bus.start()
+        esn = self._trained_esn()
+        module = LearningModule(bus, esn)
+        try:
+            await module.subscribe()
+            await bus.publish(
+                BaseEvent.create(
+                    "minion.location",
+                    payload={"payload": {"latitude": 0.0, "longitude": 0.0}},
+                    source_module="minion_event_processor",
+                )
+            )
+            assert isinstance(module.get_salience(), float)
+            probabilities = module.get_pattern_probabilities()
+            assert sum(probabilities.values()) == pytest.approx(1.0)
+        finally:
+            await bus.stop()


### PR DESCRIPTION
Closes #11

## Summary
Wire the ESN into the Cortex event bus: minion events advance the reservoir, readouts exposed via clean API.

- `MinionEventEncoder`: one-hot event type (10 types from the minion processor map) + 8 normalized numeric fields → fixed-length vector in [-1, 1]. Total/deterministic: non-numeric, NaN/inf, missing fields → 0.0; unknown types → zero-hot, never crashes the handler.
- `LearningModule`: subscribes to all `minion.*` types, `on_minion_event` = encode → `esn.step`; no-arg `get_salience`/`get_anomaly_score`/`get_pattern_probabilities` over current state. subscribe() idempotent; encoder/reservoir size guard at construction.
- `EchoStateNetwork.get_readout(name)` public accessor (KeyError on unknown; additive, #9/#10 contract untouched).
- 30 tests: subscription count, state advance, encoding layout/normalization/guards, readout API, idempotency, mismatched-size ValueError.
- Docs: ARCHITECTURE.md learning/ tree gains encoding.py + module.py.

Boundaries respected: no LLM, no fact extraction, no storage, no main.py wiring (deferred to #12/#13).

## Verification
- `pytest tests/unit tests/learning`: 599 passed
- `ruff check src tests`: clean
- `mypy src`: only pre-existing cortex_protocol error (present on master)
- Review: Standards + Spec, 2 rounds, zero actionable findings