### PR TITLE
fix: annotate schema model dict; typecheck whole src in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run mypy
-        run: uv run mypy src/cortex
+        run: uv run mypy src
 
   coverage:
     name: Coverage (pytest-cov)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: mypy
         name: mypy (typecheck)
-        args: [src/cortex]
+        args: [src]
         pass_filenames: false
         additional_dependencies:
           - pydantic>=2.0

--- a/src/cortex_protocol/schemas/jsonschema.py
+++ b/src/cortex_protocol/schemas/jsonschema.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from pydantic import BaseModel
+
 # Lazy-loaded schemas (generated from Pydantic models at import time)
 _schemas_cache: dict[str, object] | None = None
 
@@ -35,7 +37,7 @@ def _get_schemas() -> dict[str, object]:
     )
 
     # All events + config + messages
-    model_to_name = {
+    model_to_name: dict[type[BaseModel], str] = {
         LocationEvent: "location_event",
         ActivityEvent: "activity_event",
         CalendarEvent: "calendar_event",


### PR DESCRIPTION
Closes #64

## Summary
Fix the pre-existing mypy strict error in `cortex_protocol` and close the CI gap that let it survive on master.

- `src/cortex_protocol/schemas/jsonschema.py`: annotate `model_to_name` as `dict[type[BaseModel], str]` — mypy was inferring `ModelMetaclass` for the keys, which has no `model_json_schema` (a `BaseModel` classmethod) → false-positive `[attr-defined]` at line 59. Runtime was never broken.
- `.github/workflows/ci.yml` + `.pre-commit-config.yaml`: mypy now checks `src` (was `src/cortex`), so `cortex_protocol` is type-checked in CI and pre-commit for the first time.
- Verified `cortex_protocol` imports only stdlib + pydantic → covered by the pre-commit hook's existing `additional_dependencies`.

## Verification
- `uv run mypy src`: 0 errors (was 1)
- `pytest tests/unit tests/learning`: 599 passed
- `ruff check src tests`: clean
- pre-commit (ruff + mypy on src): passed