### PR TITLE
docs: evidence-based fact confidence design (ADR-0013, system doc)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,8 @@ Canonical triage labels (needs-triage, needs-info, ready-for-agent, ready-for-hu
 ### Domain docs
 
 Single-context layout: one CONTEXT.md at the repo root + docs/adr/. See `docs/agents/domain.md`.
+### Evidence system
+
+The evidence-based fact confidence system is specified in `docs/evidence-system.md` — the
+single source of truth for its data model, update rule, constants, and invariants. Update
+that document whenever the evidence system changes (ADR-0013, issues #82/#83).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -50,3 +50,28 @@ _Avoid_: Stream adapter, SSE endpoint, chat stream
 **System Event**:
 An event published on the Cortex event bus for any module to consume (e.g. goal.created, concept.rejected). Distinct from LoopEvent: system events are system-wide domain information; LoopEvents are per-caller progress.
 _Avoid_: Domain event, bus event
+## Memory
+
+**Fact**:
+A unit of knowledge Cortex stores about the user and their world: a symbolic representation (`symbolic_repr`), a natural-language form, a confidence, a mutability, and a payload. Facts are observed directly, extracted from conversations, or derived.
+_Avoid_: memory item, knowledge unit, note
+
+**Confidence**:
+The posterior probability that a Fact is true, in [0, 1]. Computed by a Bayesian odds update over accumulated Evidence; pinned at 1.0 for Static Facts. Serves as the base of relevance ranking and the `min_confidence` retrieval threshold.
+_Avoid_: certainty, trust score, strength
+
+**Evidence**:
+An observation that updates a Fact's confidence — a sensory event, a user confirmation, or an LLM extraction touching the same symbolic representation. Carries a source type (sensor, user_confirm, llm), a strength (the confidence of the ingested fact), and a timestamp. Deduplicated per (source, source_id, fact) within a time window.
+_Avoid_: proof, confirmation, data point, supporting observation
+
+**EvidenceStore**:
+The module that records Evidence and recomputes Fact confidence through the Bayesian update. Owns the deduplication window and the likelihood-ratio constants.
+_Avoid_: confidence engine, scorer, confidence store
+
+**Likelihood ratio (LR)**:
+The per-source constant encoding how strongly a full-strength Evidence of that source moves a Fact's confidence — the calibration point of the Bayesian update.
+_Avoid_: weight, importance, source reliability
+
+**Static Fact**:
+An irrefutable fact (e.g. "born in Italy", 2+2=4): confidence pinned at 1.0, never accumulates Evidence, never retracted. The `FactMutability.STATIC` semantic.
+_Avoid_: immutable fact, axiom (as a storage term)

--- a/docs/adr/0013-evidence-based-fact-confidence.md
+++ b/docs/adr/0013-evidence-based-fact-confidence.md
@@ -1,0 +1,53 @@
+# Evidence-based fact confidence
+
+Cortex stored a fixed `confidence` on each fact: sensory events got hardcoded values
+(0.8–0.9), LLM extraction judged its own, and a repeated observation of the same fact
+overwrote the stored value (last-writer-wins) instead of corroborating it. Evidence never
+aged out and there was no provenance for "why does Cortex believe this?".
+
+We replaced this with a Bayesian evidence engine: every accepted observation of a fact is
+recorded as an Evidence row (source type, source id, strength, observed value, timestamp),
+and a fact's confidence is the posterior probability that its current value is true,
+computed over **active** evidence — evidence within the fact's mutability window whose
+observed value matches the current value. The update runs in logit space:
+
+```
+logit(p') = logit(p) + (2·strength − 1) · ln(LR_base(source_type))
+```
+
+with calibration constants `LR(user_confirm)=20`, `LR(sensor)=10`, `LR(llm)=3` and prior
+0.5 for every new fact. Evidence is deduplicated per `(source_type, source_id, fact_id,
+value_hash)` within 1 hour. The evidence window is per mutability: `EPHEMERAL=1 day`,
+`MUTABLE=6 months`, `SEMI_STATIC=5 years`, `STATIC=none`. STATIC facts are pinned at
+confidence 1.0, never record evidence, and cannot be retracted.
+
+Value-tagged evidence replaced a blunt "reset on value change" rule: when a fact's value
+changes, old evidence stops counting (it recorded a different value) but is not deleted —
+reverting the value restores it. This keeps the system robust to lies and relapses ("I quit
+coffee" is an intention, not proof that "I don't like coffee"; and liking coffee ≠ drinking
+coffee are distinct facts).
+
+A new `EvidenceStore` component owns the dedup, the update, and a periodic asyncio sweep
+that recomputes stored confidence for facts whose active evidence expired, keeping the
+stored confidence equal to the posterior over active evidence.
+
+Rejected alternatives:
+
+- **Reset-on-value-change** — destroys valid history and conflates a stated intention with
+  a changed truth (people lie, even to themselves).
+- **Running mean of observation confidences** — non-monotonic: more evidence doesn't imply
+  more certainty, which is the whole point of the system.
+- **Count-curve `conf = 1 − (1−p₀)·αⁿ`** — cannot distinguish source trustworthiness or
+  weakening evidence.
+- **Fixed LR per source, ignoring the extractor's confidence** — makes the LLM-judged
+  confidence meaningless.
+- **Lazy recompute at read** — breaks the SQL `ORDER BY confidence` retrieval path.
+- **Linear interpolation of LR** — invalid below strength 0.5 (produces negative LR);
+  inversion must happen in log space.
+
+Cross-fact contradictions (same predicate, different `symbolic_repr`) remain out of scope —
+LogicEngine territory, ADR-0007 (issue #27). The producer for STATIC facts (an LLM
+extraction flag, wired together with conversation extraction) is tracked as issue #82 and
+blocks the evidence engine, issue #83. The LR and window constants are the only magic
+numbers in the system; they are isolated and documented as the calibration point for the
+future Bayesian network proposed in `docs/FEATURES_TO_ADD.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -6,6 +6,7 @@ How the engineering skills should consume this repo's domain documentation when 
 
 - **`CONTEXT.md`** at the repo root
 - **`docs/adr/`** — read ADRs that touch the area you're about to work in
+- **`docs/evidence-system.md`** — when touching the Memory module or the evidence system
 
 If any of these files don't exist, **proceed silently**. Don't flag their absence.
 

--- a/docs/evidence-system.md
+++ b/docs/evidence-system.md
@@ -1,0 +1,122 @@
+# Evidence System
+
+> Single source of truth for the evidence-based fact confidence system.
+> **Update this document whenever the evidence system changes.**
+> Rationale: `docs/adr/0013-evidence-based-fact-confidence.md`. Vocabulary: `CONTEXT.md` (`## Memory`).
+> Work items: issues #82 (conversation extraction + STATIC producer) and #83 (evidence engine).
+
+## Purpose
+
+A Fact's confidence is the posterior probability that its current value is true, computed
+over accumulated Evidence. The more recent and trustworthy the supporting evidence, the
+higher the confidence. Irrefutable facts (axioms) are Static Facts, pinned at 1.0 and
+outside the evidence machinery entirely.
+
+## Concepts
+
+Defined in the `CONTEXT.md` glossary (`## Memory`): **Fact**, **Confidence**, **Evidence**,
+**EvidenceStore**, **Likelihood ratio (LR)**, **Static Fact**. Use those terms; don't drift
+to synonyms the glossary avoids.
+
+## Data model
+
+- `facts` (existing): `confidence` is now the posterior over *active* evidence, kept fresh
+  by ingestion and the sweep.
+- `evidence` (new): one row per accepted observation —
+  `fact_id` (FK), `source_type` (`sensor` | `user_confirm` | `llm`), `source_id`,
+  `value_hash` (the value the observation supported), `strength` (the ingested fact's
+  confidence), `observed_at`. Indexed on `(fact_id, observed_at)` and `(observed_at)`.
+
+## Ingestion flow
+
+Every observation (sensory event today; conversation message after #82) reaches the fact
+store through the same seam: `FactStore.add_fact` → `EvidenceStore.record(fact)`:
+
+1. **Dedup**: if an evidence with the same `(source_type, source_id, fact_id, value_hash)`
+   exists within the last hour, the observation is discarded — it does not count again.
+2. **New fact**: stored with prior confidence 0.5, then the evidence is applied (uniform
+   pipeline — the first observation uses the same rule as later ones).
+3. **Value change**: the fact's value is replaced (existing dedup-on-write); old evidence is
+   *not* deleted but stops contributing because its `value_hash` no longer matches. Reverting
+   the value restores the old evidence.
+4. **Recompute**: the posterior over active evidence replaces `facts.confidence`.
+5. **Static Fact**: skip everything — no evidence recorded, confidence stays 1.0, retraction
+   refused.
+
+## Update rule
+
+```
+logit(p') = logit(p) + (2·strength − 1) · ln(LR_base(source_type))
+```
+
+- `logit(p) = ln(p / (1−p))`; O(1) per evidence; deterministic.
+- `strength < 0.5` weakens (evidence against), `strength = 0.5` is neutral, `strength = 1`
+  applies the full LR; interpolation happens in log space (linear interpolation goes
+  negative below 0.5 — see ADR-0013).
+- Confidence saturates toward 1.0 as supporting evidence accumulates.
+
+### Calibration constants (the only magic numbers — isolated and documented)
+
+| Constant | Value |
+|---|---|
+| `LR(user_confirm)` | 20 |
+| `LR(sensor)` | 10 |
+| `LR(llm)` | 3 |
+| prior (new fact) | 0.5 |
+| dedup window | 1 h per `(source_type, source_id, fact_id, value_hash)` |
+| window `EPHEMERAL` | 1 day |
+| window `MUTABLE` | 6 months |
+| window `SEMI_STATIC` | 5 years |
+| window `STATIC` | none (no accumulation) |
+| sweep interval | hourly (default) |
+
+The constants are the calibration point for the future Bayesian network proposed in
+`docs/FEATURES_TO_ADD.md` — change them only with that path in mind.
+
+## Evidence lifecycle
+
+- **Dedup**: identical observations from the same source within an hour count once.
+- **Value-tagging**: an evidence is *active* iff `observed_at >= now − window(mutability)`
+  AND `value_hash` matches the fact's current value. Active evidence is the whole story:
+  this is what makes the system robust to lies and relapses ("I quit coffee" is an
+  intention, not proof that "I don't like coffee").
+- **Sweep**: a periodic asyncio task recomputes `facts.confidence` for facts whose active
+  evidence expired. It exists because the stored confidence must keep matching the
+  posterior — otherwise stale evidence would inflate confidence forever (and the SQL
+  `ORDER BY confidence` retrieval path would rank on stale numbers).
+
+## Static Facts
+
+Confidence pinned at 1.0, never record evidence, never overwritten, never retracted.
+Producer: the LLM extraction prompt marks irrefutable user statements as static (#82 —
+also wires conversation extraction and separates attitudes from behaviors as distinct
+facts).
+
+## Invariants
+
+| Law | Negation → test |
+|---|---|
+| Stored confidence equals the posterior over active evidence | recompute from `evidence` and compare, after sweep |
+| Static Facts: confidence 1.0, zero evidence rows, never retracted | `SELECT` over static facts |
+| No evidence contributes after its window expires | posterior over active evidence ignores it |
+| No evidence with a non-matching `value_hash` contributes | posterior unchanged after value change |
+| At most one evidence per `(source, source_id, fact, value)` per hour | count within window |
+| Confidence always in [0, 1] | out-of-range assertion |
+
+## Out of scope
+
+- **Cross-fact contradictions** (same predicate, different `symbolic_repr` coexisting) —
+  LogicEngine territory, issue #27.
+- **Retirement of superseded facts** (stale facts with different `symbolic_repr` lingering
+  in search).
+- **"Why does Cortex believe X?" UX** — enabled by the evidence table, separate ticket.
+- **Backfill** of existing facts (they keep their confidence, no evidence rows).
+- **Event-bus events** on confidence updates.
+
+## Sources of truth
+
+- `docs/adr/0013-evidence-based-fact-confidence.md` — why (rejected alternatives,
+  rationale).
+- Issues #82, #83 — the work, with acceptance criteria.
+- `CONTEXT.md` — vocabulary.
+- This document — the system as a whole. **Keep it in sync with changes.**


### PR DESCRIPTION
## Summary

Design documentation for the evidence-based fact confidence system (issues #82, #83).

- **ADR-0013** (`docs/adr/0013-evidence-based-fact-confidence.md`): Bayesian evidence engine for fact confidence — logit update rule, LR/window calibration constants, value-tagged evidence (robust to lies/relapses), STATIC semantics, periodic sweep. Rejected alternatives with rationale.
- **`docs/evidence-system.md`**: single source of truth for the system (data model, ingestion flow, update rule, constants, invariants, out of scope). Referenced from `AGENTS.md` (always read) and `docs/agents/domain.md` so agents keep it in sync on any change.
- **`CONTEXT.md`**: new `## Memory` glossary (Fact, Confidence, Evidence, EvidenceStore, Likelihood ratio, Static Fact).

## Notes

- No code changes — design/docs only.
- `needs-triage` tickets #82 (conversation extraction + STATIC producer, dependency) and #83 (evidence engine, blocked by #82).