### PR TITLE
feat: extract FactExtractor ingestion pipeline (#20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run tests
-        run: uv run pytest tests/unit tests/learning -q
+        run: uv run pytest tests/unit tests/learning tests/memory -q
 
   lint:
     name: Lint (ruff)
@@ -76,7 +76,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run coverage
-        run: uv run pytest tests/unit tests/learning -q --cov=src/cortex --cov-report=term --cov-fail-under=70
+        run: uv run pytest tests/unit tests/learning tests/memory -q --cov=src/cortex --cov-report=term --cov-fail-under=70
 
   build:
     name: Docker build

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1896,7 +1896,8 @@ Database:
 ```python
 MemoryService             # Service API (query, store, search)
 FactStore                # Postgres client for facts/concepts
-FactExtractor           # LLM client — extracts structured facts from text
+FactExtractor           # rule-based: raw events (location/payment/activity/calendar/call_log/app_usage) -> facts via extract_from_event_type
+                        # LLM-powered: free text -> facts via extract_from_text; MinionService & MemoryService.handle_event delegate to it
 LogicEngine             # PyDatalog — validates LLM reasoning, checks consistency
 HierarchyManager        # manages frequency-adjusted fact hierarchy (hot/warm/cold)
 ```

--- a/src/cortex/main.py
+++ b/src/cortex/main.py
@@ -154,17 +154,21 @@ async def initialize_app() -> CortexApp:
     goal_repo: GoalRepository = PostgresGoalRepository()
 
     # 5c. Create memory repositories
-    from cortex.memory.interfaces import ConceptRepository, FactExtractor, FactRepository
+    from cortex.memory.interfaces import ConceptRepository, FactRepository
     from cortex.memory.repository import PostgresConceptRepository, PostgresFactRepository
 
     fact_repo: FactRepository = PostgresFactRepository()
     concept_repo: ConceptRepository = PostgresConceptRepository()
-    memory_extractor: FactExtractor | None = None
 
     # 5d. Create LLM client
     from cortex.llm.factory import LLMClientFactory
     llm_factory = LLMClientFactory(settings)
     cortex.llm_client = llm_factory.create()
+
+    # 5d'. Create fact extractor so MemoryService's conversation/event
+    # extraction is live rather than a silent no-op.
+    from cortex.memory.fact_extractor import FactExtractor
+    memory_extractor = FactExtractor(llm_client=cortex.llm_client)
 
     # 5e. Create tool registry and executor
     from cortex.tools.executor import DefaultToolExecutor
@@ -320,6 +324,7 @@ async def _subscribe_services(cortex: CortexApp) -> None:
 
 async def _initialize_minion_service(cortex: CortexApp) -> None:
     """Initialize MinionService for MQTT-based minion communication."""
+    from cortex.memory.fact_extractor import FactExtractor
     from cortex.minions.models import MinionConfig
     from cortex.minions.mqtt_client import MinionMQTTClient
     from cortex.minions.registry import InMemoryMinionRegistry
@@ -348,12 +353,14 @@ async def _initialize_minion_service(cortex: CortexApp) -> None:
     registry = InMemoryMinionRegistry()
 
     # Create and configure service
+    fact_extractor = FactExtractor(llm_client=cortex.llm_client)
     cortex.minion_service = MinionService(
         config=minion_config,
         gateway=gateway,
         registry=registry,
         event_bus=cortex.event_bus,
         memory_service=cortex.memory_service,
+        fact_extractor=fact_extractor,
     )
 
     # Connect gateway

--- a/src/cortex/memory/fact_extractor.py
+++ b/src/cortex/memory/fact_extractor.py
@@ -1,0 +1,238 @@
+"""Fact extraction from raw events and free text."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from typing import Any
+
+from cortex.events.base import BaseEvent
+from cortex.llm.base import LLMClient
+from cortex.llm.models import ChatMessage, Role
+from cortex.memory.interfaces import FactExtractor as FactExtractorABC
+from cortex.memory.models import Fact, FactMutability, FactType
+
+_SYSTEM_PROMPT = (
+    "You are a fact extraction engine. Extract structured facts from the given text.\n"
+    "Valid fact types: user_preference, user_fact, location, time, activity, calendar, "
+    "weather, device_status, entity, relationship, custom.\n"
+    'Respond with JSON of the shape {"facts": [...]} where each item has the fields: '
+    "type, symbolic_repr, natural_lang_repr, confidence, payload.\n"
+    'Return {"facts": []} if no facts; no markdown.'
+)
+
+
+def _slugify(text: str) -> str:
+    """Convert text to a slug for symbolic representation."""
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9]+", "_", text)
+    return text.strip("_")
+
+
+def _parse_llm_facts(content: str) -> list[Fact]:
+    """Parse LLM JSON output into structured Fact objects.
+
+    Accepts either ``{"facts": [...]}`` or a bare ``[...]``. Raises
+    ``ValueError`` on malformed JSON.
+    """
+    text = content.strip()
+    if text.startswith("```"):
+        # Strip markdown fenced code blocks (```json ... ``` or ``` ... ```)
+        text = re.sub(r"^```[a-zA-Z]*\s*", "", text)
+        text = re.sub(r"\s*```$", "", text).strip()
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Malformed JSON from LLM: {e}") from e
+
+    if isinstance(data, dict):
+        items = data.get("facts")
+        if items is None:
+            raise ValueError("LLM JSON must contain a 'facts' key")
+    elif isinstance(data, list):
+        items = data
+    else:
+        raise ValueError("LLM JSON must be an object with a 'facts' key or a bare list")
+
+    if not isinstance(items, list):
+        raise ValueError("LLM JSON 'facts' value must be a list")
+
+    facts: list[Fact] = []
+    for item in items:
+        if not isinstance(item, dict):
+            raise ValueError(f"Each fact item must be an object, got {type(item).__name__}")
+        try:
+            fact_type = FactType(item["type"]) if item.get("type") else FactType.CUSTOM
+        except ValueError:
+            # Unknown type string from the LLM falls back to CUSTOM
+            fact_type = FactType.CUSTOM
+        try:
+            confidence = float(item.get("confidence", 0.5))
+        except (TypeError, ValueError):
+            confidence = 0.5
+        confidence = max(0.0, min(1.0, confidence))
+        raw_payload = item.get("payload")
+        payload = raw_payload if isinstance(raw_payload, dict) else {}
+        facts.append(
+            Fact(
+                type=fact_type,
+                symbolic_repr=item.get("symbolic_repr") or "",
+                natural_lang_repr=item.get("natural_lang_repr") or "",
+                confidence=confidence,
+                payload=payload,
+            )
+        )
+    return facts
+
+
+class FactExtractor(FactExtractorABC):
+    """
+    Extract structured facts from raw events and free text.
+
+    Event extraction is rule-based; text extraction is LLM-powered.
+    No storage and no context bundling — callers own the resulting facts.
+    """
+
+    def __init__(self, llm_client: LLMClient | None = None) -> None:
+        self._llm_client = llm_client
+
+    # ─── Event extraction (rules) ────────────────────────────────────────
+
+    def extract_from_event(self, event: BaseEvent) -> list[Fact]:
+        """Extract facts from an event by dispatching on its type."""
+        return self.extract_from_event_type(event.type, event.payload)
+
+    def extract_from_event_type(self, event_type: str, payload: dict[str, Any]) -> list[Fact]:
+        """Extract facts from a raw event type and payload.
+
+        Unknown event types yield no facts.
+        """
+        handler = _EVENT_BUILDERS.get(event_type)
+        return handler(self, payload) if handler else []
+
+    def _facts_from_location(self, payload: dict[str, Any]) -> list[Fact]:
+        lat = payload.get("latitude")
+        lon = payload.get("longitude")
+        place = payload.get("place") or (
+            f"{lat},{lon}" if lat is not None and lon is not None else None
+        )
+        return [
+            Fact(
+                type=FactType.LOCATION,
+                mutability=FactMutability.MUTABLE,
+                symbolic_repr=f"location.{place or 'current'}",
+                natural_lang_repr=f"At {place or 'unknown location'}",
+                payload={
+                    "latitude": lat,
+                    "longitude": lon,
+                    "place": place,
+                },
+                confidence=0.9 if place else 0.6,
+            )
+        ]
+
+    def _facts_from_payment(self, payload: dict[str, Any]) -> list[Fact]:
+        merchant = payload.get("merchant_name") or payload.get("merchant")
+        return [
+            Fact(
+                type=FactType.PAYMENT,
+                mutability=FactMutability.MUTABLE,
+                symbolic_repr=f"payment.{merchant or 'unknown'}",
+                natural_lang_repr=(
+                    f"Paid {payload.get('amount')} {payload.get('currency')} at {merchant or 'unknown'}"
+                ),
+                payload=dict(payload),
+                confidence=0.9,
+            )
+        ]
+
+    def _facts_from_activity(self, payload: dict[str, Any]) -> list[Fact]:
+        activity = payload.get("activity")
+        duration = payload.get("duration_seconds", payload.get("duration"))
+        return [
+            Fact(
+                type=FactType.ACTIVITY,
+                mutability=FactMutability.EPHEMERAL,
+                symbolic_repr=f"activity.{activity or 'unknown'}",
+                natural_lang_repr=f"Currently {activity or 'doing something'}",
+                payload={"duration": duration},
+                confidence=0.8,
+            )
+        ]
+
+    def _facts_from_calendar(self, payload: dict[str, Any]) -> list[Fact]:
+        title = payload.get("title")
+        start = payload.get("start_time")
+        return [
+            Fact(
+                type=FactType.CALENDAR,
+                mutability=FactMutability.MUTABLE,
+                symbolic_repr=f"calendar.{_slugify(title or 'event')}",
+                natural_lang_repr=f"Event: {title or 'Unknown event'}",
+                payload={"start_time": start, **payload},
+                confidence=0.9,
+            )
+        ]
+
+    def _facts_from_call_log(self, payload: dict[str, Any]) -> list[Fact]:
+        direction = payload.get("direction")
+        contact = payload.get("contact_name") or payload.get("contact")
+        return [
+            Fact(
+                type=FactType.CALL_LOG,
+                mutability=FactMutability.MUTABLE,
+                symbolic_repr=f"call_log.{direction or 'unknown'}",
+                natural_lang_repr=f"{direction or 'unknown'} call with {contact or 'unknown'}",
+                payload=dict(payload),
+                confidence=0.9,
+            )
+        ]
+
+    def _facts_from_app_usage(self, payload: dict[str, Any]) -> list[Fact]:
+        app = payload.get("app_name") or payload.get("app_id")
+        return [
+            Fact(
+                type=FactType.APP_USAGE,
+                mutability=FactMutability.EPHEMERAL,
+                symbolic_repr=f"app_usage.{app or 'unknown'}",
+                natural_lang_repr=f"Used {app or 'unknown'}",
+                payload=dict(payload),
+                confidence=0.9,
+            )
+        ]
+
+    # ─── Text extraction (LLM) ───────────────────────────────────────────
+
+    async def extract_from_text(self, text: str) -> list[Fact]:
+        """Extract facts from free text via the LLM.
+
+        Raises ``ValueError`` when no LLM client is configured or the LLM
+        returns malformed JSON.
+        """
+        if self._llm_client is None:
+            raise ValueError("FactExtractor requires an llm_client for extract_from_text")
+
+        messages = [
+            ChatMessage(role=Role.SYSTEM, content=_SYSTEM_PROMPT),
+            ChatMessage(role=Role.USER, content=text),
+        ]
+        result = await self._llm_client.chat(messages)
+        content = result.message.content
+        if content is None:
+            raise ValueError("LLM returned no content for fact extraction")
+        return _parse_llm_facts(content)
+
+
+# Module-level builders table: single source of truth for the sensory event
+# vocabulary FactExtractor dispatches on (also exported as SUPPORTED_EVENT_TYPES).
+_EVENT_BUILDERS: dict[str, Callable[[FactExtractor, dict[str, Any]], list[Fact]]] = {
+    "location": FactExtractor._facts_from_location,
+    "payment": FactExtractor._facts_from_payment,
+    "activity": FactExtractor._facts_from_activity,
+    "calendar": FactExtractor._facts_from_calendar,
+    "call_log": FactExtractor._facts_from_call_log,
+    "app_usage": FactExtractor._facts_from_app_usage,
+}
+SUPPORTED_EVENT_TYPES = frozenset(_EVENT_BUILDERS)

--- a/src/cortex/memory/interfaces.py
+++ b/src/cortex/memory/interfaces.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from typing import Any
 from uuid import UUID
 
+from cortex.events.base import BaseEvent
+
 from .models import Concept, Fact, FactType
 
 
@@ -210,13 +212,12 @@ class FactExtractor(ABC):
     """
 
     @abstractmethod
-    async def extract_from_text(self, text: str, context: dict[str, Any] | None = None) -> list[Fact]:
+    async def extract_from_text(self, text: str) -> list[Fact]:
         """
-        Extract facts from text.
+        Extract facts from free text (LLM-powered).
 
         Args:
             text: The text to extract from.
-            context: Optional context (session_id, etc.).
 
         Returns:
             Extracted facts.
@@ -224,12 +225,26 @@ class FactExtractor(ABC):
         ...
 
     @abstractmethod
-    async def extract_from_event(self, event_data: dict[str, Any]) -> list[Fact]:
+    def extract_from_event(self, event: BaseEvent) -> list[Fact]:
         """
         Extract facts from an event.
 
         Args:
-            event_data: Event data to extract from.
+            event: The event to extract from.
+
+        Returns:
+            Extracted facts.
+        """
+        ...
+
+    @abstractmethod
+    def extract_from_event_type(self, event_type: str, payload: dict[str, Any]) -> list[Fact]:
+        """
+        Extract facts from a raw event type and payload.
+
+        Args:
+            event_type: The event type name (e.g. "location").
+            payload: The event payload.
 
         Returns:
             Extracted facts.

--- a/src/cortex/memory/models.py
+++ b/src/cortex/memory/models.py
@@ -18,6 +18,11 @@ class FactType(StrEnum):
     TIME = "time"
     ACTIVITY = "activity"
 
+    # Sensory events
+    PAYMENT = "payment"
+    CALL_LOG = "call_log"
+    APP_USAGE = "app_usage"
+
     # Contextual
     CALENDAR = "calendar"
     WEATHER = "weather"

--- a/src/cortex/minions/models.py
+++ b/src/cortex/minions/models.py
@@ -42,6 +42,8 @@ class EventType(StrEnum):
     CALENDAR_EVENT = "calendar.event"
     ACTIVITY_DETECTED = "activity.detected"
     APP_USAGE = "app.usage"
+    PAYMENT = "payment"
+    CALL_LOG = "call_log"
     BATTERY_LEVEL = "battery.level"
     NOTIFICATION = "notification"
 

--- a/src/cortex/services/memory_service.py
+++ b/src/cortex/services/memory_service.py
@@ -263,9 +263,7 @@ class MemoryService:
         if not self._extractor:
             return []
 
-        facts = await self._extractor.extract_from_text(
-            text, context={"session_id": str(session_id) if session_id else None}
-        )
+        facts = await self._extractor.extract_from_text(text)
 
         # Store extracted facts
         for fact in facts:
@@ -277,69 +275,20 @@ class MemoryService:
         """
         Process an event, extracting facts if applicable.
 
-        Event types handled:
-        - location: GPS coordinates
-        - activity: Current activity
-        - calendar: Calendar events
+        Delegates extraction to the FactExtractor; unknown event types
+        yield no facts.
         """
         event_type = getattr(event, "type", None)
         payload = getattr(event, "payload", {})
 
-        if event_type == "location":
-            await self._extract_location_facts(payload)
-        elif event_type == "activity":
-            await self._extract_activity_facts(payload)
-        elif event_type == "calendar":
-            await self._extract_calendar_facts(payload)
+        if not isinstance(event_type, str):
+            return
 
-    async def _extract_location_facts(self, payload: dict[str, Any]) -> None:
-        """Extract facts from location events."""
-        lat = payload.get("latitude")
-        lon = payload.get("longitude")
-        place = payload.get("place")
+        if not self._extractor:
+            return
 
-        fact = Fact(
-            type=FactType.LOCATION,
-            mutability=FactMutability.MUTABLE,
-            symbolic_repr=f"location.{place or 'current'}",
-            natural_lang_repr=f"At {place or 'unknown location'}",
-            payload={"latitude": lat, "longitude": lon, "place": place},
-            confidence=0.9 if place else 0.6,
-        )
-
-        await self.store_fact(fact)
-
-    async def _extract_activity_facts(self, payload: dict[str, Any]) -> None:
-        """Extract facts from activity events."""
-        activity = payload.get("activity")
-        duration = payload.get("duration")
-
-        fact = Fact(
-            type=FactType.ACTIVITY,
-            mutability=FactMutability.EPHEMERAL,
-            symbolic_repr=f"activity.{activity or 'unknown'}",
-            natural_lang_repr=f"Currently {activity or 'doing something'}",
-            payload={"duration": duration},
-            confidence=0.8,
-        )
-
-        await self.store_fact(fact)
-
-    async def _extract_calendar_facts(self, payload: dict[str, Any]) -> None:
-        """Extract facts from calendar events."""
-        title = payload.get("title")
-        start = payload.get("start_time")
-
-        fact = Fact(
-            type=FactType.CALENDAR,
-            mutability=FactMutability.MUTABLE,
-            symbolic_repr=f"calendar.{_slugify(title or 'event')}",
-            natural_lang_repr=f"Event: {title or 'Unknown event'}",
-            payload={"start_time": start, **payload},
-            confidence=0.9,
-        )
-
-        await self.store_fact(fact)
+        for fact in self._extractor.extract_from_event_type(event_type, payload):
+            await self.store_fact(fact)
 
     # ─── Concept Management ───────────────────────────────────────────────
 
@@ -426,12 +375,3 @@ def _avg(values: list[float], default: float) -> float:
     if not values:
         return default
     return sum(values) / len(values)
-
-
-def _slugify(text: str) -> str:
-    """Convert text to a slug for symbolic representation."""
-    import re
-
-    text = text.lower()
-    text = re.sub(r"[^a-z0-9]+", "_", text)
-    return text.strip("_")

--- a/src/cortex/services/minion_service.py
+++ b/src/cortex/services/minion_service.py
@@ -6,8 +6,11 @@ import logging
 from typing import Any
 
 from cortex.events import EventEmitter
+from cortex.memory.fact_extractor import SUPPORTED_EVENT_TYPES
+from cortex.memory.interfaces import FactExtractor
 from cortex.minions.interfaces import MinionEventHandler, MinionGateway, MinionRegistry
 from cortex.minions.models import (
+    EventType,
     MinionConfig,
     MinionEvent,
     MinionEventBatch,
@@ -17,15 +20,32 @@ from cortex.minions.models import (
 
 logger = logging.getLogger(__name__)
 
+_MINION_EVENT_TYPE_TO_SENSORY = {
+    "location.update": "location",
+    "activity.detected": "activity",
+    "calendar.event": "calendar",
+    "app.usage": "app_usage",
+    "payment": "payment",
+    "call_log": "call_log",
+}
 
-class MinionService:
+
+def _sensory_event_type(event_type: EventType | str) -> str | None:
+    """Map a minion event type to the plain sensory vocabulary FactExtractor dispatches on."""
+    value = event_type.value if isinstance(event_type, EventType) else str(event_type)
+    if value in SUPPORTED_EVENT_TYPES:
+        return value
+    return _MINION_EVENT_TYPE_TO_SENSORY.get(value)
+
+
+class MinionService(MinionEventHandler):
     """
     Service layer for minion management.
 
     Wraps the MinionGateway with:
     - Registry integration
     - Event processing
-    - Fact extraction
+    - Fact extraction (via FactExtractor)
     - Sequence gap detection
     - Health monitoring
     """
@@ -36,19 +56,18 @@ class MinionService:
         gateway: MinionGateway,
         registry: MinionRegistry,
         event_bus: Any | None = None,
-        memory_service: Any | None = None
+        memory_service: Any | None = None,
+        fact_extractor: FactExtractor | None = None,
     ):
         self._config = config
         self._gateway = gateway
         self._registry = registry
         self._memory_service = memory_service
+        self._fact_extractor = fact_extractor
         self._emitter = EventEmitter(event_bus, source_module="minion_service")
 
         # Sequence tracking for gap detection
         self._last_sequence: dict[str, int] = {}
-
-        # Create event handler
-        self._handler = MinionEventProcessor(event_bus, memory_service)
 
     async def connect(self) -> None:
         """Connect to the message broker and start listening."""
@@ -67,7 +86,7 @@ class MinionService:
 
         # Connect gateway
         await self._gateway.connect()
-        await self._gateway.subscribe(self._handler)
+        await self._gateway.subscribe(self)
 
         logger.info(f"MinionService connected for {self._config.minion_id}")
 
@@ -115,13 +134,25 @@ class MinionService:
         # Update heartbeat
         await self.heartbeat()
 
-        # Process based on event type
-        if event.event_type == "location":
-            await self._handle_location_event(event)
-        elif event.event_type == "activity":
-            await self._handle_activity_event(event)
-        elif event.event_type == "calendar":
-            await self._handle_calendar_event(event)
+        # Translate the minion event type to the plain sensory vocabulary
+        # FactExtractor dispatches on (EventType values are dotted, e.g.
+        # "location.update" -> "location").
+        sensory_type = _sensory_event_type(event.event_type)
+
+        # Track last known location in the registry
+        if sensory_type == "location":
+            info = await self._registry.get(event.minion_id)
+            if info:
+                info.last_location = event.payload.get("place") or (
+                    f"{event.payload.get('latitude')},{event.payload.get('longitude')}"
+                )
+
+        # Extract facts from the event via the FactExtractor
+        if sensory_type and self._fact_extractor and self._memory_service:
+            for fact in self._fact_extractor.extract_from_event_type(
+                sensory_type, event.payload
+            ):
+                await self._memory_service.store_fact(fact)
 
         await self._emitter.emit(
             "minion.event",
@@ -163,150 +194,6 @@ class MinionService:
             processed.append(event)
         return processed
 
-    async def _handle_location_event(self, event: MinionEvent) -> None:
-        """Handle a location event."""
-        payload = event.payload
-
-        # Update registry with location
-        info = await self._registry.get(event.minion_id)
-        if info:
-            info.last_location = payload.get("place") or f"{payload.get('latitude')},{payload.get('longitude')}"
-
-        # Extract fact if memory service available
-        if self._memory_service:
-            fact = await self._memory_service._extract_location_facts(payload)
-            if fact:
-                await self._memory_service.store_fact(fact)
-
-    async def _handle_activity_event(self, event: MinionEvent) -> None:
-        """Handle an activity event."""
-        payload = event.payload
-
-        # Extract fact if memory service available
-        if self._memory_service:
-            fact = await self._memory_service._extract_activity_facts(payload)
-            if fact:
-                await self._memory_service.store_fact(fact)
-
-    async def _handle_calendar_event(self, event: MinionEvent) -> None:
-        """Handle a calendar event."""
-        payload = event.payload
-
-        # Extract fact if memory service available
-        if self._memory_service:
-            fact = await self._memory_service._extract_calendar_facts(payload)
-            if fact:
-                await self._memory_service.store_fact(fact)
-
     def is_connected(self) -> bool:
         """Check if the gateway is connected."""
         return self._gateway.is_connected()
-
-
-class MinionEventProcessor(MinionEventHandler):
-    """
-    Process incoming minion events.
-
-    Transforms raw events into structured facts and emits to the system.
-    """
-
-    def __init__(self, event_bus: Any | None = None, memory_service: Any | None = None):
-        self._memory_service = memory_service
-        self._emitter = EventEmitter(event_bus, source_module="minion_event_processor")
-
-    async def handle_event(self, event: MinionEvent) -> None:
-        """
-        Handle a single minion event.
-
-        Args:
-            event: The minion event to process
-        """
-        # Process based on type
-        if event.event_type == "location":
-            await self._process_location(event)
-        elif event.event_type == "activity":
-            await self._process_activity(event)
-        elif event.event_type == "battery":
-            await self._process_battery(event)
-        elif event.event_type == "app_usage":
-            await self._process_app_usage(event)
-        elif event.event_type == "calendar":
-            await self._process_calendar(event)
-
-    async def handle_batch(self, batch: MinionEventBatch) -> list[MinionEvent]:
-        """
-        Handle a batch of events.
-
-        Args:
-            batch: The batch of events
-
-        Returns:
-            Processed events
-        """
-        processed = []
-        for event in batch.events:
-            await self.handle_event(event)
-            processed.append(event)
-        return processed
-
-    async def _process_location(self, event: MinionEvent) -> None:
-        """Process a location event."""
-        payload = event.payload
-        await self._emitter.emit(
-            "minion.location",
-            {
-                "minion_id": event.minion_id,
-                "latitude": payload.get("latitude"),
-                "longitude": payload.get("longitude"),
-                "place": payload.get("place"),
-                "accuracy": payload.get("accuracy"),
-            },
-        )
-
-    async def _process_activity(self, event: MinionEvent) -> None:
-        """Process an activity event."""
-        payload = event.payload
-        await self._emitter.emit(
-            "minion.activity",
-            {
-                "minion_id": event.minion_id,
-                "activity": payload.get("activity"),
-                "confidence": payload.get("confidence"),
-            },
-        )
-
-    async def _process_battery(self, event: MinionEvent) -> None:
-        """Process a battery event."""
-        payload = event.payload
-        await self._emitter.emit(
-            "minion.battery",
-            {
-                "minion_id": event.minion_id,
-                "level": payload.get("level"),
-                "is_charging": payload.get("is_charging"),
-            },
-        )
-
-    async def _process_app_usage(self, event: MinionEvent) -> None:
-        """Process an app usage event."""
-        payload = event.payload
-        await self._emitter.emit(
-            "minion.app_usage",
-            {
-                "minion_id": event.minion_id,
-                "app": payload.get("app"),
-                "duration": payload.get("duration"),
-            },
-        )
-
-    async def _process_calendar(self, event: MinionEvent) -> None:
-        """Process a calendar event."""
-        payload = event.payload
-        await self._emitter.emit(
-            "minion.calendar",
-            {
-                "minion_id": event.minion_id,
-                "event": payload.get("title"),
-                "start_time": payload.get("start_time"),
-            },
-        )

--- a/tests/memory/test_fact_extractor.py
+++ b/tests/memory/test_fact_extractor.py
@@ -1,0 +1,210 @@
+"""Tests for FactExtractor."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cortex.events.base import BaseEvent
+from cortex.llm.base import LLMClient
+from cortex.llm.models import ChatMessage, ChatResult, Role
+from cortex.memory.fact_extractor import FactExtractor, _parse_llm_facts
+from cortex.memory.models import FactType
+
+
+class TestExtractFromEventType:
+    """extract_from_event_type maps each event type to the correct fact."""
+
+    @pytest.mark.parametrize(
+        ("event_type", "payload", "expected_type", "expected_symbolic"),
+        [
+            ("location", {"place": "home"}, FactType.LOCATION, "location.home"),
+            ("location", {"latitude": 37.77, "longitude": -122.41}, FactType.LOCATION, "location.37.77,-122.41"),
+            ("payment", {"merchant_name": "Tesco", "amount": 12.5, "currency": "GBP"}, FactType.PAYMENT, "payment.Tesco"),
+            ("activity", {"activity": "walking", "duration_seconds": 300}, FactType.ACTIVITY, "activity.walking"),
+            ("calendar", {"title": "Team Sync"}, FactType.CALENDAR, "calendar.team_sync"),
+            ("call_log", {"direction": "incoming", "contact_name": "Alice"}, FactType.CALL_LOG, "call_log.incoming"),
+            ("app_usage", {"app_name": "WhatsApp"}, FactType.APP_USAGE, "app_usage.WhatsApp"),
+        ],
+    )
+    def test_extract_from_event_type(self, event_type, payload, expected_type, expected_symbolic):
+        """Each event type produces a fact of the right type and symbolic repr."""
+        facts = FactExtractor().extract_from_event_type(event_type, payload)
+
+        assert len(facts) == 1
+        assert facts[0].type == expected_type
+        assert facts[0].symbolic_repr == expected_symbolic
+
+    def test_call_log_natural_lang_repr_uses_contact_name(self):
+        """A call_log with contact_name renders the contact in natural language."""
+        facts = FactExtractor().extract_from_event_type(
+            "call_log", {"direction": "incoming", "contact_name": "Alice"}
+        )
+
+        assert len(facts) == 1
+        assert facts[0].natural_lang_repr == "incoming call with Alice"
+
+    def test_location_coords_only_derives_place(self):
+        """A location without a place derives the symbolic repr from coordinates."""
+        facts = FactExtractor().extract_from_event_type(
+            "location", {"latitude": 37.77, "longitude": -122.41}
+        )
+
+        assert len(facts) == 1
+        assert facts[0].symbolic_repr == "location.37.77,-122.41"
+        assert facts[0].confidence == 0.9
+
+    def test_unknown_event_type_returns_empty(self):
+        """Unknown event types yield no facts."""
+        assert FactExtractor().extract_from_event_type("unknown.type", {}) == []
+
+
+class TestExtractFromEvent:
+    """extract_from_event delegates to extract_from_event_type."""
+
+    def test_extract_from_event_delegates(self):
+        """A location BaseEvent produces a location fact."""
+        event = BaseEvent.create("location", {"place": "home"})
+
+        facts = FactExtractor().extract_from_event(event)
+
+        assert len(facts) == 1
+        assert facts[0].type == FactType.LOCATION
+        assert facts[0].symbolic_repr == "location.home"
+
+
+class TestExtractFromText:
+    """extract_from_text uses the LLM to structure free text into facts."""
+
+    @pytest.mark.asyncio
+    async def test_extract_from_text_returns_structured_facts(self):
+        """LLM JSON output is parsed into structured Fact objects."""
+        llm = MagicMock(spec=LLMClient)
+        llm.chat = AsyncMock(
+            return_value=ChatResult(
+                message=ChatMessage(
+                    role=Role.ASSISTANT,
+                    content=json.dumps(
+                        {
+                            "facts": [
+                                {
+                                    "type": "location",
+                                    "symbolic_repr": "location.home",
+                                    "natural_lang_repr": "At home",
+                                    "confidence": 0.95,
+                                    "payload": {"place": "home"},
+                                },
+                                {
+                                    "type": "user_preference",
+                                    "symbolic_repr": "user_preference.coffee",
+                                    "natural_lang_repr": "Prefers coffee",
+                                    "confidence": 0.8,
+                                    "payload": {},
+                                },
+                            ]
+                        }
+                    ),
+                )
+            )
+        )
+
+        facts = await FactExtractor(llm_client=llm).extract_from_text("I am at home and I like coffee.")
+
+        assert len(facts) == 2
+        assert facts[0].type == FactType.LOCATION
+        assert facts[0].symbolic_repr == "location.home"
+        assert facts[0].natural_lang_repr == "At home"
+        assert facts[0].confidence == 0.95
+        assert facts[0].payload == {"place": "home"}
+        assert facts[1].type == FactType.USER_PREFERENCE
+        llm.chat.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_extract_from_text_accepts_bare_list(self):
+        """A bare JSON list is accepted as the fact list."""
+        llm = MagicMock(spec=LLMClient)
+        llm.chat = AsyncMock(
+            return_value=ChatResult(
+                message=ChatMessage(
+                    role=Role.ASSISTANT,
+                    content=json.dumps([{"type": "activity", "symbolic_repr": "activity.walking"}]),
+                )
+            )
+        )
+
+        facts = await FactExtractor(llm_client=llm).extract_from_text("walking")
+
+        assert len(facts) == 1
+        assert facts[0].type == FactType.ACTIVITY
+        assert facts[0].symbolic_repr == "activity.walking"
+
+    @pytest.mark.asyncio
+    async def test_extract_from_text_accepts_fenced_json(self):
+        """Markdown-fenced JSON blocks are stripped before parsing."""
+        llm = MagicMock(spec=LLMClient)
+        llm.chat = AsyncMock(
+            return_value=ChatResult(
+                message=ChatMessage(
+                    role=Role.ASSISTANT,
+                    content='```json\n{"facts": [{"type": "calendar", "symbolic_repr": "calendar.meeting"}]}\n```',
+                )
+            )
+        )
+
+        facts = await FactExtractor(llm_client=llm).extract_from_text("meeting tomorrow")
+
+        assert len(facts) == 1
+        assert facts[0].type == FactType.CALENDAR
+
+    @pytest.mark.asyncio
+    async def test_extract_from_text_without_llm_client_raises(self):
+        """Without an LLM client, extract_from_text raises ValueError."""
+        with pytest.raises(ValueError):
+            await FactExtractor().extract_from_text("hello")
+
+    @pytest.mark.asyncio
+    async def test_extract_from_text_malformed_json_raises(self):
+        """Malformed LLM JSON raises ValueError."""
+        llm = MagicMock(spec=LLMClient)
+        llm.chat = AsyncMock(
+            return_value=ChatResult(message=ChatMessage(role=Role.ASSISTANT, content="not json at all"))
+        )
+
+        with pytest.raises(ValueError):
+            await FactExtractor(llm_client=llm).extract_from_text("hello")
+
+
+class TestParseLlmFacts:
+    """_parse_llm_facts tolerates noisy LLM output."""
+
+    def test_non_numeric_confidence_falls_back_to_default(self):
+        """A non-numeric confidence string defaults to 0.5."""
+        facts = _parse_llm_facts(
+            json.dumps({"facts": [{"type": "activity", "symbolic_repr": "activity.walking", "confidence": "high"}]})
+        )
+
+        assert facts[0].confidence == 0.5
+
+    def test_confidence_clamped_to_unit_range(self):
+        """Out-of-range confidence values are clamped to [0.0, 1.0]."""
+        facts = _parse_llm_facts(
+            json.dumps(
+                {
+                    "facts": [
+                        {"type": "activity", "symbolic_repr": "activity.a", "confidence": 1.7},
+                        {"type": "activity", "symbolic_repr": "activity.b", "confidence": -0.3},
+                    ]
+                }
+            )
+        )
+
+        assert facts[0].confidence == 1.0
+        assert facts[1].confidence == 0.0
+
+    def test_non_dict_payload_becomes_empty(self):
+        """A non-dict payload is discarded in favour of {}."""
+        facts = _parse_llm_facts(
+            json.dumps({"facts": [{"type": "activity", "symbolic_repr": "activity.walking", "payload": "oops"}]})
+        )
+
+        assert facts[0].payload == {}

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -257,10 +257,17 @@ class TestMemoryService:
         assert ctx.formality >= 0  # Should be derived from facts
 
     @pytest.mark.asyncio
-    async def test_handle_event_location(self, service, mock_fact_repo):
-        """Location events create facts."""
+    async def test_handle_event_location(self, service, mock_fact_repo, mock_extractor):
+        """Location events create facts via the extractor."""
         mock_fact_repo.get_by_symbolic_repr.return_value = None
         mock_fact_repo.store.return_value = Fact()
+        mock_extractor.extract_from_event_type.return_value = [
+            Fact(
+                type=FactType.LOCATION,
+                symbolic_repr="location.home",
+                natural_lang_repr="At home",
+            )
+        ]
 
         event = MagicMock()
         event.type = "location"
@@ -272,7 +279,10 @@ class TestMemoryService:
 
         await service.handle_event(event)
 
-        # Check that store was called (create a location fact)
+        mock_extractor.extract_from_event_type.assert_called_once_with(
+            "location", event.payload
+        )
+        # Check that store was called with the LOCATION fact from the extractor
         mock_fact_repo.store.assert_called()
         call_args = mock_fact_repo.store.call_args[0][0]
         assert call_args.type == FactType.LOCATION

--- a/tests/unit/services/test_minion_service.py
+++ b/tests/unit/services/test_minion_service.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from cortex.minions.interfaces import MinionEventHandler, MinionGateway, MinionRegistry
+from cortex.minions.interfaces import MinionGateway, MinionRegistry
 from cortex.minions.models import (
     MinionConfig,
     MinionEvent,
@@ -48,14 +48,6 @@ class TestMinionService:
         return bus
 
     @pytest.fixture
-    def mock_handler(self):
-        """Create a mock event handler."""
-        handler = MagicMock(spec=MinionEventHandler)
-        handler.handle_event = AsyncMock()
-        handler.handle_batch = AsyncMock(return_value=[])
-        return handler
-
-    @pytest.fixture
     def config(self):
         """Create a minion config."""
         return MinionConfig(
@@ -81,7 +73,7 @@ class TestMinionService:
         await service.connect()
 
         mock_gateway.connect.assert_called_once()
-        mock_gateway.subscribe.assert_called_once()
+        mock_gateway.subscribe.assert_called_once_with(service)
         mock_registry.register.assert_called_once()
 
     @pytest.mark.asyncio
@@ -173,6 +165,88 @@ class TestMinionService:
         assert mock_event_bus.publish.called
 
     @pytest.mark.asyncio
+    async def test_handle_event_uses_fact_extractor(
+        self, mock_gateway, mock_registry, mock_event_bus, config
+    ):
+        """handle_event routes extraction through FactExtractor and stores facts."""
+        from cortex.memory.models import Fact, FactMutability, FactType
+        memory_service = MagicMock()
+        memory_service.store_fact = AsyncMock()
+        fact_extractor = MagicMock()
+        fact_extractor.extract_from_event_type = MagicMock(
+            return_value=[
+                Fact(
+                    type=FactType.LOCATION,
+                    mutability=FactMutability.MUTABLE,
+                    symbolic_repr="location.work",
+                    natural_lang_repr="At work",
+                ),
+                Fact(
+                    type=FactType.ACTIVITY,
+                    mutability=FactMutability.EPHEMERAL,
+                    symbolic_repr="activity.walking",
+                    natural_lang_repr="Currently walking",
+                ),
+            ]
+        )
+        service = MinionService(
+            config=config,
+            gateway=mock_gateway,
+            registry=mock_registry,
+            event_bus=mock_event_bus,
+            memory_service=memory_service,
+            fact_extractor=fact_extractor,
+        )
+
+        from cortex.minions.models import EventType
+        event = MinionEvent(
+            event_id="e3",
+            minion_id="test-minion",
+            event_type=EventType.LOCATION_UPDATE,
+            payload={"latitude": 37.77, "longitude": -122.41, "place": "work"},
+        )
+
+        await service.handle_event(event)
+
+        # The dotted enum value ("location.update") is translated to the plain
+        # sensory vocabulary ("location") before reaching the extractor.
+        fact_extractor.extract_from_event_type.assert_called_once_with(
+            "location", event.payload
+        )
+        assert memory_service.store_fact.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_handle_event_passes_plain_string_sensory_type(
+        self, mock_gateway, mock_registry, mock_event_bus, config
+    ):
+        """A plain-string sensory event type is passed through untranslated."""
+        memory_service = MagicMock()
+        memory_service.store_fact = AsyncMock()
+        fact_extractor = MagicMock()
+        fact_extractor.extract_from_event_type = MagicMock(return_value=[])
+        service = MinionService(
+            config=config,
+            gateway=mock_gateway,
+            registry=mock_registry,
+            event_bus=mock_event_bus,
+            memory_service=memory_service,
+            fact_extractor=fact_extractor,
+        )
+
+        event = MinionEvent(
+            event_id="e4",
+            minion_id="test-minion",
+            event_type="payment",
+            payload={"merchant_name": "Tesco", "amount": 12.5},
+        )
+
+        await service.handle_event(event)
+
+        fact_extractor.extract_from_event_type.assert_called_once_with(
+            "payment", event.payload
+        )
+
+    @pytest.mark.asyncio
     async def test_batch_events_processed(self, service):
         """Batch events are processed correctly."""
         from cortex.minions.models import EventType
@@ -189,68 +263,6 @@ class TestMinionService:
         processed = await service.handle_batch(batch)
 
         assert processed is not None  # Should return processed events
-
-
-class TestMinionEventHandler:
-    """Tests for MinionEventProcessor."""
-
-    @pytest.fixture
-    def processor(self):
-        """Create a processor with mocked dependencies."""
-        from cortex.services.minion_service import MinionEventProcessor
-        mock_bus = MagicMock()
-        return MinionEventProcessor(event_bus=mock_bus)
-
-    @pytest.mark.asyncio
-    async def test_process_location_event(self, processor):
-        """Location events are processed correctly."""
-        from cortex.minions.models import EventType
-        event = MinionEvent(
-            event_id="event-1",
-            minion_id="minion-1",
-            event_type=EventType.LOCATION_UPDATE,
-            payload={
-                "latitude": 37.7749,
-                "longitude": -122.4194,
-                "accuracy": 10.0,
-                "place": "coffee_shop"
-            }
-        )
-
-        await processor.handle_event(event)
-
-    @pytest.mark.asyncio
-    async def test_process_activity_event(self, processor):
-        """Activity events are processed correctly."""
-        from cortex.minions.models import EventType
-        event = MinionEvent(
-            event_id="event-2",
-            minion_id="minion-1",
-            event_type=EventType.ACTIVITY_DETECTED,
-            payload={
-                "activity": "driving",
-                "confidence": 0.85
-            }
-        )
-
-        await processor.handle_event(event)
-
-    @pytest.mark.asyncio
-    async def test_process_batch(self, processor):
-        """Batch events are processed."""
-        from cortex.minions.models import EventType
-        batch = MinionEventBatch(
-            batch_id="batch-123",
-            minion_id="minion-1",
-            events=[
-                MinionEvent(event_id="e1", minion_id="test", event_type=EventType.LOCATION_UPDATE, payload={}),
-                MinionEvent(event_id="e2", minion_id="test", event_type=EventType.BATTERY_LEVEL, payload={"level": 80}),
-            ]
-        )
-
-        results = await processor.handle_batch(batch)
-
-        assert len(results) == 2
 
 
 class TestMinionConfig:

--- a/tests/unit/test_minions.py
+++ b/tests/unit/test_minions.py
@@ -384,6 +384,17 @@ class TestMinionInterfaces:
         assert EventType.HEARTBEAT.value == "minion.heartbeat"
         assert EventType.LOCATION_UPDATE.value == "location.update"
 
+    def test_payment_and_call_log_event_types(self):
+        """Test payment/call_log event types construct via MQTT path."""
+        event = MinionEvent.create(
+            minion_id="m",
+            event_type="payment",
+            payload={},
+        )
+        assert event.event_type == EventType.PAYMENT
+        assert EventType("payment") is EventType.PAYMENT
+        assert EventType("call_log") is EventType.CALL_LOG
+
 
 class TestPostgresMinionRegistry:
     """Tests for Postgres-backed MinionRegistry."""


### PR DESCRIPTION
## Summary

Implements #20 — extract the ingestion pipeline into a standalone `FactExtractor` (ADR-0003 split).

## Changes

- **`src/cortex/memory/fact_extractor.py` (new)** — concrete `FactExtractor`:
  - `extract_from_event(event: BaseEvent) -> list[Fact]` — delegates to `extract_from_event_type`
  - `extract_from_event_type(event_type, payload) -> list[Fact]` — public dispatch on the six sensory types (`location`, `payment`, `activity`, `calendar`, `call_log`, `app_usage`); unknown → `[]`
  - `extract_from_text(text) -> list[Fact]` — LLM-powered, JSON-parse hardened (ValueError contract)
- **`memory/interfaces.py`** — `FactExtractor` ABC updated to the new contract
- **`memory/models.py`** — `FactType.PAYMENT / CALL_LOG / APP_USAGE`
- **`minions/models.py`** — `EventType.PAYMENT / CALL_LOG` so MQTT events reach the pipeline (previously `MinionEvent.create("payment")` raised and events were dropped)
- **`services/minion_service.py`** — `MinionService` is now a `MinionEventHandler` (subscribes itself); `handle_event` translates dotted `EventType` values to the sensory vocabulary (`location.update` → `location`, …) and delegates extraction to `FactExtractor`; the dead internal `MinionEventProcessor` and private `memory_service._extract_*_facts` calls are removed
- **`services/memory_service.py`** — `handle_event` delegates to its configured `FactExtractor`; duplicate `_extract_*_facts` rules deleted
- **`main.py`** — wires `FactExtractor(llm_client=cortex.llm_client)` into both services
- **Tests** — `tests/memory/test_fact_extractor.py` (new) + MinionService/MemoryService wiring tests
- **CI** — `tests/memory` added to the pytest and coverage jobs

## Verification

- `uv run pytest tests/unit tests/learning tests/memory -q` → 618 passed
- `uv run ruff check src tests` → clean
- `uv run mypy src` → strict clean (99 files)
- Two-axis review (Standards + Spec) across 4 rounds → zero actionable findings

## Follow-ups (out of scope, pre-existing)

- `MinionEvent.create` still coerces unknown wire types via `EventType(...)` — the broader dotted-vs-plain vocabulary debt (`screen_activity`, `application_focus`, …) is untouched.
- The `minions/event_handler.MinionEventProcessor` sibling (with a working type map) remains unwired — not part of this issue.
