### PR TITLE
feat: extract FactStore CRUD layer (#19)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1895,7 +1895,7 @@ Database:
 **Internal Components:**
 ```python
 MemoryService             # Service API (query, store, search)
-FactStore                # Postgres client for facts/concepts
+FactStore                # pure CRUD seam over FactRepository: dedup-on-write by symbolic_repr, session-scoped listing; MemoryService delegates CRUD to it
 FactExtractor           # rule-based: raw events (location/payment/activity/calendar/call_log/app_usage) -> facts via extract_from_event_type
                         # LLM-powered: free text -> facts via extract_from_text; MinionService & MemoryService.handle_event delegate to it
 LogicEngine             # PyDatalog — validates LLM reasoning, checks consistency

--- a/src/cortex/memory/__init__.py
+++ b/src/cortex/memory/__init__.py
@@ -1,4 +1,5 @@
 """Memory module types and models."""
+from .fact_store import FactStore
 from .models import (
     Concept,
     ConfidenceLevel,
@@ -8,6 +9,7 @@ from .models import (
 )
 
 __all__ = [
+    "FactStore",
     "Fact",
     "Concept",
     "FactType",

--- a/src/cortex/memory/fact_store.py
+++ b/src/cortex/memory/fact_store.py
@@ -1,0 +1,82 @@
+"""Pure CRUD layer for facts.
+
+FactStore wraps a FactRepository and owns the dedup-on-write rule.
+No LLM calls, no event bus subscriptions, no concept cascade.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from uuid import UUID
+
+from cortex.memory.interfaces import FactRepository
+from cortex.memory.models import Fact, FactMutability, FactType
+
+logger = logging.getLogger(__name__)
+
+_LIST_LIMIT = 500
+
+
+class FactStore:
+    """Pure CRUD for facts. No LLM, no event bus, no concept cascade."""
+
+    def __init__(self, fact_repository: FactRepository) -> None:
+        self._fact_repo = fact_repository
+
+    async def add_fact(self, fact: Fact) -> Fact:
+        """
+        Store a fact, deduplicating by symbolic representation.
+
+        An existing active fact with the same symbolic_repr is updated in
+        place. The gate is the EXISTING fact's mutability: when the stored
+        fact is STATIC, the existing fact is returned unchanged (no
+        duplicate insert, no overwrite).
+        """
+        existing = await self._fact_repo.get_by_symbolic_repr(fact.symbolic_repr)
+        if existing:
+            if existing.mutability != FactMutability.STATIC:
+                fact_updated = await self._fact_repo.update(
+                    existing.id,
+                    {
+                        "natural_lang_repr": fact.natural_lang_repr,
+                        "payload": fact.payload,
+                        "confidence": fact.confidence,
+                    },
+                )
+                if not fact_updated:
+                    logger.warning("Fact update not return the new fact")
+                    raise Exception("Fact update not return the new fact")
+                return fact_updated
+            # Static facts don't get updated
+            return existing
+
+        return await self._fact_repo.store(fact)
+
+    async def get_fact(self, fact_id: UUID) -> Fact | None:
+        """Get a fact by ID."""
+        return await self._fact_repo.get(fact_id)
+
+    async def update_fact(self, fact_id: UUID, updates: dict[str, Any]) -> Fact | None:
+        """Update a fact's fields."""
+        return await self._fact_repo.update(fact_id, updates)
+
+    async def retract_fact(self, fact_id: UUID, reason: str | None = None) -> bool:
+        """Soft-delete a fact. Returns True when the fact existed."""
+        existing = await self._fact_repo.get(fact_id)
+        if existing is None:
+            return False
+        await self._fact_repo.retract(fact_id, reason)
+        return True
+
+    async def list_facts(self, session_id: UUID, fact_type: FactType | None = None) -> list[Fact]:
+        """List facts for a session, optionally filtered by fact type.
+
+        The session filter is applied in the repository so the row limit
+        applies after filtering (no in-memory truncation).
+        """
+        return await self._fact_repo.list_by_session(
+            session_id=session_id,
+            fact_type=fact_type,
+            limit=_LIST_LIMIT,
+        )

--- a/src/cortex/memory/interfaces.py
+++ b/src/cortex/memory/interfaces.py
@@ -139,6 +139,29 @@ class FactRepository(ABC):
         ...
 
     @abstractmethod
+    async def list_by_session(
+        self,
+        session_id: UUID,
+        fact_type: FactType | None = None,
+        *,
+        limit: int = 100,
+    ) -> list[Fact]:
+        """
+        List active facts for a session, optionally filtered by type.
+
+        The session filter is applied before any row limit.
+
+        Args:
+            session_id: The session's UUID.
+            fact_type: Optional fact type to filter by.
+            limit: Maximum number of results.
+
+        Returns:
+            Active facts for the session.
+        """
+        ...
+
+    @abstractmethod
     async def record_access(self, fact_id: UUID) -> None:
         """
         Record that a fact was accessed.

--- a/src/cortex/memory/repository.py
+++ b/src/cortex/memory/repository.py
@@ -181,6 +181,34 @@ class PostgresFactRepository(FactRepository):
             )
             return [self._row_to_fact(row) for row in rows]
 
+    async def list_by_session(
+        self,
+        session_id: UUID,
+        fact_type: FactType | None = None,
+        *,
+        limit: int = 100,
+    ) -> list[Fact]:
+        """List active facts for a session, optionally filtered by type."""
+        type_filter = ""
+        params: list[Any] = [str(session_id), limit]
+        if fact_type is not None:
+            type_filter = "AND type = $2"
+            params.insert(1, fact_type.value if hasattr(fact_type, "value") else fact_type)
+        async with DbSession() as db:
+            rows = await db.fetch(
+                f"""
+                SELECT id, type, mutability, symbolic_repr, natural_lang_repr,
+                       payload, confidence, created_at, retracted_at,
+                       last_accessed_at, access_count
+                FROM facts
+                WHERE payload->>'session_id' = $1 AND retracted_at IS NULL {type_filter}
+                ORDER BY created_at DESC
+                LIMIT ${len(params)}
+                """,
+                *params,
+            )
+            return [self._row_to_fact(row) for row in rows]
+
     async def record_access(self, fact_id: UUID) -> None:
         """Record that a fact was accessed."""
         async with DbSession() as db:

--- a/src/cortex/services/memory_service.py
+++ b/src/cortex/services/memory_service.py
@@ -7,8 +7,9 @@ from typing import Any
 from uuid import UUID
 
 from cortex.agentic.models import AmbientContext, MemoryContext, PersonalityContext
+from cortex.memory.fact_store import FactStore
 from cortex.memory.interfaces import ConceptRepository, FactExtractor, FactRepository
-from cortex.memory.models import Concept, Fact, FactMutability, FactType
+from cortex.memory.models import Concept, Fact, FactType
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +34,7 @@ class MemoryService:
         llm_client: Any | None = None,
     ):
         self._fact_repo = fact_repository
+        self._fact_store = FactStore(fact_repository)
         self._extractor = fact_extractor
         self._concept_repo = concept_repository
         self._event_bus = event_bus
@@ -47,38 +49,27 @@ class MemoryService:
         """
         Store a new fact.
 
-        Handles deduplication by checking for existing facts with
-        the same symbolic representation.
+        Deduplication by symbolic representation is handled by FactStore.
         """
-        # Check for existing fact
-        existing = await self._fact_repo.get_by_symbolic_repr(fact.symbolic_repr)
-        if existing:
-            # Update existing instead
-            if fact.mutability != FactMutability.STATIC:
-                fact_updated = await self._fact_repo.update(existing.id, fact.to_dict())
-                if not fact_updated:
-                    logger.warning("Fact update not return the new fact")
-                    raise Exception("Fact update not return the new fact")
-                return fact_updated
-            # Static facts don't get updated
-
-        return await self._fact_repo.store(fact)
+        return await self._fact_store.add_fact(fact)
 
     async def store_batch(self, facts: list[Fact]) -> list[Fact]:
-        """Store multiple facts in a batch."""
-        return await self._fact_repo.store_batch(facts)
+        """Store multiple facts (dedup applied per fact)."""
+        return [await self._fact_store.add_fact(fact) for fact in facts]
 
-    async def retract_fact(self, fact_id: UUID, reason: str | None = None) -> None:
+    async def retract_fact(self, fact_id: UUID, reason: str | None = None) -> bool:
         """
         Retract a fact (soft delete).
 
         Also invalidates any concepts that depend on this fact.
         """
-        await self._fact_repo.retract(fact_id, reason)
+        deleted = await self._fact_store.retract_fact(fact_id, reason)
 
         # Cascade to concepts
         if self._concept_repo:
             await self._concept_repo.invalidate_from_fact(fact_id)
+
+        return deleted
 
     # ─── Bundle Seam ─────────────────────────────────────────────────────
 

--- a/tests/memory/test_fact_store.py
+++ b/tests/memory/test_fact_store.py
@@ -1,0 +1,272 @@
+"""Tests for FactStore."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cortex.memory.fact_store import FactStore
+from cortex.memory.interfaces import FactRepository
+from cortex.memory.models import Fact, FactMutability, FactType
+
+
+class TestFactStoreCRUD:
+    """CRUD operations delegate to the underlying repository."""
+
+    @pytest.fixture
+    def repo(self):
+        """Create a mock fact repository."""
+        repo = MagicMock(spec=FactRepository)
+        repo.get_by_symbolic_repr = AsyncMock(return_value=None)
+        return repo
+
+    @pytest.fixture
+    def store(self, repo):
+        """Create a FactStore over the mock repository."""
+        return FactStore(repo)
+
+    @pytest.mark.asyncio
+    async def test_add_fact_stores_and_returns(self, store, repo):
+        """add_fact stores a new fact and returns it."""
+        fact = Fact(symbolic_repr="location.home", natural_lang_repr="At home")
+        repo.store.return_value = fact
+
+        result = await store.add_fact(fact)
+
+        repo.get_by_symbolic_repr.assert_awaited_once_with("location.home")
+        repo.store.assert_awaited_once_with(fact)
+        assert result == fact
+
+    @pytest.mark.asyncio
+    async def test_get_fact_returns_repo_get(self, store, repo):
+        """get_fact delegates to the repository."""
+        fact_id = uuid4()
+        fact = Fact(id=fact_id, symbolic_repr="location.home")
+        repo.get.return_value = fact
+
+        result = await store.get_fact(fact_id)
+
+        repo.get.assert_awaited_once_with(fact_id)
+        assert result == fact
+
+    @pytest.mark.asyncio
+    async def test_get_fact_missing_returns_none(self, store, repo):
+        """get_fact returns None when the fact does not exist."""
+        fact_id = uuid4()
+        repo.get.return_value = None
+
+        result = await store.get_fact(fact_id)
+
+        repo.get.assert_awaited_once_with(fact_id)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_update_fact_delegates(self, store, repo):
+        """update_fact passes updates through to the repository."""
+        fact_id = uuid4()
+        updates = {"natural_lang_repr": "Updated", "confidence": 0.9}
+        updated = Fact(id=fact_id, natural_lang_repr="Updated", confidence=0.9)
+        repo.update.return_value = updated
+
+        result = await store.update_fact(fact_id, updates)
+
+        repo.update.assert_awaited_once_with(fact_id, updates)
+        assert result == updated
+
+    @pytest.mark.asyncio
+    async def test_retract_fact_returns_true_when_exists(self, store, repo):
+        """retract_fact retracts an existing fact and returns True."""
+        fact_id = uuid4()
+        repo.get.return_value = Fact(id=fact_id)
+
+        result = await store.retract_fact(fact_id, reason="Outdated")
+
+        repo.get.assert_awaited_once_with(fact_id)
+        repo.retract.assert_awaited_once_with(fact_id, "Outdated")
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_retract_fact_returns_false_when_missing(self, store, repo):
+        """retract_fact returns False and does not retract a missing fact."""
+        fact_id = uuid4()
+        repo.get.return_value = None
+
+        result = await store.retract_fact(fact_id, reason="Outdated")
+
+        repo.get.assert_awaited_once_with(fact_id)
+        repo.retract.assert_not_called()
+        assert result is False
+
+
+class TestFactStoreDedup:
+    """add_fact deduplicates by symbolic representation."""
+
+    @pytest.fixture
+    def repo(self):
+        """Create a mock fact repository."""
+        return MagicMock(spec=FactRepository)
+
+    @pytest.fixture
+    def store(self, repo):
+        """Create a FactStore over the mock repository."""
+        return FactStore(repo)
+
+    @pytest.mark.asyncio
+    async def test_mutable_duplicate_updates_existing(self, store, repo):
+        """A mutable fact with an existing symbolic_repr updates the existing fact."""
+        existing = Fact(
+            id=uuid4(),
+            symbolic_repr="location.home",
+            mutability=FactMutability.MUTABLE,
+        )
+        repo.get_by_symbolic_repr.return_value = existing
+        updated = Fact(
+            id=existing.id,
+            symbolic_repr="location.home",
+            natural_lang_repr="At work now",
+            payload={"place": "work"},
+            confidence=0.9,
+        )
+        repo.update.return_value = updated
+
+        fact = Fact(
+            symbolic_repr="location.home",
+            natural_lang_repr="At work now",
+            payload={"place": "work"},
+            confidence=0.9,
+        )
+        result = await store.add_fact(fact)
+
+        repo.store.assert_not_called()
+        repo.update.assert_awaited_once_with(
+            existing.id,
+            {
+                "natural_lang_repr": "At work now",
+                "payload": {"place": "work"},
+                "confidence": 0.9,
+            },
+        )
+        assert result == updated
+
+    @pytest.mark.asyncio
+    async def test_static_duplicate_returns_existing_without_insert(self, store, repo):
+        """A STATIC fact with an existing symbolic_repr returns it without inserting."""
+        existing = Fact(
+            id=uuid4(),
+            symbolic_repr="user.birthdate",
+            mutability=FactMutability.STATIC,
+            natural_lang_repr="Born 1990",
+        )
+        repo.get_by_symbolic_repr.return_value = existing
+
+        fact = Fact(
+            symbolic_repr="user.birthdate",
+            mutability=FactMutability.STATIC,
+            natural_lang_repr="Born 1990",
+        )
+        result = await store.add_fact(fact)
+
+        repo.store.assert_not_called()
+        repo.update.assert_not_called()
+        assert result == existing
+
+    @pytest.mark.asyncio
+    async def test_existing_static_with_mutable_incoming_returns_existing(self, store, repo):
+        """An incoming MUTABLE fact does not overwrite an existing STATIC fact."""
+        existing = Fact(
+            id=uuid4(),
+            symbolic_repr="user.birthdate",
+            mutability=FactMutability.STATIC,
+            natural_lang_repr="Born 1990",
+        )
+        repo.get_by_symbolic_repr.return_value = existing
+
+        fact = Fact(
+            symbolic_repr="user.birthdate",
+            mutability=FactMutability.MUTABLE,
+            natural_lang_repr="Born 1991",
+            payload={"year": 1991},
+        )
+        result = await store.add_fact(fact)
+
+        repo.update.assert_not_called()
+        repo.store.assert_not_called()
+        assert result == existing
+
+    @pytest.mark.asyncio
+    async def test_mutable_duplicate_update_failure_raises(self, store, repo):
+        """A failed update of an existing mutable fact raises."""
+        existing = Fact(id=uuid4(), symbolic_repr="location.home")
+        repo.get_by_symbolic_repr.return_value = existing
+        repo.update.return_value = None
+
+        with pytest.raises(Exception, match="Fact update not return the new fact"):
+            await store.add_fact(Fact(symbolic_repr="location.home"))
+
+
+class TestFactStoreListFacts:
+    """list_facts delegates session-filtering to the repository."""
+
+    @pytest.fixture
+    def repo(self):
+        """Create a mock fact repository."""
+        return MagicMock(spec=FactRepository)
+
+    @pytest.fixture
+    def store(self, repo):
+        """Create a FactStore over the mock repository."""
+        return FactStore(repo)
+
+    @pytest.mark.asyncio
+    async def test_list_facts_delegates_to_repo(self, store, repo):
+        """list_facts delegates to repo.list_by_session with session and limit."""
+        session_id = uuid4()
+        facts = [
+            Fact(symbolic_repr="fact.a", payload={"session_id": str(session_id)}),
+        ]
+        repo.list_by_session.return_value = facts
+
+        result = await store.list_facts(session_id)
+
+        repo.list_by_session.assert_awaited_once_with(
+            session_id=session_id, fact_type=None, limit=500
+        )
+        assert result == facts
+
+    @pytest.mark.asyncio
+    async def test_list_facts_passes_fact_type(self, store, repo):
+        """list_facts with a fact_type passes it through to repo.list_by_session."""
+        session_id = uuid4()
+        facts = [
+            Fact(
+                type=FactType.PAYMENT,
+                symbolic_repr="payment.tesco",
+                payload={"session_id": str(session_id)},
+            ),
+        ]
+        repo.list_by_session.return_value = facts
+
+        result = await store.list_facts(session_id, FactType.PAYMENT)
+
+        repo.list_by_session.assert_awaited_once_with(
+            session_id=session_id, fact_type=FactType.PAYMENT, limit=500
+        )
+        assert result == facts
+
+    @pytest.mark.asyncio
+    async def test_list_facts_returns_all_repo_facts(self, store, repo):
+        """list_facts returns every fact the repository returns — no in-memory truncation."""
+        session_id = uuid4()
+        facts = [
+            Fact(symbolic_repr=f"fact.{i}", payload={"session_id": str(session_id)})
+            for i in range(600)
+        ]
+        repo.list_by_session.return_value = facts
+
+        result = await store.list_facts(session_id)
+
+        repo.list_by_session.assert_awaited_once_with(
+            session_id=session_id, fact_type=None, limit=500
+        )
+        assert len(result) == 600
+        assert result == facts

--- a/tests/unit/services/test_memory_service.py
+++ b/tests/unit/services/test_memory_service.py
@@ -222,22 +222,27 @@ class TestMemoryService:
     async def test_retract_fact(self, service, mock_fact_repo):
         """Retracting a fact calls repository."""
         fact_id = uuid4()
+        mock_fact_repo.get.return_value = Fact()
 
-        await service.retract_fact(fact_id, reason="Outdated")
+        result = await service.retract_fact(fact_id, reason="Outdated")
 
+        mock_fact_repo.get.assert_awaited_once_with(fact_id)
         mock_fact_repo.retract.assert_called_once_with(fact_id, "Outdated")
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_retract_cascades_to_concepts(self, service, mock_fact_repo):
         """Retracting a fact invalidates derived concepts."""
         fact_id = uuid4()
+        mock_fact_repo.get.return_value = Fact()
         concept_repo = MagicMock()
         concept_repo.invalidate_from_fact = AsyncMock()
         service._concept_repo = concept_repo
 
-        await service.retract_fact(fact_id)
+        result = await service.retract_fact(fact_id)
 
         concept_repo.invalidate_from_fact.assert_called_once_with(fact_id)
+        assert result is True
 
     @pytest.mark.asyncio
     async def test_get_personality_context_returns_facts(self, service, mock_fact_repo):
@@ -318,15 +323,19 @@ class TestMemoryService:
 
     @pytest.mark.asyncio
     async def test_store_batch(self, service, mock_fact_repo):
-        """Store batch stores multiple facts."""
+        """Store batch stores multiple facts with dedup applied per fact."""
         facts = [
             Fact(symbolic_repr="fact.1", natural_lang_repr="Fact 1"),
             Fact(symbolic_repr="fact.2", natural_lang_repr="Fact 2"),
         ]
+        mock_fact_repo.get_by_symbolic_repr.return_value = None
+        mock_fact_repo.store.side_effect = lambda f: f
 
-        await service.store_batch(facts)
+        stored = await service.store_batch(facts)
 
-        mock_fact_repo.store_batch.assert_called_once_with(facts)
+        mock_fact_repo.store_batch.assert_not_called()
+        assert mock_fact_repo.store.call_count == 2
+        assert stored == facts
 
     @pytest.mark.asyncio
     async def test_build_concept_from_facts(self, service):


### PR DESCRIPTION
## Summary

Implements #19 — extract the CRUD layer into a standalone `FactStore` (ADR-0003 split, ticket 2/3).

## Changes

- **`src/cortex/memory/fact_store.py` (new)** — pure CRUD over `FactRepository`:
  - `add_fact(fact)` — dedup-on-write by `symbolic_repr`: mutable existing → updated in place; stored STATIC facts returned unchanged (no duplicate insert — fixes a latent duplicate-row bug in the old `store_fact`); else insert
  - `get_fact(id)`, `update_fact(id, updates)`, `retract_fact(id, reason) -> bool` (soft delete, `False` when missing), `list_facts(session_id, fact_type=None)` — session-scoped listing
  - No LLM, no event bus, no concept cascade
- **`memory/interfaces.py` + `repository.py`** — new `FactRepository.list_by_session` ABC method + Postgres impl (session filter `payload->>'session_id'` applied before `LIMIT` — no silent truncation)
- **`services/memory_service.py`** — `store_fact`/`store_batch`/`retract_fact` delegate to an internally composed `FactStore`; constructor unchanged; queries stay on the repo until ContextProvider (#21); concept cascade retained until #21
- **Tests** — `tests/memory/test_fact_store.py` (13 tests: CRUD, dedup incl. static-protection, session/type listing) + MemoryService delegation tests

## Verification

- `uv run pytest tests/unit tests/learning tests/memory -q` → 631 passed
- `uv run ruff check src tests` → clean; `uv run mypy src` → strict clean (100 files)
- Two-axis review (Standards + Spec) → zero actionable findings
