### PR TITLE
fix: markdown layout in chat bubbles (#80)

### DIFF
--- a/src/cortex/api/static/index.html
+++ b/src/cortex/api/static/index.html
@@ -62,6 +62,59 @@
     content: "▍"; color: var(--accent); animation: blink 1s steps(2) infinite;
   }
   @keyframes blink { 50% { opacity: 0; } }
+  /* --- Markdown elements inside assistant bubbles (issue #80) --- */
+  .msg.assistant pre {
+    max-width: 100%;
+    overflow-x: auto;
+    white-space: pre;
+    background: rgba(0,0,0,.35);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    font-family: var(--mono);
+    font-size: 12.5px;
+    line-height: 1.5;
+    padding: 10px 12px;
+    margin: 8px 0;
+  }
+  .msg.assistant code {
+    font-family: var(--mono);
+    font-size: .85em;
+    background: rgba(94,234,212,.08);
+    border-radius: 4px;
+    padding: 1px 5px;
+  }
+  .msg.assistant pre code {
+    background: transparent;
+    padding: 0;
+    border-radius: 0;
+    font-size: inherit;
+    white-space: pre;
+  }
+  .msg.assistant h1, .msg.assistant h2, .msg.assistant h3 {
+    font-weight: 500;
+    line-height: 1.3;
+    margin: 14px 0 6px;
+  }
+  .msg.assistant h1 { font-size: 17px; }
+  .msg.assistant h2 { font-size: 16px; }
+  .msg.assistant h3 { font-size: 15px; }
+  .msg.assistant h1:first-child, .msg.assistant h2:first-child, .msg.assistant h3:first-child { margin-top: 0; }
+  .msg.assistant p { margin: 6px 0; }
+  .msg.assistant p:last-child { margin-bottom: 0; }
+  .msg.assistant ul, .msg.assistant ol { margin: 6px 0; padding-left: 22px; }
+  .msg.assistant li { margin: 3px 0; }
+  .msg.assistant blockquote {
+    margin: 8px 0;
+    padding: 2px 12px;
+    border-left: 3px solid var(--accent);
+    color: var(--muted);
+  }
+  .msg.assistant a {
+    color: var(--accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  .msg.assistant a:hover { color: #a5f3e6; }
   .thinking { align-self: flex-start; color: var(--muted); font-size: 13px; font-style: italic; display: flex; gap: 6px; align-items: center; }
   .thinking .tick { display: inline-flex; gap: 3px; }
   .thinking .tick i { width: 4px; height: 4px; border-radius: 50%; background: var(--muted); animation: bounce 1.2s infinite; }


### PR DESCRIPTION
Fixes #80 — code-block overflow + unthemed markdown elements. `.msg.assistant pre` gets max-width:100% + overflow-x:auto (long lines scroll inside the bubble; verified: bubble scrollWidth == clientWidth, no page overflow); headings/lists/blockquote/links/code styled to the dark theme (mint links, accent-tinted inline code). User bubble untouched. Browser-verified independently.