### PR TITLE
feat: minimal web UI for Cortex (#71)

### DIFF
--- a/src/cortex/api/main.py
+++ b/src/cortex/api/main.py
@@ -5,11 +5,13 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 from cortex.api.dependencies import set_app_state
 from cortex.api.routes import (
@@ -103,6 +105,11 @@ def create_api_app() -> FastAPI:
             "version": settings.version,
             "docs": "/docs",
         }
+
+    # Minimal web UI (single self-contained page, no build step)
+    static_dir = Path(__file__).resolve().parent / "static"
+    if static_dir.is_dir():
+        app.mount("/ui", StaticFiles(directory=static_dir, html=True), name="ui")
 
     return app
 

--- a/src/cortex/api/static/index.html
+++ b/src/cortex/api/static/index.html
@@ -1,0 +1,326 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Cortex</title>
+<style>
+  :root {
+    --bg: #0b0e13;
+    --surface: #12161d;
+    --border: #1f2530;
+    --text: #e6e9ef;
+    --muted: #8b93a3;
+    --accent: #5eead4;
+    --accent-dim: #123b36;
+    --danger: #f87171;
+    --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  html, body { height: 100%; }
+  body {
+    background: var(--bg);
+    color: var(--text);
+    font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Inter, sans-serif;
+    display: flex;
+    flex-direction: column;
+    -webkit-font-smoothing: antialiased;
+  }
+  header {
+    display: flex; align-items: center; gap: 12px;
+    padding: 12px 20px;
+    border-bottom: 1px solid var(--border);
+    background: var(--surface);
+  }
+  .brand { font-weight: 650; letter-spacing: .02em; }
+  .brand span { color: var(--accent); }
+  .spacer { flex: 1; }
+  .status { display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); }
+  .dot { width: 7px; height: 7px; border-radius: 50%; background: #3a4254; }
+  .dot.on { background: var(--accent); box-shadow: 0 0 6px var(--accent); }
+  .token {
+    background: transparent; color: var(--muted); font-family: var(--mono); font-size: 12px;
+    border: 1px solid var(--border); border-radius: 8px; padding: 5px 10px; width: 210px; outline: none;
+  }
+  .token:focus { border-color: #2c3547; color: var(--text); }
+  button {
+    background: transparent; color: var(--muted); border: 1px solid var(--border); border-radius: 8px;
+    padding: 6px 12px; font-size: 13px; cursor: pointer; transition: color .15s, border-color .15s;
+  }
+  button:hover { color: var(--text); border-color: #2c3547; }
+  button:disabled { opacity: .4; cursor: default; }
+  #chat {
+    flex: 1; overflow-y: auto; padding: 28px 20px;
+    scroll-behavior: smooth;
+  }
+  .inner { max-width: 760px; margin: 0 auto; display: flex; flex-direction: column; gap: 18px; }
+  .msg { max-width: 82%; padding: 10px 14px; border-radius: 12px; white-space: pre-wrap; overflow-wrap: anywhere; }
+  .msg.user { align-self: flex-end; background: var(--accent-dim); color: #d9fbf3; border-bottom-right-radius: 4px; }
+  .msg.assistant { align-self: flex-start; background: var(--surface); border: 1px solid var(--border); border-bottom-left-radius: 4px; }
+  .msg.error { align-self: flex-start; background: rgba(248,113,113,.08); border: 1px solid rgba(248,113,113,.35); color: var(--danger); }
+  .msg.assistant.streaming::after {
+    content: "▍"; color: var(--accent); animation: blink 1s steps(2) infinite;
+  }
+  @keyframes blink { 50% { opacity: 0; } }
+  .thinking { align-self: flex-start; color: var(--muted); font-size: 13px; font-style: italic; display: flex; gap: 6px; align-items: center; }
+  .thinking .tick { display: inline-flex; gap: 3px; }
+  .thinking .tick i { width: 4px; height: 4px; border-radius: 50%; background: var(--muted); animation: bounce 1.2s infinite; }
+  .thinking .tick i:nth-child(2) { animation-delay: .2s; } .thinking .tick i:nth-child(3) { animation-delay: .4s; }
+  @keyframes bounce { 0%,100% { opacity: .25; transform: translateY(0); } 50% { opacity: 1; transform: translateY(-2px); } }
+  .tools { align-self: flex-start; display: flex; flex-wrap: wrap; gap: 6px; }
+  .tool {
+    font-size: 12px; font-family: var(--mono); color: var(--muted);
+    border: 1px solid var(--border); border-radius: 999px; padding: 3px 10px;
+  }
+  .tool.ok { color: var(--accent); border-color: rgba(94,234,212,.3); }
+  .tool.fail { color: var(--danger); border-color: rgba(248,113,113,.3); }
+  .tool pre { display: none; }
+  footer { border-top: 1px solid var(--border); background: var(--surface); padding: 12px 20px 16px; }
+  .bar { max-width: 760px; margin: 0 auto; display: flex; gap: 10px; align-items: flex-end; }
+  textarea {
+    flex: 1; resize: none; background: var(--bg); color: var(--text); font: inherit;
+    border: 1px solid var(--border); border-radius: 12px; padding: 11px 14px; outline: none;
+    max-height: 160px; line-height: 1.45;
+  }
+  textarea:focus { border-color: #2c3547; }
+  textarea::placeholder { color: #4d5566; }
+  .send {
+    background: var(--accent-dim); color: #bdf5e8; border: 1px solid rgba(94,234,212,.35);
+    border-radius: 12px; padding: 11px 18px; font-weight: 600;
+  }
+  .send:hover { background: #17483f; color: #d9fbf3; }
+  .hint { max-width: 760px; margin: 8px auto 0; font-size: 11.5px; color: #4d5566; text-align: center; }
+  .empty { align-self: center; color: #4d5566; text-align: center; padding: 40px 0; }
+  .empty h2 { font-weight: 600; font-size: 18px; color: var(--muted); margin-bottom: 6px; }
+  #banner {
+    display: none; max-width: 760px; margin: 12px auto 0; padding: 8px 12px;
+    background: rgba(248,113,113,.1); border: 1px solid rgba(248,113,113,.3); color: var(--danger);
+    border-radius: 10px; font-size: 13px;
+  }
+</style>
+</head>
+<body>
+<header>
+  <div class="brand">Cort<span>ex</span></div>
+  <div class="spacer"></div>
+  <div class="status"><span class="dot" id="dot"></span><span id="stext">offline</span></div>
+  <input class="token" id="token" type="password" placeholder="Bearer token…" autocomplete="off">
+  <button id="newbtn">Nuova sessione</button>
+</header>
+
+<div id="chat"><div class="inner" id="inner"></div></div>
+
+<footer>
+  <div class="bar">
+    <textarea id="input" rows="1" placeholder="Scrivi un messaggio… (Invio per inviare)" disabled></textarea>
+    <button class="send" id="send" disabled>Invia</button>
+  </div>
+  <div id="banner"></div>
+  <div class="hint" id="hint">Inserisci il token (crealo con <code>uv run cortex token:create &lt;nome&gt;</code>) per iniziare.</div>
+</footer>
+
+<script>
+"use strict";
+const $ = (id) => document.getElementById(id);
+const LS = {
+  get token() { return localStorage.getItem("cortex.token") || ""; },
+  set token(v) { v ? localStorage.setItem("cortex.token", v) : localStorage.removeItem("cortex.token"); },
+  get session() { return localStorage.getItem("cortex.session") || ""; },
+  set session(v) { v ? localStorage.setItem("cortex.session", v) : localStorage.removeItem("cortex.session"); },
+};
+
+const inner = $("inner"), input = $("input"), sendBtn = $("send"), banner = $("banner");
+let busy = false;
+let toolChips = []; // {el, count} current turn's tool chips
+
+function setStatus(on, text) { $("dot").classList.toggle("on", on); $("stext").textContent = text; }
+function showBanner(msg) { if (!msg) { banner.style.display = "none"; return; } banner.textContent = msg; banner.style.display = "block"; }
+function esc(s) { const d = document.createElement("div"); d.textContent = s; return d.innerHTML; }
+
+function addMsg(cls, text) {
+  const el = document.createElement("div");
+  el.className = "msg " + cls;
+  el.textContent = text;
+  inner.appendChild(el);
+  scroll();
+  return el;
+}
+function scroll() { $("chat").scrollTop = $("chat").scrollHeight; }
+
+function addThinking() {
+  const el = document.createElement("div");
+  el.className = "thinking";
+  el.innerHTML = '<span class="tick"><i></i><i></i><i></i></span> <span>sto pensando…</span>';
+  inner.appendChild(el); scroll();
+  return el;
+}
+
+function addTool(name, ok, out) {
+  const wrap = toolChips.length ? toolChips[toolChips.length - 1].wrap : null;
+  const chip = document.createElement("span");
+  chip.className = "tool " + (ok ? "ok" : "fail");
+  chip.textContent = (ok ? "✓ " : "✗ ") + name;
+  if (out) { const pre = document.createElement("pre"); pre.textContent = out; chip.appendChild(pre); chip.title = out.slice(0, 300); }
+  if (wrap) wrap.appendChild(chip); else { const w = document.createElement("div"); w.className = "tools"; w.appendChild(chip); inner.appendChild(w); toolChips.push({ wrap: w }); }
+  scroll();
+}
+
+function renderHistory(messages) {
+  for (const m of messages) {
+    if (m.role === "user") addMsg("user", m.content);
+    else if (m.role === "assistant") addMsg("assistant", m.content);
+  }
+}
+
+function handleFrame(frame, assistantEl, thinkingEl, onDone) {
+  const ev = /^event: (.*)$/m.exec(frame)?.[1];
+  const dl = frame.split("\n").find((l) => l.startsWith("data: "));
+  if (!ev || !dl) return;
+  let data; try { data = JSON.parse(dl.slice(6)); } catch { return; }
+  switch (ev) {
+    case "thinking":
+      if (thinkingEl) thinkingEl.textContent = data.message || "sto pensando…";
+      break;
+    case "text":
+      if (thinkingEl) { thinkingEl.remove(); thinkingEl = null; }
+      assistantEl.classList.add("streaming");
+      assistantEl.textContent += data.delta || "";
+      scroll();
+      break;
+    case "tool_start":
+      if (thinkingEl) { thinkingEl.remove(); thinkingEl = null; }
+      break;
+    case "tool_done":
+      addTool(data.tool_name, !!data.success, data.error || (data.success ? "" : ""));
+      break;
+    case "done":
+      if (assistantEl.classList.contains("streaming")) assistantEl.classList.remove("streaming");
+      if (!assistantEl.textContent && data.final_message) assistantEl.textContent = data.final_message;
+      onDone();
+      break;
+    case "error":
+      if (thinkingEl) thinkingEl.remove();
+      assistantEl.remove();
+      addMsg("error", data.error || "Errore sconosciuto");
+      onDone();
+      break;
+  }
+}
+
+async function api(path, opts = {}) {
+  const res = await fetch(path, {
+    ...opts,
+    headers: { "Content-Type": "application/json", "Authorization": "Bearer " + LS.token, ...(opts.headers || {}) },
+  });
+  if (!res.ok) {
+    let detail = res.statusText;
+    try { const j = await res.json(); detail = (j.detail && (j.detail.detail || j.detail.error)) || JSON.stringify(j.detail || j); } catch {}
+    const err = new Error(detail);
+    err.status = res.status;
+    throw err;
+  }
+  return res;
+}
+
+async function ensureSession() {
+  if (LS.session) { try { await api("/sessions/" + LS.session); return; } catch (e) { if (e.status !== 404) throw e; } }
+  const res = await api("/sessions", { method: "POST" });
+  const s = await res.json();
+  LS.session = s.id;
+}
+
+async function send() {
+  const text = input.value.trim();
+  if (!text || busy) return;
+  showBanner("");
+  input.value = ""; autoSize();
+  addMsg("user", text);
+  const assistantEl = addMsg("assistant", "");
+  const thinkingEl = addThinking();
+  toolChips = [];
+  busy = true; setBusy(true);
+
+  try {
+    await ensureSession();
+    const res = await api("/chat/stream", {
+      method: "POST",
+      body: JSON.stringify({ message: text, session_id: LS.session || null }),
+    });
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buf = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buf += decoder.decode(value, { stream: true });
+      let idx;
+      while ((idx = buf.indexOf("\n\n")) >= 0) {
+        handleFrame(buf.slice(0, idx), assistantEl, thinkingEl, () => {});
+        buf = buf.slice(idx + 2);
+      }
+    }
+    if (thinkingEl) thinkingEl.remove();
+    if (!assistantEl.textContent) assistantEl.remove();
+  } catch (e) {
+    if (thinkingEl) thinkingEl.remove();
+    assistantEl.remove();
+    if (e.status === 404) { LS.session = ""; addMsg("error", "Sessione scaduta — riprova."); }
+    else addMsg("error", String(e.message || e));
+  } finally {
+    busy = false; setBusy(false);
+  }
+}
+
+function setBusy(b) { sendBtn.disabled = b || !LS.token; input.disabled = b; }
+
+function autoSize() { input.style.height = "auto"; input.style.height = Math.min(input.scrollHeight, 160) + "px"; }
+
+async function init() {
+  $("token").value = LS.token;
+  input.placeholder = LS.token ? "Scrivi un messaggio… (Invio per inviare)" : "Inserisci il token qui sopra per iniziare";
+  setBusy(false);
+  if (!LS.token) return;
+
+  // Health check
+  try {
+    const r = await fetch("/health");
+    const h = await r.json();
+    const ok = h.components && h.components.database && h.components.database.status === "healthy";
+    setStatus(ok, ok ? "connesso" : "health: " + JSON.stringify(h.components));
+  } catch { setStatus(false, "API non raggiungibile"); }
+
+  // Restore history
+  if (LS.session) {
+    try {
+      const r = await api("/sessions/" + LS.session);
+      const s = await r.json();
+      if (s.messages && s.messages.length) { $("empty") && $("empty").remove(); renderHistory(s.messages); }
+    } catch { LS.session = ""; }
+  }
+  if (!inner.children.length) showEmpty();
+}
+
+function showEmpty() {
+  const el = document.createElement("div");
+  el.className = "empty"; el.id = "empty";
+  el.innerHTML = "<h2>Ciao</h2>Chiedi qualcosa — Cortex ha memoria, strumenti e un loop agentico.";
+  inner.appendChild(el);
+}
+
+$("token").addEventListener("input", (e) => { LS.token = e.target.value.trim(); setBusy(false); });
+$("newbtn").addEventListener("click", async () => {
+  showBanner("");
+  inner.innerHTML = "";
+  LS.session = "";
+  if (LS.token) {
+    try { await ensureSession(); } catch (e) { showBanner(String(e.message || e)); }
+  }
+  showEmpty();
+});
+$("send").addEventListener("click", send);
+input.addEventListener("keydown", (e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); } });
+input.addEventListener("input", autoSize);
+init();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Implements #71 — minimal, aesthetically pleasing web UI for Cortex, fastest path: one self-contained HTML file, no build step, no dependencies.

## Changes

- **`src/cortex/api/static/index.html`** — single-file UI:
  - Dark minimal theme (system fonts, mint accent, no external assets)
  - Token input persisted in localStorage (Bearer auth)
  - Streaming chat over `/chat/stream` (SSE): thinking indicator, streaming text deltas, tool chips, error banner
  - Session lifecycle: auto-create via `POST /sessions`, persisted `session_id`, "Nuova sessione" button; best-effort history restore from `GET /sessions/{id}`
  - No framework, no build — works offline from a single file
- **`src/cortex/api/main.py`** — mounts the static dir at `/ui` (skipped gracefully when absent)

## Verification

- Booted cortex locally (Postgres + MQTT up): `/ui/` serves the page
- Browser round-trip: token stored, session auto-created + stored, streamed assistant response rendered ("Ciao! Sono Cortex, un assistente AI…"), thinking indicator cleared, send re-enabled
- Computed styles: bg `rgb(11,14,19)`, surface `rgb(18,22,29)`, accent `rgb(94,234,212)` — dark minimal theme confirmed
- `uv run pytest tests/unit tests/learning tests/memory -q` → 638 passed; ruff + mypy clean

## Note (out of scope)

Discovered during verification: chat messages are never persisted (`run_chat` has no `add_message` calls) — sessions come back empty, so multi-turn context is broken. Filed as #72.
