### PR TITLE
feat: UsageStats + latency through the agent loop, pricing table (#87)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,7 +36,7 @@ A unit of the loop's response text delivered to the caller. One event per respon
 _Avoid_: Token event, streaming chunk
 
 **ResponseDoneEvent**:
-The loop's final-response signal, emitted once per response after the last TextDeltaEvent. Carries the full response text, the tool names used, and the iteration count — the metadata a non-streaming consumer needs for its final result.
+The loop's final-response signal, emitted once per response after the last TextDeltaEvent. Carries the full response text, the tool names used, and the iteration count — the metadata a non-streaming consumer needs for its final result. It also carries the accumulated token usage (`usage`) and the response latency in milliseconds (`latency_ms`).
 _Avoid_: Done event, completion event, final event
 
 **Drain wrapper**:

--- a/docs/AGENTIC_LOOP.md
+++ b/docs/AGENTIC_LOOP.md
@@ -533,6 +533,8 @@ class AgentLoop:
         response_text = ""
         tools_used: list[str] = []
         iterations = 0
+        usage: UsageStats | None = None
+        latency_ms: float | None = None
 
         async for event in self.stream_chat(
             session_id=session_id,
@@ -544,6 +546,7 @@ class AgentLoop:
                     response_text += delta
                 case ResponseDoneEvent(tools_used=used, iterations=iters):
                     tools_used, iterations = used, iters
+                    usage, latency_ms = event.usage, event.latency_ms
                 case _:
                     pass  # progress events + ErrorEvent; generator re-raises
 
@@ -552,6 +555,8 @@ class AgentLoop:
             tools_used=tools_used,
             iterations=iterations,
             session_id=session_id,
+            usage=usage,
+            latency_ms=latency_ms,
         )
 
     async def run_goal(

--- a/docs/adr/0002-async-generator-as-streaming-seam.md
+++ b/docs/adr/0002-async-generator-as-streaming-seam.md
@@ -41,3 +41,7 @@ The obsolete `loop.*` members in `EventTypes` (loop.started, loop.thought, loop.
 - Session resolution happens before the stream starts: a missing session is an HTTP 404, never an in-stream `error` frame. The stream itself only iterates `stream_chat()`.
 - Error policy: on `ErrorEvent` the adapter yields the `error` frame and returns — the loop's reraise stays silent, so expected conditions like `max_iterations` produce no server traceback. Unexpected exceptions in the adapter yield an `error{code:null}` frame and then re-raise, so bugs are logged.
 - Consequence of the above: streaming and non-streaming diverge on max-iterations — the stream emits `error{code:"max_iterations"}` and ends, while non-streaming `run_chat()` returns the friendly fallback message.
+
+## Consequences (refined during #87)
+
+`ResponseDoneEvent` carries `usage` (`UsageStats`) and `latency_ms`, and LLM-layer data models such as `UsageStats` may ride on agentic-core dataclasses (`Decision`, `ChatResponse`, `LoopEvent`). This refines "Pydantic stays at the API boundary": pydantic models are value objects defined in the llm layer — core never imports pydantic at runtime, and serialization is delegated to the model's own `model_dump()` at the `to_dict` boundary. Rationale: the one-type-per-concept rule documented in `llm/models.py` wins over duplicating a parallel core type.

--- a/src/cortex/agentic/events.py
+++ b/src/cortex/agentic/events.py
@@ -19,8 +19,11 @@ Instances are JSON-ready via :meth:`LoopEvent.to_dict`.
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from typing import Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 from uuid import UUID
+
+if TYPE_CHECKING:
+    from cortex.llm.models import UsageStats
 
 
 @dataclass
@@ -94,6 +97,15 @@ class ResponseDoneEvent(LoopEvent):
     message: str
     tools_used: list[str] = field(default_factory=list)
     iterations: int = 0
+    usage: UsageStats | None = None
+    latency_ms: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-ready dict; usage is a plain dict so payloads stay serializable."""
+        payload = super().to_dict()
+        if self.usage is not None:
+            payload["usage"] = self.usage.model_dump()
+        return payload
 
 
 @dataclass

--- a/src/cortex/agentic/loop.py
+++ b/src/cortex/agentic/loop.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
     from cortex.agentic.executor import LoopExecutor
     from cortex.agentic.reasoner import Reasoner
     from cortex.events import EventBus
+    from cortex.llm.models import UsageStats
     from cortex.sessions.interfaces import SessionRepository
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,7 @@ class AgentLoop:
         session_repository: SessionRepository | None = None,
         max_chat_iterations: int = 20,
         max_goal_iterations: int = 100,
+        now: Callable[[], float] = time.monotonic,
     ):
         self._context_builder = context_builder
         self._reasoner = reasoner
@@ -70,6 +72,7 @@ class AgentLoop:
         self._session_repository = session_repository
         self._max_chat_iterations = max_chat_iterations
         self._max_goal_iterations = max_goal_iterations
+        self._now = now
 
     async def run_chat(
         self,
@@ -102,6 +105,8 @@ class AgentLoop:
         response_text = ""
         tools_used: list[str] = []
         iterations = 0
+        usage: UsageStats | None = None
+        latency_ms: float | None = None
         async for event in self.stream_chat(
             session_id=session_id,
             user_message=user_message,
@@ -112,6 +117,7 @@ class AgentLoop:
                     response_text += delta
                 case ResponseDoneEvent(tools_used=used, iterations=iters):
                     tools_used, iterations = used, iters
+                    usage, latency_ms = event.usage, event.latency_ms
                 # Ignore progress events; stream_chat re-raises the original exception
                 case _:
                     pass
@@ -120,6 +126,8 @@ class AgentLoop:
             tools_used=tools_used,
             iterations=iterations,
             session_id=session_id,
+            usage=usage,
+            latency_ms=latency_ms,
         )
 
     async def stream_chat(
@@ -149,6 +157,8 @@ class AgentLoop:
         iterations = 0
         tools_used: list[str] = []
         messages: list[Message] = []
+        started_at = self._now()
+        total_usage: UsageStats | None = None
 
         # Seed history from the repository so multi-turn context works. The
         # limit mirrors the context builder's window (max_messages - 1) so
@@ -186,6 +196,14 @@ class AgentLoop:
 
                 # 2. Think - reason about what to do
                 decision = await self._reasoner.reason(context)
+                # Accumulate per-call usage so the final done event carries
+                # the whole task's token spend (prompt/completion/total).
+                if decision.usage is not None:
+                    total_usage = (
+                        total_usage + decision.usage
+                        if total_usage is not None
+                        else decision.usage
+                    )
 
                 # Emit the reasoning step for this iteration
                 yield ThinkingEvent(session_id, message=decision.reasoning)
@@ -200,11 +218,13 @@ class AgentLoop:
                                 session_id, MessageRole.ASSISTANT, text
                             )
                         yield TextDeltaEvent(session_id, delta=text)
-                        yield ResponseDoneEvent(
+                        yield self._done_event(
                             session_id,
-                            message=text,
-                            tools_used=tools_used,
-                            iterations=iterations,
+                            text,
+                            tools_used,
+                            iterations,
+                            total_usage=total_usage,
+                            started_at=started_at,
                         )
                         return
 
@@ -216,11 +236,13 @@ class AgentLoop:
                                 session_id, MessageRole.ASSISTANT, text
                             )
                         yield TextDeltaEvent(session_id, delta=text)
-                        yield ResponseDoneEvent(
+                        yield self._done_event(
                             session_id,
-                            message=text,
-                            tools_used=tools_used,
-                            iterations=iterations,
+                            text,
+                            tools_used,
+                            iterations,
+                            total_usage=total_usage,
+                            started_at=started_at,
                         )
                         return
 
@@ -321,11 +343,13 @@ class AgentLoop:
                                     session_id, MessageRole.ASSISTANT, fallback
                                 )
                             yield TextDeltaEvent(session_id, delta=fallback)
-                            yield ResponseDoneEvent(
+                            yield self._done_event(
                                 session_id,
-                                message=fallback,
-                                tools_used=tools_used,
-                                iterations=iterations,
+                                fallback,
+                                tools_used,
+                                iterations,
+                                total_usage=total_usage,
+                                started_at=started_at,
                             )
                             return
 
@@ -503,4 +527,24 @@ class AgentLoop:
         await self._emitter.emit(
             f"goal.{status}",
             {"goal_id": str(goal_id), **data},
+        )
+
+    def _done_event(
+        self,
+        session_id: UUID,
+        text: str,
+        tools_used: list[str],
+        iterations: int,
+        *,
+        total_usage: UsageStats | None,
+        started_at: float,
+    ) -> ResponseDoneEvent:
+        """Build the final done event, computing usage and latency once."""
+        return ResponseDoneEvent(
+            session_id,
+            message=text,
+            tools_used=tools_used,
+            iterations=iterations,
+            usage=total_usage,
+            latency_ms=(self._now() - started_at) * 1000.0,
         )

--- a/src/cortex/agentic/models.py
+++ b/src/cortex/agentic/models.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 if TYPE_CHECKING:
+    from cortex.llm.models import UsageStats
     from cortex.memory.models import Fact
     from cortex.sessions.models import Message
     from cortex.tools.interfaces import ToolCall, ToolDefinition
@@ -45,37 +46,42 @@ class Decision:
         text: Text response (for RESPOND or ASK_QUESTION)
         tool_calls: Tools to execute (for EXECUTE_TOOLS)
         reasoning: Explanation of why this decision was made
+        usage: Token usage of the reasoning call that produced this decision
     """
     decision_type: DecisionType
     text: str | None = None
     tool_calls: list[ToolCall] | None = None
     reasoning: str = ""
+    usage: UsageStats | None = None
 
     @classmethod
-    def respond(cls, text: str, reasoning: str = "") -> Decision:
+    def respond(cls, text: str, reasoning: str = "", usage: UsageStats | None = None) -> Decision:
         """Create a RESPOND decision."""
         return cls(
             decision_type=DecisionType.RESPOND,
             text=text,
             reasoning=reasoning,
+            usage=usage,
         )
 
     @classmethod
-    def execute_tools(cls, tool_calls: list[ToolCall], reasoning: str = "") -> Decision:
+    def execute_tools(cls, tool_calls: list[ToolCall], reasoning: str = "", usage: UsageStats | None = None) -> Decision:
         """Create an EXECUTE_TOOLS decision."""
         return cls(
             decision_type=DecisionType.EXECUTE_TOOLS,
             tool_calls=tool_calls,
             reasoning=reasoning,
+            usage=usage,
         )
 
     @classmethod
-    def ask_question(cls, question: str, reasoning: str = "") -> Decision:
+    def ask_question(cls, question: str, reasoning: str = "", usage: UsageStats | None = None) -> Decision:
         """Create an ASK_QUESTION decision."""
         return cls(
             decision_type=DecisionType.ASK_QUESTION,
             text=question,
             reasoning=reasoning,
+            usage=usage,
         )
 
 
@@ -147,6 +153,8 @@ class ChatResponse:
     iterations: int = 0
     tools_used: list[str] = field(default_factory=list)
     session_id: UUID | None = None
+    usage: UsageStats | None = None
+    latency_ms: float | None = None
 
     @property
     def tool_names(self) -> list[str]:

--- a/src/cortex/agentic/reasoner.py
+++ b/src/cortex/agentic/reasoner.py
@@ -173,6 +173,7 @@ class Reasoner:
             return Decision.execute_tools(
                 tool_calls=list(tool_calls),
                 reasoning=f"Using {len(tool_calls)} tool(s) to complete the request",
+                usage=result.usage,
             )
 
         match = QUESTION_PATTERN.search(content)
@@ -183,10 +184,12 @@ class Reasoner:
             return Decision.ask_question(
                 question=question,
                 reasoning="LLM signaled need for clarification",
+                usage=result.usage,
             )
 
         return Decision.respond(
             text=content,
             reasoning="Direct response to user",
+            usage=result.usage,
         )
 

--- a/src/cortex/config/models.py
+++ b/src/cortex/config/models.py
@@ -2,10 +2,39 @@
 Pydantic settings models for Cortex configuration.
 """
 
-from typing import Literal
+from __future__ import annotations
 
-from pydantic import Field, SecretStr
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field, SecretStr
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+if TYPE_CHECKING:
+    from cortex.llm.models import UsageStats
+
+
+class ModelPricing(BaseModel):
+    """Per-model token pricing, in USD per 1M tokens (mtok).
+
+    Mirrors the published per-model price sheets (OpenAI, DeepSeek):
+    input tokens and output tokens are priced independently.
+    """
+
+    input_per_mtok: float
+    output_per_mtok: float
+
+
+def derive_cost(usage: UsageStats, pricing: ModelPricing) -> float:
+    """Derive the USD cost of a call's token usage from per-model pricing.
+
+    Pure and deterministic: same usage + pricing always yields the same cost.
+    ``total_tokens`` is informational — cost is driven by the
+    prompt/completion split because the two directions are priced differently.
+    """
+    return (
+        usage.prompt_tokens * pricing.input_per_mtok
+        + usage.completion_tokens * pricing.output_per_mtok
+    ) / 1_000_000
 
 
 class Settings(BaseSettings):
@@ -52,6 +81,15 @@ class Settings(BaseSettings):
     circuit_breaker_timeout: float = Field(default=30.0, ge=0.0)
     circuit_breaker_half_open_successes: int = Field(default=3, ge=1)
     llm_timeout: int = Field(default=60, ge=1)
+    llm_pricing: dict[str, ModelPricing] = Field(
+        default_factory=lambda: {
+            # Defaults cover the shipped config model and the Settings default;
+            # override via LLM_PRICING (JSON) or constructor for any other model.
+            "deepseek-chat": ModelPricing(input_per_mtok=0.27, output_per_mtok=1.10),
+            "gpt-4o": ModelPricing(input_per_mtok=2.50, output_per_mtok=10.00),
+        },
+        description="Per-model token pricing in USD per 1M tokens",
+    )
 
     # ─── MQTT ─────────────────────────────────────────────────
     mqtt_broker_url: str = Field(

--- a/src/cortex/llm/models.py
+++ b/src/cortex/llm/models.py
@@ -5,6 +5,8 @@
 there is one type per concept across the codebase.
 """
 
+from __future__ import annotations
+
 from datetime import datetime
 from enum import StrEnum
 
@@ -42,6 +44,14 @@ class UsageStats(BaseModel):
     prompt_tokens: int = 0
     completion_tokens: int = 0
     total_tokens: int = 0
+
+    def __add__(self, other: UsageStats) -> UsageStats:
+        """Accumulate usage across calls: sums each token counter."""
+        return UsageStats(
+            prompt_tokens=self.prompt_tokens + other.prompt_tokens,
+            completion_tokens=self.completion_tokens + other.completion_tokens,
+            total_tokens=self.total_tokens + other.total_tokens,
+        )
 
 
 class ChatResult(BaseModel):

--- a/tests/unit/agentic/test_loop_events.py
+++ b/tests/unit/agentic/test_loop_events.py
@@ -15,6 +15,7 @@ from cortex.agentic.events import (
     ToolResultEvent,
     ToolStartEvent,
 )
+from cortex.llm.models import UsageStats
 
 WIRE_NAMES = {
     ThinkingEvent: "thinking",
@@ -290,6 +291,50 @@ class TestResponseDoneEvent:
         second = ResponseDoneEvent(session_id=uuid4(), message="Done")
         first.tools_used.append("web_search")
         assert second.tools_used == []
+
+    def test_usage_defaults_to_none(self):
+        event = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        assert event.usage is None
+
+    def test_latency_ms_defaults_to_none(self):
+        event = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        assert event.latency_ms is None
+
+    def test_usage_field_accepts_usage_stats(self):
+        event = ResponseDoneEvent(
+            session_id=uuid4(),
+            message="Done",
+            usage=UsageStats(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+        )
+        assert event.usage == UsageStats(prompt_tokens=1, completion_tokens=2, total_tokens=3)
+
+    def test_latency_ms_field(self):
+        event = ResponseDoneEvent(session_id=uuid4(), message="Done", latency_ms=12.5)
+        assert event.latency_ms == 12.5
+
+    def test_to_dict_serializes_usage_as_plain_dict(self):
+        """to_dict stays JSON-ready: usage is a plain dict, not a model object."""
+        event = ResponseDoneEvent(
+            session_id=uuid4(),
+            message="Done",
+            usage=UsageStats(prompt_tokens=1, completion_tokens=2, total_tokens=3),
+            latency_ms=12.5,
+        )
+        payload = event.to_dict()
+        assert payload["usage"] == {
+            "prompt_tokens": 1,
+            "completion_tokens": 2,
+            "total_tokens": 3,
+        }
+        assert payload["latency_ms"] == 12.5
+        json.dumps(payload)  # JSON-ready without default=str
+
+    def test_to_dict_usage_none_roundtrips(self):
+        event = ResponseDoneEvent(session_id=uuid4(), message="Done")
+        payload = event.to_dict()
+        assert payload["usage"] is None
+        assert payload["latency_ms"] is None
+        json.dumps(payload)
 
 
 class TestErrorEvent:

--- a/tests/unit/agentic/test_usage_flow.py
+++ b/tests/unit/agentic/test_usage_flow.py
@@ -1,0 +1,250 @@
+"""Token usage and latency flow: LLM client -> reasoner -> loop -> events (issue #87)."""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from cortex.agentic.events import ResponseDoneEvent
+from cortex.agentic.loop import AgentLoop
+from cortex.agentic.models import Context, Decision, DecisionType
+from cortex.agentic.reasoner import Reasoner
+from cortex.llm.models import ChatMessage, ChatResult, Role, UsageStats
+from cortex.tools.interfaces import ToolCall, ToolResult
+
+
+def _chat_result(
+    content: str = "ok",
+    tool_calls=None,
+    usage: UsageStats | None = None,
+) -> ChatResult:
+    return ChatResult(
+        message=ChatMessage(role=Role.ASSISTANT, content=content),
+        tool_calls=tool_calls,
+        usage=usage,
+    )
+
+
+class FakeClock:
+    """Scripted clock for deterministic latency assertions."""
+
+    def __init__(self, *readings: float):
+        self._readings = list(readings)
+        self._calls = 0
+
+    def __call__(self) -> float:
+        value = self._readings[self._calls]
+        self._calls += 1
+        return value
+
+
+class TestReasonerThreadsUsage:
+    """UsageStats from the LLM client reaches the Decision."""
+
+    @pytest.fixture
+    def client(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def reasoner(self, client):
+        return Reasoner(llm_client=client, tool_registry=MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_respond_decision_carries_usage(self, reasoner, client):
+        client.chat = AsyncMock(return_value=_chat_result(
+            content="Hello!",
+            usage=UsageStats(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+        ))
+        decision = await reasoner.reason(Context(session_id=uuid4()))
+        assert decision.decision_type == DecisionType.RESPOND
+        assert decision.usage == UsageStats(
+            prompt_tokens=100, completion_tokens=50, total_tokens=150
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_tools_decision_carries_usage(self, reasoner, client):
+        call = ToolCall(id="call_1", name="shell", arguments={})
+        client.chat = AsyncMock(return_value=_chat_result(
+            content=None,
+            tool_calls=[call],
+            usage=UsageStats(prompt_tokens=10, completion_tokens=2, total_tokens=12),
+        ))
+        decision = await reasoner.reason(Context(session_id=uuid4()))
+        assert decision.decision_type == DecisionType.EXECUTE_TOOLS
+        assert decision.usage == UsageStats(
+            prompt_tokens=10, completion_tokens=2, total_tokens=12
+        )
+
+    @pytest.mark.asyncio
+    async def test_ask_question_decision_carries_usage(self, reasoner, client):
+        client.chat = AsyncMock(return_value=_chat_result(
+            content="[QUESTION]Which file?[/QUESTION]",
+            usage=UsageStats(prompt_tokens=5, completion_tokens=1, total_tokens=6),
+        ))
+        decision = await reasoner.reason(Context(session_id=uuid4()))
+        assert decision.decision_type == DecisionType.ASK_QUESTION
+        assert decision.usage == UsageStats(
+            prompt_tokens=5, completion_tokens=1, total_tokens=6
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_usage_yields_none(self, reasoner, client):
+        client.chat = AsyncMock(return_value=_chat_result(content="ok", usage=None))
+        decision = await reasoner.reason(Context(session_id=uuid4()))
+        assert decision.usage is None
+
+    @pytest.mark.asyncio
+    async def test_error_path_has_no_usage(self, reasoner, client):
+        client.chat = AsyncMock(side_effect=RuntimeError("boom"))
+        decision = await reasoner.reason(Context(session_id=uuid4()))
+        assert decision.usage is None
+
+
+class TestLoopStreamsUsage:
+    """The loop accumulates usage and measures latency into the event stream."""
+
+    def _loop(self, clock=None):
+        context_builder = MagicMock()
+        context_builder.build = AsyncMock(return_value=Context(session_id=uuid4()))
+        reasoner = MagicMock()
+        reasoner.reason = AsyncMock()
+        executor = MagicMock()
+        executor.execute_single = AsyncMock()
+        loop = AgentLoop(
+            context_builder=context_builder,
+            reasoner=reasoner,
+            executor=executor,
+            now=clock if clock is not None else (lambda: 0.0),
+        )
+        return loop, context_builder, reasoner, executor
+
+    @pytest.mark.asyncio
+    async def test_respond_done_event_carries_usage(self):
+        loop, _cb, reasoner, _ex = self._loop()
+        reasoner.reason = AsyncMock(return_value=Decision.respond(
+            "Hello!",
+            usage=UsageStats(prompt_tokens=7, completion_tokens=3, total_tokens=10),
+        ))
+        events = [e async for e in loop.stream_chat(uuid4(), "Hi")]
+        done = events[-1]
+        assert isinstance(done, ResponseDoneEvent)
+        assert done.usage == UsageStats(
+            prompt_tokens=7, completion_tokens=3, total_tokens=10
+        )
+
+    @pytest.mark.asyncio
+    async def test_usage_accumulates_across_tool_iterations(self):
+        loop, _cb, reasoner, executor = self._loop()
+        call = ToolCall(id="call_1", name="shell", arguments={"cmd": "true"})
+        reasoner.reason = AsyncMock(side_effect=[
+            Decision.execute_tools(
+                [call],
+                usage=UsageStats(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+            ),
+            Decision.respond(
+                "Done.",
+                usage=UsageStats(prompt_tokens=100, completion_tokens=50, total_tokens=150),
+            ),
+        ])
+        executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_1", tool_name="shell", success=True, output="ok",
+        ))
+        events = [e async for e in loop.stream_chat(uuid4(), "Run")]
+        done = events[-1]
+        assert done.usage == UsageStats(
+            prompt_tokens=110, completion_tokens=55, total_tokens=165
+        )
+
+    @pytest.mark.asyncio
+    async def test_ask_question_done_event_carries_usage(self):
+        loop, _cb, reasoner, _ex = self._loop()
+        reasoner.reason = AsyncMock(return_value=Decision.ask_question(
+            "Which?",
+            usage=UsageStats(prompt_tokens=4, completion_tokens=2, total_tokens=6),
+        ))
+        events = [e async for e in loop.stream_chat(uuid4(), "Hmm")]
+        done = events[-1]
+        assert done.usage == UsageStats(
+            prompt_tokens=4, completion_tokens=2, total_tokens=6
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_usage_anywhere_yields_none(self):
+        loop, _cb, reasoner, _ex = self._loop()
+        reasoner.reason = AsyncMock(return_value=Decision.respond("Hello!"))
+        events = [e async for e in loop.stream_chat(uuid4(), "Hi")]
+        assert events[-1].usage is None
+
+    @pytest.mark.asyncio
+    async def test_zero_usage_is_present_not_none(self):
+        """A zero-usage response is still recorded — presence matters for eval accounting."""
+        loop, _cb, reasoner, _ex = self._loop()
+        reasoner.reason = AsyncMock(return_value=Decision.respond(
+            "Hello!", usage=UsageStats(),
+        ))
+        events = [e async for e in loop.stream_chat(uuid4(), "Hi")]
+        assert events[-1].usage == UsageStats()
+
+    @pytest.mark.asyncio
+    async def test_latency_ms_measured_from_stream_start_to_done(self):
+        loop, _cb, reasoner, _ex = self._loop(clock=FakeClock(100.0, 100.5))
+        reasoner.reason = AsyncMock(return_value=Decision.respond("Hello!"))
+        events = [e async for e in loop.stream_chat(uuid4(), "Hi")]
+        assert events[-1].latency_ms == pytest.approx(500.0)
+
+    @pytest.mark.asyncio
+    async def test_latency_ms_zero_when_instant(self):
+        loop, _cb, reasoner, _ex = self._loop(clock=FakeClock(10.0, 10.0))
+        reasoner.reason = AsyncMock(return_value=Decision.respond("Hello!"))
+        events = [e async for e in loop.stream_chat(uuid4(), "Hi")]
+        assert events[-1].latency_ms == 0.0
+
+
+class TestRunChatCarriesUsage:
+    """The drain wrapper forwards usage and latency into ChatResponse."""
+
+    def _loop(self, clock=None):
+        context_builder = MagicMock()
+        context_builder.build = AsyncMock(return_value=Context(session_id=uuid4()))
+        reasoner = MagicMock()
+        reasoner.reason = AsyncMock()
+        executor = MagicMock()
+        loop = AgentLoop(
+            context_builder=context_builder,
+            reasoner=reasoner,
+            executor=executor,
+            now=clock if clock is not None else (lambda: 0.0),
+        )
+        return loop, reasoner
+
+    @pytest.mark.asyncio
+    async def test_run_chat_response_carries_usage_and_latency(self):
+        loop, reasoner = self._loop(clock=FakeClock(0.0, 0.25))
+        reasoner.reason = AsyncMock(return_value=Decision.respond(
+            "Hello!",
+            usage=UsageStats(prompt_tokens=7, completion_tokens=3, total_tokens=10),
+        ))
+        response = await loop.run_chat(uuid4(), "Hi")
+        assert response.message == "Hello!"
+        assert response.usage == UsageStats(
+            prompt_tokens=7, completion_tokens=3, total_tokens=10
+        )
+        assert response.latency_ms == pytest.approx(250.0)
+
+    @pytest.mark.asyncio
+    async def test_run_chat_without_usage_yields_none(self):
+        loop, reasoner = self._loop()
+        reasoner.reason = AsyncMock(return_value=Decision.respond("Hello!"))
+        response = await loop.run_chat(uuid4(), "Hi")
+        assert response.usage is None
+        assert response.latency_ms == 0.0
+
+    @pytest.mark.asyncio
+    async def test_stream_parity_usage_matches_done_event(self):
+        loop, reasoner = self._loop()
+        usage = UsageStats(prompt_tokens=20, completion_tokens=8, total_tokens=28)
+        reasoner.reason = AsyncMock(return_value=Decision.respond("Done", usage=usage))
+        response = await loop.run_chat(uuid4(), "Go")
+        events = [e async for e in loop.stream_chat(uuid4(), "Go")]
+        assert response.usage == events[-1].usage
+        assert response.latency_ms == events[-1].latency_ms

--- a/tests/unit/test_pricing.py
+++ b/tests/unit/test_pricing.py
@@ -1,0 +1,87 @@
+"""Tests for per-model pricing table and deterministic cost derivation (issue #87)."""
+
+import json
+
+import pytest
+
+from cortex.config.models import ModelPricing, Settings, derive_cost
+from cortex.llm.models import UsageStats
+
+
+class TestModelPricing:
+    """Settings exposes a per-model pricing table with sane defaults."""
+
+    def test_defaults_cover_deepseek_chat(self):
+        settings = Settings(llm_api_key="test-key")
+        assert "deepseek-chat" in settings.llm_pricing
+
+    def test_defaults_cover_gpt_4o(self):
+        settings = Settings(llm_api_key="test-key")
+        assert "gpt-4o" in settings.llm_pricing
+
+    def test_default_prices_are_positive(self):
+        for pricing in Settings(llm_api_key="test-key").llm_pricing.values():
+            assert pricing.input_per_mtok > 0
+            assert pricing.output_per_mtok > 0
+
+    def test_custom_pricing_overrides_defaults(self):
+        settings = Settings(
+            llm_api_key="test-key",
+            llm_pricing={
+                "my-model": ModelPricing(input_per_mtok=1.5, output_per_mtok=3.0)
+            },
+        )
+        assert settings.llm_pricing == {
+            "my-model": ModelPricing(input_per_mtok=1.5, output_per_mtok=3.0),
+        }
+
+    def test_pricing_configurable_via_environment(self, monkeypatch):
+        monkeypatch.setenv(
+            "LLM_PRICING",
+            json.dumps({"env-model": {"input_per_mtok": 2.0, "output_per_mtok": 4.0}}),
+        )
+        settings = Settings(llm_api_key="test-key")
+        assert settings.llm_pricing == {
+            "env-model": ModelPricing(input_per_mtok=2.0, output_per_mtok=4.0),
+        }
+
+
+class TestDeriveCost:
+    """derive_cost is a pure, deterministic function of usage + pricing."""
+
+    PRICING = ModelPricing(input_per_mtok=1.0, output_per_mtok=2.0)
+
+    def test_zero_usage_costs_zero(self):
+        assert derive_cost(UsageStats(), self.PRICING) == 0.0
+
+    def test_math_is_prompt_times_input_plus_completion_times_output(self):
+        usage = UsageStats(
+            prompt_tokens=1_000_000,
+            completion_tokens=500_000,
+            total_tokens=1_500_000,
+        )
+        assert derive_cost(usage, self.PRICING) == pytest.approx(2.0)
+
+    def test_deterministic_same_inputs_same_output(self):
+        usage = UsageStats(
+            prompt_tokens=1234, completion_tokens=567, total_tokens=1801
+        )
+        assert derive_cost(usage, self.PRICING) == derive_cost(usage, self.PRICING)
+
+    def test_prompt_and_completion_priced_independently(self):
+        pricing = ModelPricing(input_per_mtok=0.27, output_per_mtok=1.10)
+        usage = UsageStats(prompt_tokens=1000, completion_tokens=1000)
+        expected = 0.27 * 1000 / 1_000_000 + 1.10 * 1000 / 1_000_000
+        assert derive_cost(usage, pricing) == pytest.approx(expected)
+
+    def test_total_tokens_does_not_influence_cost(self):
+        """total_tokens is informational; cost derives from the prompt/completion split."""
+        with_extra = UsageStats(
+            prompt_tokens=100, completion_tokens=50, total_tokens=999
+        )
+        normal = UsageStats(
+            prompt_tokens=100, completion_tokens=50, total_tokens=150
+        )
+        assert derive_cost(with_extra, self.PRICING) == derive_cost(
+            normal, self.PRICING
+        )


### PR DESCRIPTION
Closes #87 (T1 — Thread UsageStats through the agent loop + pricing table).

- UsageStats flows client → Decision → ResponseDoneEvent → ChatResponse, accumulated across tool iterations without loss or double-count
- latency_ms measured stream-start→done via injectable clock (deterministic tests)
- Settings.llm_pricing per-model table (deepseek-chat, gpt-4o defaults); pure deterministic derive_cost
- SSE wire names unchanged; chat.py untouched (tested contract)
- ADR-0002 refined for llm-layer value objects on core dataclasses; CONTEXT.md + AGENTIC_LOOP.md updated

Review: two-axis (standards+spec) zero fatal findings; 674 tests pass, mypy strict clean, ruff clean.