### PR TITLE
feat: eval harness core — suite runner, sandbox, grader, metrics, baseline (#88)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run tests
-        run: uv run pytest tests/unit tests/learning tests/memory -q
+        run: uv run pytest tests/unit tests/learning tests/memory tests/eval -q
 
   lint:
     name: Lint (ruff)
@@ -76,7 +76,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Run coverage
-        run: uv run pytest tests/unit tests/learning tests/memory -q --cov=src/cortex --cov-report=term --cov-fail-under=70
+        run: uv run pytest tests/unit tests/learning tests/memory tests/eval -q --cov=src/cortex --cov-report=term --cov-fail-under=70
 
   build:
     name: Docker build

--- a/src/cortex/eval/__init__.py
+++ b/src/cortex/eval/__init__.py
@@ -1,0 +1,54 @@
+"""Eval harness core (ADR-0014).
+
+Runs an evaluation suite locally with one command (a pytest entry point in
+``tests/eval/``). The harness composes the real ``AgentLoop`` — reasoner,
+context builder, executor, and the four meta tools — inside a per-task
+sandbox directory, with no new seams inside existing modules.
+
+Public seam:
+
+* :func:`load_suite` — YAML task fixtures (scripted user turns + annotated
+  goal state)
+* :func:`run_suite` — runs every task through the real loop with an
+  injected (or factory-created) LLM client, grades goal states, records
+  metrics and an optional versioned baseline
+* :func:`record_baseline` / :func:`load_baseline` — per-suite baseline JSON
+* :class:`TaskSandbox` — per-task sandbox the tools execute against
+"""
+
+from cortex.eval.baseline import EvalBaseline, load_baseline, record_baseline
+from cortex.eval.fixtures import (
+    EvalSuite,
+    EvalTask,
+    GoalFile,
+    GoalState,
+    SandboxFile,
+    load_suite,
+)
+from cortex.eval.grader import GradingResult, grade_goal
+from cortex.eval.metrics import SuiteMetrics, TaskMetrics, collect_metrics
+from cortex.eval.runner import SuiteResult, TaskResult, run_suite
+from cortex.eval.sandbox import SandboxedTool, SandboxEscapeError, TaskSandbox
+
+__all__ = [
+    "EvalBaseline",
+    "EvalSuite",
+    "EvalTask",
+    "GradingResult",
+    "GoalFile",
+    "GoalState",
+    "SandboxEscapeError",
+    "SandboxFile",
+    "SandboxedTool",
+    "SuiteMetrics",
+    "SuiteResult",
+    "TaskMetrics",
+    "TaskResult",
+    "TaskSandbox",
+    "collect_metrics",
+    "grade_goal",
+    "load_baseline",
+    "load_suite",
+    "record_baseline",
+    "run_suite",
+]

--- a/src/cortex/eval/baseline.py
+++ b/src/cortex/eval/baseline.py
@@ -1,0 +1,102 @@
+"""Per-suite baseline recording and loading.
+
+A baseline is the recorded metrics of a suite on a known-good run
+(CONTEXT.md: Eval Baseline). It is written as a small versioned JSON file
+(suite name, suite version, task count, pass count, metrics, timestamp) so
+nightly runs can compare against it and gates can trigger on gross
+regressions.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from cortex.eval.metrics import SuiteMetrics
+
+#: Version of the baseline file schema; bump on breaking shape changes.
+BASELINE_SCHEMA_VERSION = 1
+
+
+@dataclass
+class EvalBaseline:
+    """Recorded metrics of a suite on a known-good run."""
+
+    suite_name: str
+    suite_version: str
+    task_count: int
+    pass_count: int
+    metrics: SuiteMetrics
+    created_at: str
+    schema_version: int = BASELINE_SCHEMA_VERSION
+
+
+def record_baseline(
+    *,
+    suite_name: str,
+    suite_version: str,
+    metrics: SuiteMetrics,
+    path: str | Path,
+    created_at: str | None = None,
+) -> EvalBaseline:
+    """Write a versioned baseline JSON file and return it.
+
+    Args:
+        suite_name: Name of the eval suite.
+        suite_version: Version of the suite (baselines are versioned per suite).
+        metrics: Aggregate metrics of the run.
+        path: Destination file (parent directories are created).
+        created_at: ISO timestamp; defaults to now (UTC).
+
+    Returns:
+        The recorded :class:`EvalBaseline`.
+    """
+    baseline = EvalBaseline(
+        suite_name=suite_name,
+        suite_version=suite_version,
+        task_count=metrics.task_count,
+        pass_count=metrics.pass_count,
+        metrics=metrics,
+        created_at=created_at or datetime.now(UTC).isoformat(),
+    )
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    dest.write_text(
+        json.dumps(asdict(baseline), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return baseline
+
+
+def load_baseline(path: str | Path) -> EvalBaseline | None:
+    """Load a baseline file; None when missing or malformed.
+
+    Validates shape only: required keys present, metrics is a mapping.
+    Value types under valid keys are not validated, so a future schema
+    version that changes a field's type still loads (forward compat).
+    """
+    try:
+        raw: Any = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    required = ("suite_name", "suite_version", "task_count", "pass_count", "created_at")
+    if not isinstance(raw, dict) or not all(key in raw for key in required):
+        return None
+    metrics = raw.get("metrics")
+    if not isinstance(metrics, dict):
+        return None
+    try:
+        return EvalBaseline(
+            suite_name=raw["suite_name"],
+            suite_version=raw["suite_version"],
+            task_count=raw["task_count"],
+            pass_count=raw["pass_count"],
+            metrics=SuiteMetrics(**metrics),
+            created_at=raw["created_at"],
+            schema_version=raw.get("schema_version", BASELINE_SCHEMA_VERSION),
+        )
+    except (KeyError, TypeError):
+        return None

--- a/src/cortex/eval/fixtures.py
+++ b/src/cortex/eval/fixtures.py
@@ -1,0 +1,211 @@
+"""Eval task fixtures: the YAML schema and its loader (ADR-0014).
+
+Schema
+------
+A fixture file is a YAML document with a ``suite`` header and a non-empty
+``tasks`` list::
+
+    suite:
+      name: sample          # required, non-empty
+      version: 1.0.0        # required, non-empty (baselines are versioned per suite)
+    tasks:
+      - name: write-answer  # required
+        description: optional human-readable context
+        sandbox:            # optional files materialized before the run
+          files:
+            - path: data/input.txt
+              content: "40\\n2"
+        turns:              # required; scripted user turns, run in one session
+          - "Read data/input.txt and write the sum to answer.txt"
+        goal:               # required; the annotated goal state (ADR-0015) —
+                            # the only pass/fail oracle. At least one check.
+          files:            # optional expected sandbox files
+            - path: answer.txt
+              equals: "42"  # exact content match (optional)
+              contains: "4" # substring match (optional, alternative to equals)
+          absent:           # optional paths that must not exist
+            - tmp/scratch.txt
+          answer: "42"      # optional exact final-response text match
+
+The goal state is graded deterministically against the sandbox directory
+after the run (and, for ``answer``, against the final response text).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass
+class SandboxFile:
+    """A file materialized into the task sandbox before the run."""
+
+    path: str
+    content: str = ""
+
+
+@dataclass
+class GoalFile:
+    """An expected file in the sandbox after the run."""
+
+    path: str
+    equals: str | None = None
+    contains: str | None = None
+
+
+@dataclass
+class GoalState:
+    """Annotated goal state — the deterministic pass/fail oracle (ADR-0015)."""
+
+    files: list[GoalFile] = field(default_factory=list)
+    absent: list[str] = field(default_factory=list)
+    answer: str | None = None
+
+
+@dataclass
+class EvalTask:
+    """A self-contained evaluation case (see module docstring for the schema)."""
+
+    name: str
+    turns: list[str]
+    goal: GoalState
+    description: str = ""
+    sandbox: list[SandboxFile] = field(default_factory=list)
+
+
+@dataclass
+class EvalSuite:
+    """A versioned set of Eval Tasks measuring one capability."""
+
+    name: str
+    version: str
+    tasks: list[EvalTask]
+
+
+def load_suite(path: str | Path) -> EvalSuite:
+    """Load an :class:`EvalSuite` from a YAML fixture file.
+
+    Raises:
+        OSError: If the file cannot be read.
+        ValueError: If the document does not match the task schema.
+    """
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    return _parse_suite(raw, str(path))
+
+
+def _parse_suite(raw: Any, source: str) -> EvalSuite:
+    if not isinstance(raw, dict) or not isinstance(raw.get("suite"), dict):
+        raise ValueError(f"{source}: fixture must have a 'suite' mapping")
+
+    suite = raw["suite"]
+    name = suite.get("name")
+    version = suite.get("version")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"{source}: suite.name must be a non-empty string")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"{source}: suite.version must be a non-empty string")
+
+    tasks = raw.get("tasks")
+    if not isinstance(tasks, list) or not tasks:
+        raise ValueError(f"{source}: suite must define at least one task")
+
+    return EvalSuite(
+        name=name,
+        version=version,
+        tasks=[_parse_task(task, source, i) for i, task in enumerate(tasks)],
+    )
+
+
+def _parse_task(raw: Any, source: str, index: int) -> EvalTask:
+    where = f"{source}: tasks[{index}]"
+    if not isinstance(raw, dict):
+        raise ValueError(f"{where}: task must be a mapping")
+
+    name = raw.get("name")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"{where}: task name must be a non-empty string")
+
+    turns = raw.get("turns")
+    if (
+        not isinstance(turns, list)
+        or not turns
+        or not all(isinstance(t, str) for t in turns)
+    ):
+        raise ValueError(f"{where}: task turns must be a non-empty list of strings")
+
+    goal_raw = raw.get("goal")
+    if not isinstance(goal_raw, dict):
+        raise ValueError(f"{where}: task goal must be a mapping")
+    goal = _parse_goal(goal_raw, where)
+
+    description = raw.get("description", "")
+    if not isinstance(description, str):
+        raise ValueError(f"{where}: task description must be a string")
+
+    sandbox_raw = raw.get("sandbox", {})
+    if not isinstance(sandbox_raw, dict):
+        raise ValueError(f"{where}: task sandbox must be a mapping")
+    files_raw = sandbox_raw.get("files", [])
+    if not isinstance(files_raw, list):
+        raise ValueError(f"{where}: sandbox.files must be a list")
+    sandbox = [
+        _parse_sandbox_file(f, where) for f in files_raw
+    ]
+
+    return EvalTask(
+        name=name,
+        turns=list(turns),
+        goal=goal,
+        description=description,
+        sandbox=sandbox,
+    )
+
+
+def _parse_sandbox_file(raw: Any, where: str) -> SandboxFile:
+    if not isinstance(raw, dict):
+        raise ValueError(f"{where}: sandbox file must be a mapping")
+    path = raw.get("path")
+    if not isinstance(path, str) or not path:
+        raise ValueError(f"{where}: sandbox file path must be a non-empty string")
+    content = raw.get("content", "")
+    if not isinstance(content, str):
+        raise ValueError(f"{where}: sandbox file content must be a string")
+    return SandboxFile(path=path, content=content)
+
+
+def _parse_goal(raw: dict[str, Any], where: str) -> GoalState:
+    files_raw = raw.get("files", [])
+    if not isinstance(files_raw, list):
+        raise ValueError(f"{where}: goal.files must be a list")
+
+    files: list[GoalFile] = []
+    for file_raw in files_raw:
+        if not isinstance(file_raw, dict):
+            raise ValueError(f"{where}: goal file must be a mapping")
+        path = file_raw.get("path")
+        if not isinstance(path, str) or not path:
+            raise ValueError(f"{where}: goal file path must be a non-empty string")
+        equals = file_raw.get("equals")
+        contains = file_raw.get("contains")
+        if equals is not None and not isinstance(equals, str):
+            raise ValueError(f"{where}: goal file equals must be a string")
+        if contains is not None and not isinstance(contains, str):
+            raise ValueError(f"{where}: goal file contains must be a string")
+        files.append(GoalFile(path=path, equals=equals, contains=contains))
+
+    absent = raw.get("absent", [])
+    if not isinstance(absent, list) or not all(isinstance(a, str) for a in absent):
+        raise ValueError(f"{where}: goal.absent must be a list of strings")
+
+    answer = raw.get("answer")
+    if answer is not None and not isinstance(answer, str):
+        raise ValueError(f"{where}: goal.answer must be a string")
+
+    goal = GoalState(files=files, absent=list(absent), answer=answer)
+    if not (files or absent or answer):
+        raise ValueError(f"{where}: goal must declare at least one check")
+    return goal

--- a/src/cortex/eval/grader.py
+++ b/src/cortex/eval/grader.py
@@ -1,0 +1,54 @@
+"""Deterministic goal-state grading (ADR-0015).
+
+The annotated goal state — sandbox filesystem state and, optionally, the
+exact final answer — is the only pass/fail oracle. Grading compares the
+sandbox directory (and final response text) against the goal with plain
+executable checks: file existence, exact content, substring, absence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from cortex.eval.fixtures import GoalState
+from cortex.eval.sandbox import TaskSandbox
+
+
+@dataclass
+class GradingResult:
+    """Outcome of grading one task's goal state."""
+
+    passed: bool
+    failures: list[str] = field(default_factory=list)
+
+
+def grade_goal(
+    goal: GoalState,
+    sandbox: TaskSandbox,
+    final_message: str = "",
+) -> GradingResult:
+    """Compare sandbox state (and final answer) against the goal state.
+
+    Every declared check must pass; failures carry a human-readable reason.
+    """
+    failures: list[str] = []
+    for expected in goal.files:
+        path = sandbox.confine(expected.path)
+        if not path.is_file():
+            failures.append(f"missing file: {expected.path}")
+            continue
+        content = path.read_text(encoding="utf-8")
+        if expected.equals is not None and content != expected.equals:
+            failures.append(
+                f"{expected.path}: content {content!r} != expected {expected.equals!r}"
+            )
+        elif expected.contains is not None and expected.contains not in content:
+            failures.append(
+                f"{expected.path}: content {content!r} lacks {expected.contains!r}"
+            )
+    for absent_path in goal.absent:
+        if sandbox.confine(absent_path).exists():
+            failures.append(f"unexpected file: {absent_path}")
+    if goal.answer is not None and final_message != goal.answer:
+        failures.append(f"final answer {final_message!r} != expected {goal.answer!r}")
+    return GradingResult(passed=not failures, failures=failures)

--- a/src/cortex/eval/metrics.py
+++ b/src/cortex/eval/metrics.py
@@ -1,0 +1,69 @@
+"""Task and suite metrics from the LoopEvent transcript.
+
+Metrics are recorded from the loop's streaming events — what the
+transcript carries today: ``ResponseDoneEvent.iterations``,
+``ToolStartEvent`` tool names, ``ToolResultEvent`` success flags. Usage and
+latency fields are intentionally not depended on (a sibling ticket adds
+them to the transcript).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from cortex.agentic.events import (
+    LoopEvent,
+    ResponseDoneEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
+
+
+@dataclass
+class TaskMetrics:
+    """Per-task metrics collected from the loop transcript."""
+
+    iterations: int = 0
+    tools_used: list[str] = field(default_factory=list)  # unique, first-use order
+    tool_calls: int = 0
+    failed_calls: int = 0
+
+
+@dataclass
+class SuiteMetrics:
+    """Aggregate metrics over a whole suite run."""
+
+    task_count: int = 0
+    pass_count: int = 0
+    total_iterations: int = 0
+    total_tool_calls: int = 0
+    tools_used: list[str] = field(default_factory=list)
+
+    @property
+    def pass_rate(self) -> float:
+        """Fraction of tasks that passed (0.0 for an empty suite)."""
+        return self.pass_count / self.task_count if self.task_count else 0.0
+
+    @property
+    def avg_iterations(self) -> float:
+        """Mean iterations across tasks (0.0 for an empty suite)."""
+        return self.total_iterations / self.task_count if self.task_count else 0.0
+
+
+def collect_metrics(events: list[LoopEvent]) -> TaskMetrics:
+    """Reduce a task's event transcript to :class:`TaskMetrics`."""
+    metrics = TaskMetrics()
+    seen: set[str] = set()
+    for event in events:
+        match event:
+            case ResponseDoneEvent(iterations=iterations):
+                metrics.iterations += iterations
+            case ToolStartEvent(tool_name=name):
+                metrics.tool_calls += 1
+                if name not in seen:
+                    seen.add(name)
+                    metrics.tools_used.append(name)
+            case ToolResultEvent(success=success):
+                if not success:
+                    metrics.failed_calls += 1
+    return metrics

--- a/src/cortex/eval/runner.py
+++ b/src/cortex/eval/runner.py
@@ -1,0 +1,314 @@
+"""Suite runner: composes the real AgentLoop inside a per-task sandbox.
+
+Per task the runner builds the production loop wiring — ``ContextBuilder``,
+``Reasoner``, ``LoopExecutor`` wrapping a ``DefaultToolExecutor`` registered
+with the four meta tools — confined to a fresh ``TaskSandbox``, then drives
+the task's scripted user turns through ``AgentLoop.stream_chat`` and grades
+the annotated goal state against the sandbox afterwards. No new seams are
+added inside existing modules; the only injected dependency is the LLM
+client, so harness tests run against a fake while real runs use the factory.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+from uuid import UUID, uuid4
+
+from cortex.agentic.context_builder import ContextBuilder
+from cortex.agentic.events import LoopEvent, TextDeltaEvent
+from cortex.agentic.executor import LoopExecutor
+from cortex.agentic.loop import AgentLoop
+from cortex.agentic.reasoner import Reasoner
+from cortex.eval.baseline import record_baseline
+from cortex.eval.fixtures import EvalSuite, EvalTask
+from cortex.eval.grader import GradingResult, grade_goal
+from cortex.eval.metrics import SuiteMetrics, TaskMetrics, collect_metrics
+from cortex.eval.sandbox import TaskSandbox, build_sandboxed_tools
+from cortex.sessions.interfaces import SessionRepository
+from cortex.sessions.models import Message, MessageRole, Session, SessionState
+from cortex.tools.executor import DefaultToolExecutor
+from cortex.tools.registry import InMemoryToolRegistry
+
+if TYPE_CHECKING:
+    from cortex.llm.base import LLMClient
+    from cortex.memory.context_provider import ContextProvider
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TaskResult:
+    """Outcome of one eval task."""
+
+    name: str
+    passed: bool
+    message: str
+    failures: list[str] = field(default_factory=list)
+    metrics: TaskMetrics = field(default_factory=TaskMetrics)
+
+
+@dataclass
+class SuiteResult:
+    """Outcome of a whole suite run."""
+
+    suite_name: str
+    suite_version: str
+    results: list[TaskResult]
+    metrics: SuiteMetrics
+    created_at: str
+
+
+class _InMemorySessionRepository(SessionRepository):
+    """Minimal in-memory session store so the loop keeps multi-turn state."""
+
+    def __init__(self) -> None:
+        self._sessions: dict[UUID, Session] = {}
+        self._messages: dict[UUID, list[Message]] = {}
+
+    async def create(self) -> Session:
+        session = Session()
+        self._sessions[session.id] = session
+        self._messages[session.id] = []
+        return session
+
+    async def get(self, session_id: UUID) -> Session | None:
+        return self._sessions.get(session_id)
+
+    async def update_state(
+        self,
+        session_id: UUID,
+        state: SessionState,
+        ended_at: datetime | None = None,
+    ) -> Session | None:
+        session = self._sessions.get(session_id)
+        if session is None:
+            return None
+        session.state = state
+        session.ended_at = ended_at
+        return session
+
+    async def update_activity(self, session_id: UUID) -> None:
+        session = self._sessions.get(session_id)
+        if session is not None:
+            session.last_activity_at = datetime.now(UTC)
+
+    async def add_message(
+        self,
+        session_id: UUID,
+        role: MessageRole,
+        content: str,
+        tool_calls: list[dict[str, Any]] | None = None,
+        tool_call_id: str | None = None,
+    ) -> Message:
+        message = Message(
+            session_id=session_id,
+            role=role,
+            content=content,
+            tool_calls=tool_calls,
+            tool_call_id=tool_call_id,
+        )
+        self._messages.setdefault(session_id, []).append(message)
+        return message
+
+    async def get_messages(
+        self,
+        session_id: UUID,
+        limit: int = 50,
+        before: datetime | None = None,
+    ) -> list[Message]:
+        messages = self._messages.get(session_id, [])
+        if before is not None:
+            messages = [m for m in messages if m.created_at < before]
+        return messages[-limit:]
+
+    async def list_active(self, limit: int = 10) -> list[Session]:
+        active = [
+            s
+            for s in self._sessions.values()
+            if s.state in (SessionState.CREATED, SessionState.ACTIVE, SessionState.IDLE)
+        ]
+        return active[-limit:]
+
+
+class _EmptyContextProvider:
+    """Memory-free stand-in so eval runs need no database."""
+
+    async def get_memory_context(
+        self,
+        session_id: UUID | None,
+        query: str,
+        *,
+        max_facts: int = 10,
+        fact_types: list[Any] | None = None,
+    ) -> Any:
+        from cortex.agentic.models import MemoryContext
+
+        return MemoryContext()
+
+
+async def run_suite(
+    suite: EvalSuite,
+    llm_client: LLMClient | None = None,
+    *,
+    max_iterations: int = 20,
+    baseline_path: str | Path | None = None,
+) -> SuiteResult:
+    """Run every task in ``suite`` through the real AgentLoop.
+
+    Args:
+        suite: The eval suite to run.
+        llm_client: LLM client used for reasoning. Harness tests inject a
+            deterministic fake; when None, a real client is created from
+            settings via the LLM client factory.
+        max_iterations: Per-turn iteration cap for the loop.
+        baseline_path: When given, a versioned baseline JSON is recorded
+            for the suite at this path.
+
+    Returns:
+        A :class:`SuiteResult` with per-task results and suite metrics.
+    """
+    client = llm_client if llm_client is not None else _default_llm_client()
+    results = [
+        await _run_task(task, client, max_iterations=max_iterations)
+        for task in suite.tasks
+    ]
+    metrics = _suite_metrics(results)
+    suite_result = SuiteResult(
+        suite_name=suite.name,
+        suite_version=suite.version,
+        results=results,
+        metrics=metrics,
+        created_at=datetime.now(UTC).isoformat(),
+    )
+    if baseline_path is not None:
+        record_baseline(
+            suite_name=suite.name,
+            suite_version=suite.version,
+            metrics=metrics,
+            path=baseline_path,
+            created_at=suite_result.created_at,
+        )
+    return suite_result
+
+
+def _default_llm_client() -> LLMClient:
+    """Create a real LLM client from settings (requires LLM_API_KEY etc.)."""
+    from cortex.config.loader import get_settings
+    from cortex.llm.factory import LLMClientFactory
+
+    return LLMClientFactory(get_settings()).create()
+
+
+async def _run_task(
+    task: EvalTask,
+    llm_client: LLMClient,
+    *,
+    max_iterations: int,
+) -> TaskResult:
+    sandbox = TaskSandbox()
+    events: list[LoopEvent] = []
+    error: str | None = None
+    final_message = ""
+    try:
+        sandbox.setup(task.sandbox)
+        loop = _build_loop(llm_client, sandbox, max_iterations=max_iterations)
+        session_id = uuid4()
+        for turn in task.turns:
+            final_message = await _drive_turn(loop, session_id, turn, events)
+    except Exception as exc:  # noqa: BLE001 - loop errors fail the task
+        error = str(exc)
+        logger.warning("Eval task %s failed: %s", task.name, exc)
+
+    try:
+        grade: GradingResult = grade_goal(task.goal, sandbox, final_message)
+    except Exception as exc:  # noqa: BLE001 - grading must not crash the suite
+        grade = GradingResult(passed=False, failures=[f"grading failed: {exc}"])
+    finally:
+        sandbox.cleanup()
+
+    failures = list(grade.failures)
+    if error is not None:
+        failures.append(f"loop error: {error}")
+    return TaskResult(
+        name=task.name,
+        passed=grade.passed and error is None,
+        message=error or final_message,
+        failures=failures,
+        metrics=collect_metrics(events),
+    )
+
+
+def _build_loop(
+    llm_client: LLMClient,
+    sandbox: TaskSandbox,
+    *,
+    max_iterations: int,
+) -> AgentLoop:
+    """Wire the real loop components against the sandbox (no new seams)."""
+    registry = InMemoryToolRegistry()
+    for tool in build_sandboxed_tools(sandbox):
+        registry.register(tool)
+
+    tool_executor = DefaultToolExecutor(registry=registry)
+    loop_executor = LoopExecutor(tool_executor=tool_executor)
+
+    session_repository: SessionRepository = _InMemorySessionRepository()
+    from cortex.memory.context_provider import ContextProvider
+
+    context_provider: ContextProvider = cast(
+        ContextProvider, _EmptyContextProvider()
+    )
+    context_builder = ContextBuilder(
+        session_repository=session_repository,
+        context_provider=context_provider,
+        tool_registry=registry,
+    )
+    reasoner = Reasoner(llm_client=llm_client, tool_registry=registry)
+
+    return AgentLoop(
+        context_builder=context_builder,
+        reasoner=reasoner,
+        executor=loop_executor,
+        session_repository=session_repository,
+        max_chat_iterations=max_iterations,
+    )
+
+
+async def _drive_turn(
+    loop: AgentLoop,
+    session_id: UUID,
+    turn: str,
+    events: list[LoopEvent],
+) -> str:
+    """Run one scripted user turn, recording the transcript.
+
+    Returns the final response text, accumulated from TextDeltaEvent deltas
+    in order — consumers must never assume chunk size.
+    """
+    final_text = ""
+    async for event in loop.stream_chat(session_id, turn):
+        events.append(event)
+        if isinstance(event, TextDeltaEvent):
+            final_text += event.delta
+    return final_text
+
+
+def _suite_metrics(results: list[TaskResult]) -> SuiteMetrics:
+    tools_used: list[str] = []
+    seen: set[str] = set()
+    for result in results:
+        for name in result.metrics.tools_used:
+            if name not in seen:
+                seen.add(name)
+                tools_used.append(name)
+    return SuiteMetrics(
+        task_count=len(results),
+        pass_count=sum(1 for r in results if r.passed),
+        total_iterations=sum(r.metrics.iterations for r in results),
+        total_tool_calls=sum(r.metrics.tool_calls for r in results),
+        tools_used=tools_used,
+    )

--- a/src/cortex/eval/sandbox.py
+++ b/src/cortex/eval/sandbox.py
@@ -1,0 +1,132 @@
+"""Per-task sandbox: confines tool execution to a temporary directory.
+
+Each Eval Task runs inside its own sandbox directory (a ``mkdtemp`` tree
+by default). The four meta tools are wrapped in :class:`SandboxedTool`
+instances so the agent's file operations resolve inside the sandbox and
+shell commands run with the sandbox as their working directory — the
+agent works on the task, never on the host repo.
+
+This is a convenience isolation boundary, not a security sandbox: a
+scripted ``shell`` command can still reach host paths explicitly.
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from cortex.eval.fixtures import SandboxFile
+from cortex.tools.interfaces import Tool, ToolDefinition, ToolResult
+from cortex.tools.meta import FileReadTool, FileWriteTool, GrepTool, ShellTool
+
+
+class SandboxEscapeError(ValueError):
+    """Raised when a tool-supplied path would escape the sandbox."""
+
+
+class TaskSandbox:
+    """A temporary working directory a task's tools are confined to."""
+
+    def __init__(self, root: str | Path | None = None) -> None:
+        if root is None:
+            root = Path(tempfile.mkdtemp(prefix="cortex-eval-"))
+        self._root = Path(root).resolve()
+
+    @property
+    def root(self) -> Path:
+        """Absolute path of the sandbox directory."""
+        return self._root
+
+    def setup(self, files: list[SandboxFile]) -> None:
+        """Materialize the task's fixture files inside the sandbox."""
+        for file in files:
+            path = self.confine(file.path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(file.content, encoding="utf-8")
+
+    def confine(self, path: str) -> Path:
+        """Resolve a tool-supplied path inside the sandbox.
+
+        Relative paths are joined to the sandbox root; absolute paths must
+        already be inside it. Anything that would land outside the root
+        raises :class:`SandboxEscapeError`.
+        """
+        candidate = Path(path)
+        if not candidate.is_absolute():
+            candidate = self._root / candidate
+        resolved = candidate.resolve()
+        if not resolved.is_relative_to(self._root):
+            raise SandboxEscapeError(f"Path escapes the eval sandbox: {path}")
+        return resolved
+
+    def cleanup(self) -> None:
+        """Remove the sandbox directory and its contents."""
+        shutil.rmtree(self._root, ignore_errors=True)
+
+
+class SandboxedTool(Tool):
+    """Wraps a meta tool so its arguments stay inside the task sandbox.
+
+    * ``file_read`` / ``file_write`` / ``grep`` paths are confined to the
+      sandbox root (escapes fail the call).
+    * ``shell`` commands run with the sandbox as their working directory.
+    """
+
+    _PATH_TOOLS = frozenset({"file_read", "file_write", "grep"})
+
+    def __init__(self, tool: Tool, sandbox: TaskSandbox) -> None:
+        self._tool = tool
+        self._sandbox = sandbox
+
+    @property
+    def name(self) -> str:
+        return self._tool.name
+
+    @property
+    def description(self) -> str:
+        return self._tool.description
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return self._tool.input_schema
+
+    @property
+    def output_schema(self) -> dict[str, Any] | None:
+        return self._tool.output_schema
+
+    @property
+    def category(self) -> str:
+        return self._tool.category
+
+    @property
+    def tags(self) -> list[str]:
+        return self._tool.tags
+
+    @property
+    def idempotent(self) -> bool:
+        return self._tool.idempotent
+
+    @property
+    def timeout_seconds(self) -> int:
+        return self._tool.timeout_seconds
+
+    def to_definition(self) -> ToolDefinition:
+        return self._tool.to_definition()
+
+    async def execute(self, arguments: dict[str, Any]) -> ToolResult:
+        confined = dict(arguments)
+        if self.name in self._PATH_TOOLS and "path" in confined:
+            confined["path"] = str(self._sandbox.confine(confined["path"]))
+        elif self.name == "shell":
+            confined["working_dir"] = str(self._sandbox.root)
+        return await self._tool.execute(confined)
+
+
+def build_sandboxed_tools(sandbox: TaskSandbox) -> list[Tool]:
+    """The four meta tools (file_read, file_write, grep, shell), sandboxed."""
+    return [
+        SandboxedTool(tool, sandbox)
+        for tool in (FileReadTool(), FileWriteTool(), GrepTool(), ShellTool())
+    ]

--- a/tests/eval/__init__.py
+++ b/tests/eval/__init__.py
@@ -1,0 +1,1 @@
+"""Eval harness tests (ADR-0014)."""

--- a/tests/eval/conftest.py
+++ b/tests/eval/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for eval harness tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cortex.eval.fixtures import EvalSuite, load_suite
+
+
+@pytest.fixture
+def sample_suite_path() -> Path:
+    """Path to the sample YAML eval suite shipped with the tests."""
+    return Path(__file__).parent / "fixtures" / "sample_suite.yaml"
+
+
+@pytest.fixture
+def sample_suite(sample_suite_path: Path) -> EvalSuite:
+    """The sample suite loaded from YAML."""
+    return load_suite(sample_suite_path)

--- a/tests/eval/fakes.py
+++ b/tests/eval/fakes.py
@@ -1,0 +1,69 @@
+"""Deterministic fake LLM client for eval harness tests.
+
+Lets harness tests drive the real AgentLoop (real Reasoner, real meta
+tools) without ever hitting a real API: each ``chat()`` call pops the next
+scripted :class:`~cortex.llm.models.ChatResult` off a queue.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from cortex.config.models import Settings
+from cortex.llm.base import LLMClient
+from cortex.llm.config import GenerationConfig
+from cortex.llm.models import ChatMessage, ChatResult, Role
+from cortex.tools.interfaces import ToolCall, ToolDefinition
+
+
+class ScriptedLLMClient(LLMClient):
+    """Returns scripted responses in order, one per ``chat()`` call."""
+
+    def __init__(self, responses: list[ChatResult] | None = None) -> None:
+        self._responses: list[ChatResult] = list(responses or [])
+        self.calls: list[list[ChatMessage]] = []
+
+    def queue_tool_call(self, name: str, arguments: dict[str, Any]) -> None:
+        """Queue a response that tells the loop to call a tool."""
+        self._responses.append(
+            ChatResult(
+                message=ChatMessage(role=Role.ASSISTANT, content=""),
+                tool_calls=[ToolCall(name=name, arguments=arguments)],
+            )
+        )
+
+    def queue_text(self, text: str) -> None:
+        """Queue a response that ends the loop with the given text."""
+        self._responses.append(
+            ChatResult(message=ChatMessage(role=Role.ASSISTANT, content=text))
+        )
+
+    @property
+    def exhausted(self) -> bool:
+        """True when every scripted response has been consumed."""
+        return not self._responses
+
+    async def chat(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        generation_config: GenerationConfig | None = None,
+    ) -> ChatResult:
+        self.calls.append(list(messages))
+        if not self._responses:
+            raise AssertionError("ScriptedLLMClient ran out of scripted responses")
+        return self._responses.pop(0)
+
+    def translate_tools(self, tools: list[ToolDefinition]) -> list[dict[str, Any]]:
+        return [{"name": tool.name} for tool in tools]
+
+    def translate_tool_call(self, raw: dict[str, Any]) -> ToolCall:
+        return ToolCall(**raw)
+
+    def get_provider_name(self) -> str:
+        return "scripted"
+
+    @classmethod
+    def from_settings(cls, settings: Settings) -> LLMClient:
+        return cls()

--- a/tests/eval/fixtures/sample_suite.yaml
+++ b/tests/eval/fixtures/sample_suite.yaml
@@ -1,0 +1,27 @@
+# Sample eval suite exercising the YAML task schema end-to-end.
+suite:
+  name: sample
+  version: 1.0.0
+
+tasks:
+  - name: write-answer
+    description: Write the sum of the numbers in data/input.txt to answer.txt
+    sandbox:
+      files:
+        - path: data/input.txt
+          content: "40\n2"
+    turns:
+      - "Read data/input.txt and write the sum of the numbers to answer.txt"
+    goal:
+      files:
+        - path: answer.txt
+          contains: "42"
+
+  - name: leave-marker
+    description: Write marker.txt (the agent never does, so this task fails)
+    turns:
+      - "Create marker.txt with the content 'done'"
+    goal:
+      files:
+        - path: marker.txt
+          equals: "done"

--- a/tests/eval/test_baseline.py
+++ b/tests/eval/test_baseline.py
@@ -1,0 +1,90 @@
+"""Tests for baseline loading: malformed files must yield None."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cortex.eval.baseline import load_baseline
+
+
+def _write(path: Path, raw: object) -> Path:
+    path.write_text(json.dumps(raw), encoding="utf-8")
+    return path
+
+
+class TestLoadBaseline:
+    """The documented contract: None when missing or malformed."""
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert load_baseline(tmp_path / "nope.json") is None
+
+    def test_invalid_json_returns_none(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
+        path.write_text("{not json", encoding="utf-8")
+        assert load_baseline(path) is None
+
+    def test_non_dict_root_returns_none(self, tmp_path: Path) -> None:
+        path = _write(tmp_path / "root.json", ["not", "a", "dict"])
+        assert load_baseline(path) is None
+
+    def test_list_root_with_required_keys_returns_none(self, tmp_path: Path) -> None:
+        """A list whose elements happen to be all required keys is still not a dict."""
+        required = ["suite_name", "suite_version", "task_count", "pass_count", "created_at"]
+        path = _write(tmp_path / "list-root.json", required)
+        assert load_baseline(path) is None
+
+    @pytest.mark.parametrize(
+        "root",
+        [None, 5, 1.5, True, False, "root"],
+        ids=["null", "int", "float", "true", "false", "string"],
+    )
+    def test_scalar_root_returns_none(self, tmp_path: Path, root: object) -> None:
+        path = _write(tmp_path / "scalar-root.json", root)
+        assert load_baseline(path) is None
+
+    def test_missing_top_level_key_returns_none(self, tmp_path: Path) -> None:
+        """A dict missing a required key is malformed, not a crash."""
+        raw = {
+            "suite_name": "mix",
+            "suite_version": "1.0.0",
+            "task_count": 2,
+            "pass_count": 1,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metrics": {"task_count": 2, "pass_count": 1},
+        }
+        del raw["pass_count"]
+        path = _write(tmp_path / "missing-key.json", raw)
+        assert load_baseline(path) is None
+
+    def test_malformed_metrics_returns_none(self, tmp_path: Path) -> None:
+        """A metrics payload with the wrong shape is malformed, not a crash."""
+        raw = {
+            "suite_name": "mix",
+            "suite_version": "1.0.0",
+            "task_count": 2,
+            "pass_count": 1,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metrics": {"task_count": 2, "pass_count": 1, "bogus_field": 1},
+        }
+        path = _write(tmp_path / "bad-metrics.json", raw)
+        assert load_baseline(path) is None
+
+    def test_unknown_extra_fields_are_ignored(self, tmp_path: Path) -> None:
+        """A future schema version with extra fields still loads (v1 subset)."""
+        raw = {
+            "suite_name": "mix",
+            "suite_version": "1.0.0",
+            "task_count": 2,
+            "pass_count": 1,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "metrics": {"task_count": 2, "pass_count": 1},
+            "schema_version": 2,
+            "future_field": "ignored",
+        }
+        path = _write(tmp_path / "future.json", raw)
+        baseline = load_baseline(path)
+        assert baseline is not None
+        assert baseline.schema_version == 2

--- a/tests/eval/test_fixtures.py
+++ b/tests/eval/test_fixtures.py
@@ -1,0 +1,132 @@
+"""Tests for the eval YAML fixture loader (ADR-0014 task schema)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cortex.eval.fixtures import GoalFile, load_suite
+
+
+class TestLoadSuite:
+    """Loading a well-formed suite from YAML."""
+
+    def test_loads_suite_metadata(self, sample_suite):
+        """Suite name and version come from the YAML header."""
+        assert sample_suite.name == "sample"
+        assert sample_suite.version == "1.0.0"
+
+    def test_loads_all_tasks(self, sample_suite):
+        """Every task in the YAML is loaded, in order."""
+        assert [t.name for t in sample_suite.tasks] == ["write-answer", "leave-marker"]
+
+    def test_loads_scripted_turns(self, sample_suite):
+        """Each task carries its scripted user turns."""
+        assert sample_suite.tasks[0].turns == [
+            "Read data/input.txt and write the sum of the numbers to answer.txt"
+        ]
+
+    def test_loads_sandbox_files(self, sample_suite):
+        """Sandbox setup files are loaded with path and content."""
+        assert sample_suite.tasks[0].sandbox[0].path == "data/input.txt"
+        assert sample_suite.tasks[0].sandbox[0].content == "40\n2"
+
+    def test_loads_goal_state(self, sample_suite):
+        """Annotated goal state (files/absent/answer) is loaded."""
+        goal = sample_suite.tasks[0].goal
+        assert goal.files == [GoalFile(path="answer.txt", contains="42")]
+        assert goal.absent == []
+        assert goal.answer is None
+
+    def test_goal_state_with_absent_and_answer(self, tmp_path):
+        """absent paths and exact answers parse too."""
+        path = tmp_path / "suite.yaml"
+        path.write_text(
+            """
+suite:
+  name: s
+  version: 2.0.0
+tasks:
+  - name: t
+    turns: ["hello"]
+    goal:
+      absent: ["tmp/scratch.txt"]
+      answer: "42"
+""",
+            encoding="utf-8",
+        )
+        suite = load_suite(path)
+        assert suite.tasks[0].goal.absent == ["tmp/scratch.txt"]
+        assert suite.tasks[0].goal.answer == "42"
+
+
+class TestLoadSuiteErrors:
+    """Malformed fixtures fail loudly at load time."""
+
+    def _write(self, tmp_path, yaml_text: str) -> str:
+        path = tmp_path / "suite.yaml"
+        path.write_text(yaml_text, encoding="utf-8")
+        return str(path)
+
+    def test_missing_file_raises(self, tmp_path):
+        """Loading a nonexistent fixture raises."""
+        with pytest.raises(OSError):
+            load_suite(tmp_path / "nope.yaml")
+
+    def test_missing_suite_key(self, tmp_path):
+        path = self._write(tmp_path, "tasks: []\n")
+        with pytest.raises(ValueError, match="suite"):
+            load_suite(path)
+
+    def test_missing_suite_name(self, tmp_path):
+        path = self._write(tmp_path, "suite:\n  version: 1.0.0\ntasks: []\n")
+        with pytest.raises(ValueError, match="name"):
+            load_suite(path)
+
+    def test_missing_suite_version(self, tmp_path):
+        path = self._write(tmp_path, "suite:\n  name: s\ntasks: []\n")
+        with pytest.raises(ValueError, match="version"):
+            load_suite(path)
+
+    def test_no_tasks(self, tmp_path):
+        path = self._write(
+            tmp_path, "suite:\n  name: s\n  version: 1.0.0\ntasks: []\n"
+        )
+        with pytest.raises(ValueError, match="tasks"):
+            load_suite(path)
+
+    def test_task_without_turns(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            "suite:\n  name: s\n  version: 1.0.0\ntasks:\n  - name: t\n"
+            "    goal:\n      files:\n        - path: a\n",
+        )
+        with pytest.raises(ValueError, match="turns"):
+            load_suite(path)
+
+    def test_task_without_goal(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            "suite:\n  name: s\n  version: 1.0.0\ntasks:\n  - name: t\n"
+            "    turns: ['hi']\n",
+        )
+        with pytest.raises(ValueError, match="goal"):
+            load_suite(path)
+
+    def test_empty_goal_state(self, tmp_path):
+        """A goal with no checks is rejected — it would pass trivially."""
+        path = self._write(
+            tmp_path,
+            "suite:\n  name: s\n  version: 1.0.0\ntasks:\n  - name: t\n"
+            "    turns: ['hi']\n    goal: {}\n",
+        )
+        with pytest.raises(ValueError, match="goal"):
+            load_suite(path)
+
+    def test_goal_file_without_path(self, tmp_path):
+        path = self._write(
+            tmp_path,
+            "suite:\n  name: s\n  version: 1.0.0\ntasks:\n  - name: t\n"
+            "    turns: ['hi']\n    goal:\n      files:\n        - contains: x\n",
+        )
+        with pytest.raises(ValueError, match="path"):
+            load_suite(path)

--- a/tests/eval/test_grader.py
+++ b/tests/eval/test_grader.py
@@ -1,0 +1,85 @@
+"""Tests for the deterministic goal-state grader (ADR-0015)."""
+
+from __future__ import annotations
+
+from cortex.eval.fixtures import GoalFile, GoalState
+from cortex.eval.grader import grade_goal
+from cortex.eval.sandbox import TaskSandbox
+
+
+class TestGradeGoal:
+    """Goal-state grading is deterministic and executable."""
+
+    def _sandbox(self, tmp_path, files: dict[str, str]) -> TaskSandbox:
+        sandbox = TaskSandbox(root=tmp_path / "sandbox")
+        for name, content in files.items():
+            path = sandbox.root / name
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        return sandbox
+
+    def test_passes_when_goal_files_exist(self, tmp_path):
+        """A bare file expectation passes when the file exists."""
+        sandbox = self._sandbox(tmp_path, {"answer.txt": "42"})
+        result = grade_goal(GoalState(files=[GoalFile(path="answer.txt")]), sandbox)
+        assert result.passed is True
+        assert result.failures == []
+
+    def test_fails_when_goal_file_missing(self, tmp_path):
+        """A missing expected file fails with a clear reason."""
+        sandbox = self._sandbox(tmp_path, {})
+        result = grade_goal(GoalState(files=[GoalFile(path="answer.txt")]), sandbox)
+        assert result.passed is False
+        assert "answer.txt" in result.failures[0]
+
+    def test_equals_must_match_exactly(self, tmp_path):
+        """equals requires exact content."""
+        sandbox = self._sandbox(tmp_path, {"answer.txt": "43"})
+        result = grade_goal(
+            GoalState(files=[GoalFile(path="answer.txt", equals="42")]), sandbox
+        )
+        assert result.passed is False
+        sandbox2 = self._sandbox(tmp_path, {"answer.txt": "42"})
+        assert grade_goal(
+            GoalState(files=[GoalFile(path="answer.txt", equals="42")]), sandbox2
+        ).passed is True
+
+    def test_contains_is_substring(self, tmp_path):
+        """contains only requires the substring."""
+        sandbox = self._sandbox(tmp_path, {"answer.txt": "the answer is 42"})
+        result = grade_goal(
+            GoalState(files=[GoalFile(path="answer.txt", contains="42")]), sandbox
+        )
+        assert result.passed is True
+        sandbox2 = self._sandbox(tmp_path, {"answer.txt": "the answer is 43"})
+        assert grade_goal(
+            GoalState(files=[GoalFile(path="answer.txt", contains="42")]), sandbox2
+        ).passed is False
+
+    def test_absent_file_fails_when_present(self, tmp_path):
+        """absent paths must not exist in the sandbox."""
+        sandbox = self._sandbox(tmp_path, {"scratch.txt": "temp"})
+        result = grade_goal(GoalState(absent=["scratch.txt"]), sandbox)
+        assert result.passed is False
+        sandbox2 = TaskSandbox(root=tmp_path / "empty")
+        assert grade_goal(GoalState(absent=["scratch.txt"]), sandbox2).passed is True
+
+    def test_answer_match(self, tmp_path):
+        """The exact-answer goal compares the final response text."""
+        sandbox = self._sandbox(tmp_path, {})
+        goal = GoalState(answer="42")
+        assert grade_goal(goal, sandbox, final_message="42").passed is True
+        assert grade_goal(goal, sandbox, final_message="43").passed is False
+
+    def test_all_checks_must_pass(self, tmp_path):
+        """Any single failure fails the whole goal."""
+        sandbox = self._sandbox(tmp_path, {"answer.txt": "42", "scratch.txt": "x"})
+        result = grade_goal(
+            GoalState(
+                files=[GoalFile(path="answer.txt", equals="42")],
+                absent=["scratch.txt"],
+            ),
+            sandbox,
+        )
+        assert result.passed is False
+        assert len(result.failures) == 1

--- a/tests/eval/test_metrics.py
+++ b/tests/eval/test_metrics.py
@@ -1,0 +1,82 @@
+"""Tests for transcript metrics collection."""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from cortex.agentic.events import (
+    ErrorEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
+from cortex.eval.metrics import collect_metrics
+
+
+def _sid() -> str:
+    return str(uuid4())
+
+
+class TestCollectMetrics:
+    """Metrics come from the LoopEvent transcript only (what it carries today)."""
+
+    def test_empty_transcript(self):
+        """No events -> zeroed metrics."""
+        metrics = collect_metrics([])
+        assert metrics.iterations == 0
+        assert metrics.tools_used == []
+        assert metrics.tool_calls == 0
+        assert metrics.failed_calls == 0
+
+    def test_counts_iterations_from_done_event(self):
+        """iterations come from ResponseDoneEvent, summed across turns."""
+        events = [
+            ResponseDoneEvent(session_id=_sid(), message="a", iterations=2),
+            ResponseDoneEvent(session_id=_sid(), message="b", iterations=3),
+        ]
+        metrics = collect_metrics(events)
+        assert metrics.iterations == 5
+
+    def test_counts_tool_calls_in_first_use_order(self):
+        """tools_used is the unique tool names in first-use order."""
+        sid = _sid()
+        events = [
+            ToolStartEvent(session_id=sid, tool_name="grep", tool_call_id="c1"),
+            ToolStartEvent(session_id=sid, tool_name="file_read", tool_call_id="c2"),
+            ToolStartEvent(session_id=sid, tool_name="grep", tool_call_id="c3"),
+        ]
+        metrics = collect_metrics(events)
+        assert metrics.tool_calls == 3
+        assert metrics.tools_used == ["grep", "file_read"]
+
+    def test_counts_failed_tool_calls(self):
+        """ToolResultEvent(success=False) counts as a failed call."""
+        sid = _sid()
+        events = [
+            ToolResultEvent(
+                session_id=sid, tool_name="shell", tool_call_id="c1", success=True
+            ),
+            ToolResultEvent(
+                session_id=sid, tool_name="file_write", tool_call_id="c2", success=False
+            ),
+        ]
+        metrics = collect_metrics(events)
+        assert metrics.failed_calls == 1
+        assert metrics.tool_calls == 0  # only starts count calls
+
+    def test_ignores_progress_and_error_events(self):
+        """thinking/text/error events contribute nothing."""
+        sid = _sid()
+        events = [
+            ThinkingEvent(session_id=sid, message="hmm"),
+            TextDeltaEvent(session_id=sid, delta="hi"),
+            ErrorEvent(session_id=sid, error="boom"),
+            ToolStartEvent(session_id=sid, tool_name="shell", tool_call_id="c1"),
+            ResponseDoneEvent(session_id=sid, message="hi", iterations=1),
+        ]
+        metrics = collect_metrics(events)
+        assert metrics.iterations == 1
+        assert metrics.tool_calls == 1
+        assert metrics.tools_used == ["shell"]

--- a/tests/eval/test_runner.py
+++ b/tests/eval/test_runner.py
@@ -1,0 +1,281 @@
+"""Integration tests for the suite runner: real AgentLoop + fake LLM.
+
+These drive the real loop composition (Reasoner, ContextBuilder,
+LoopExecutor, the four meta tools) with a scripted LLM client, so they
+never hit a real API.
+"""
+
+import json
+from collections.abc import AsyncGenerator
+from uuid import UUID, uuid4
+
+from cortex.agentic.events import LoopEvent, TextDeltaEvent
+from cortex.eval.baseline import load_baseline
+from cortex.eval.fixtures import EvalSuite, EvalTask, GoalFile, GoalState, SandboxFile
+from cortex.eval.runner import _drive_turn, run_suite
+from tests.eval.fakes import ScriptedLLMClient
+
+
+class TestRunSuite:
+    """End-to-end suite runs against the real AgentLoop."""
+
+    async def test_passing_task_writes_goal_file(self):
+        """A task whose agent writes the goal file passes."""
+        suite = EvalSuite(
+            name="write",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="write-answer",
+                    turns=["Write 42 to answer.txt"],
+                    goal=GoalState(files=[GoalFile(path="answer.txt", equals="42")]),
+                )
+            ],
+        )
+        client = ScriptedLLMClient()
+        client.queue_tool_call("file_write", {"path": "answer.txt", "content": "42"})
+        client.queue_text("Done")
+
+        result = await run_suite(suite, client)
+
+        assert result.suite_name == "write"
+        assert result.suite_version == "1.0.0"
+        assert len(result.results) == 1
+        task = result.results[0]
+        assert task.passed is True
+        assert task.message == "Done"
+        assert task.failures == []
+        assert task.metrics.iterations == 1
+        assert task.metrics.tools_used == ["file_write"]
+        assert task.metrics.tool_calls == 1
+
+    async def test_failing_task_when_goal_not_reached(self):
+        """A task whose agent responds without doing the work fails."""
+        suite = EvalSuite(
+            name="fail",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="write-answer",
+                    turns=["Write 42 to answer.txt"],
+                    goal=GoalState(files=[GoalFile(path="answer.txt", equals="42")]),
+                )
+            ],
+        )
+        client = ScriptedLLMClient()
+        client.queue_text("I can't do that")
+
+        result = await run_suite(suite, client)
+
+        task = result.results[0]
+        assert task.passed is False
+        assert task.message == "I can't do that"
+        assert task.metrics.iterations == 0
+        assert task.metrics.tools_used == []
+        assert any("answer.txt" in f for f in task.failures)
+
+    async def test_sandbox_files_are_visible_to_tools(self):
+        """Fixture sandbox files exist for the agent's tools."""
+        suite = EvalSuite(
+            name="read",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="copy-input",
+                    turns=["Copy data/input.txt to output.txt"],
+                    goal=GoalState(files=[GoalFile(path="output.txt", equals="40\n2")]),
+                    sandbox=[SandboxFile(path="data/input.txt", content="40\n2")],
+                )
+            ],
+        )
+        client = ScriptedLLMClient()
+        client.queue_tool_call(
+            "file_write",
+            {"path": "output.txt", "content": "40\n2"},
+        )
+        client.queue_text("Copied")
+
+        result = await run_suite(suite, client)
+
+        task = result.results[0]
+        assert task.passed is True
+        assert task.metrics.tools_used == ["file_write"]
+
+    async def test_multi_turn_task_accumulates_metrics(self):
+        """Scripted turns share one session; metrics span the whole transcript."""
+        suite = EvalSuite(
+            name="multi",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="read-then-write",
+                    turns=[
+                        "Read data/input.txt",
+                        "Write the number you read to answer.txt",
+                    ],
+                    goal=GoalState(files=[GoalFile(path="answer.txt", equals="42")]),
+                    sandbox=[SandboxFile(path="data/input.txt", content="42")],
+                )
+            ],
+        )
+        client = ScriptedLLMClient()
+        # Turn 1: read the file
+        client.queue_tool_call("file_read", {"path": "data/input.txt"})
+        client.queue_text("I read 42")
+        # Turn 2: write the answer
+        client.queue_tool_call("file_write", {"path": "answer.txt", "content": "42"})
+        client.queue_text("Written")
+
+        result = await run_suite(suite, client)
+
+        task = result.results[0]
+        assert task.passed is True
+        assert task.metrics.tools_used == ["file_read", "file_write"]
+        assert task.metrics.tool_calls == 2
+        assert task.metrics.iterations == 2
+
+    async def test_shell_tool_runs_against_sandbox(self):
+        """The sandboxed shell tool works through the real loop."""
+        suite = EvalSuite(
+            name="shell",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="touch-file",
+                    turns=["Run: echo 42 > answer.txt"],
+                    goal=GoalState(files=[GoalFile(path="answer.txt", contains="42")]),
+                )
+            ],
+        )
+        client = ScriptedLLMClient()
+        client.queue_tool_call("shell", {"command": "echo 42 > answer.txt"})
+        client.queue_text("Done")
+
+        result = await run_suite(suite, client)
+
+        task = result.results[0]
+        assert task.passed is True
+        assert task.metrics.tools_used == ["shell"]
+
+    async def test_suite_metrics_and_baseline(self, tmp_path):
+        """Suite-level metrics and the versioned baseline are recorded."""
+        suite = EvalSuite(
+            name="mix",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="passes",
+                    turns=["Write 42 to answer.txt"],
+                    goal=GoalState(files=[GoalFile(path="answer.txt", contains="42")]),
+                ),
+                EvalTask(
+                    name="fails",
+                    turns=["Write 42 to other.txt"],
+                    goal=GoalState(files=[GoalFile(path="other.txt", contains="42")]),
+                ),
+            ],
+        )
+        client = ScriptedLLMClient()
+        client.queue_tool_call("file_write", {"path": "answer.txt", "content": "42"})
+        client.queue_text("done")
+        client.queue_text("nope")
+
+        baseline_path = tmp_path / "baselines" / "mix-v1.0.0.json"
+        result = await run_suite(suite, client, baseline_path=baseline_path)
+
+        assert result.metrics.task_count == 2
+        assert result.metrics.pass_count == 1
+        assert result.metrics.pass_rate == 0.5
+        assert result.metrics.tools_used == ["file_write"]
+
+        assert baseline_path.exists()
+        baseline = load_baseline(baseline_path)
+        assert baseline is not None
+        assert baseline.suite_name == "mix"
+        assert baseline.suite_version == "1.0.0"
+        assert baseline.task_count == 2
+        assert baseline.pass_count == 1
+        assert baseline.metrics.pass_rate == 0.5
+        assert baseline.created_at
+        assert baseline.schema_version == 1
+
+        raw = json.loads(baseline_path.read_text(encoding="utf-8"))
+        assert raw["suite_name"] == "mix"
+        assert "created_at" in raw
+
+    async def test_sample_suite_runs_end_to_end(self, sample_suite: EvalSuite):
+        """The shipped sample YAML suite runs: one pass, one fail."""
+        client = ScriptedLLMClient()
+        # write-answer task: read is optional; script writes the answer directly
+        client.queue_tool_call("file_write", {"path": "answer.txt", "content": "42"})
+        client.queue_text("Written answer.txt")
+        # leave-marker task: agent never creates the marker
+        client.queue_text("I'm done")
+
+        result = await run_suite(sample_suite, client)
+
+        assert result.suite_name == "sample"
+        assert result.metrics.task_count == 2
+        assert result.metrics.pass_count == 1
+        assert [r.name for r in result.results] == ["write-answer", "leave-marker"]
+        assert result.results[0].passed is True
+        assert result.results[1].passed is False
+
+    async def test_loop_error_after_goal_met_reports_not_passed(self):
+        """A loop failure after the goal state was reached fails the task.
+
+        The goal file is written on turn two, then the loop raises
+        MaxIterationsError; the task must not be reported passed and the
+        error must surface in the message rather than a stale earlier-turn
+        message.
+        """
+        suite = EvalSuite(
+            name="error-after-goal",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="write-then-exceed",
+                    turns=[
+                        "Acknowledge the request",
+                        "Write 42 to answer.txt",
+                    ],
+                    goal=GoalState(files=[GoalFile(path="answer.txt", equals="42")]),
+                )
+            ],
+        )
+        client = ScriptedLLMClient()
+        # Turn 1 completes normally, leaving an earlier-turn message behind.
+        client.queue_text("On it")
+        # Turn 2 writes the goal file, then the loop hits the iteration cap.
+        client.queue_tool_call("file_write", {"path": "answer.txt", "content": "42"})
+
+        result = await run_suite(suite, client, max_iterations=1)
+
+        task = result.results[0]
+        assert task.passed is False
+        assert any(f.startswith("loop error:") for f in task.failures)
+        assert "exceeded 1 iterations" in task.message
+        assert task.message != "On it"
+
+
+class _TwoDeltaLoop:
+    """Minimal stand-in for AgentLoop streaming two text deltas per turn."""
+
+    async def stream_chat(
+        self, session_id: UUID, user_message: str
+    ) -> AsyncGenerator[LoopEvent, None]:
+        yield TextDeltaEvent(session_id, delta="Hello")
+        yield TextDeltaEvent(session_id, delta=" world")
+
+
+class TestDriveTurn:
+    """Per-turn response text must accumulate deltas in order."""
+
+    async def test_multiple_delta_events_accumulate_in_order(self):
+        """Two TextDeltaEvents in one turn concatenate, not last-wins."""
+        events: list[LoopEvent] = []
+        text = await _drive_turn(_TwoDeltaLoop(), uuid4(), "Say hello", events)
+
+        assert text == "Hello world"
+        deltas = [e.delta for e in events if isinstance(e, TextDeltaEvent)]
+        assert deltas == ["Hello", " world"]

--- a/tests/eval/test_sandbox.py
+++ b/tests/eval/test_sandbox.py
@@ -1,0 +1,107 @@
+"""Tests for the per-task sandbox and sandboxed tool wrappers."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from cortex.eval.fixtures import SandboxFile
+from cortex.eval.sandbox import SandboxedTool, SandboxEscapeError, TaskSandbox
+from cortex.tools.executor import DefaultToolExecutor
+from cortex.tools.interfaces import ToolCall
+from cortex.tools.meta import FileReadTool, FileWriteTool, ShellTool
+from cortex.tools.registry import InMemoryToolRegistry
+
+
+class TestTaskSandbox:
+    """The sandbox directory itself."""
+
+    def test_root_created_under_tmp(self):
+        """A sandbox without an explicit root lives under the system tmp."""
+        sandbox = TaskSandbox()
+        try:
+            assert sandbox.root.exists()
+            assert str(sandbox.root).startswith(tempfile.gettempdir())
+        finally:
+            sandbox.cleanup()
+        assert not sandbox.root.exists()
+
+    def test_setup_writes_files_with_parents(self, tmp_path):
+        """setup() materializes fixture files, creating parent dirs."""
+        sandbox = TaskSandbox(root=tmp_path / "s")
+        sandbox.setup([SandboxFile(path="data/input.txt", content="40\n2")])
+        assert (sandbox.root / "data" / "input.txt").read_text() == "40\n2"
+
+    def test_confine_relative_path_inside_sandbox(self, tmp_path):
+        """Relative paths resolve under the sandbox root."""
+        sandbox = TaskSandbox(root=tmp_path)
+        assert sandbox.confine("a/b.txt") == (tmp_path / "a" / "b.txt").resolve()
+
+    def test_confine_rejects_parent_traversal(self, tmp_path):
+        """'..' escapes are refused."""
+        sandbox = TaskSandbox(root=tmp_path)
+        with pytest.raises(SandboxEscapeError):
+            sandbox.confine("../escape.txt")
+
+    def test_confine_rejects_absolute_path_outside(self, tmp_path):
+        """Absolute paths outside the sandbox are refused."""
+        sandbox = TaskSandbox(root=tmp_path)
+        with pytest.raises(SandboxEscapeError):
+            sandbox.confine("/etc/passwd")
+
+
+class TestSandboxedTool:
+    """Tool wrappers confine execution to the sandbox."""
+
+    async def test_file_write_lands_in_sandbox(self, tmp_path):
+        """A relative write goes to the sandbox, not the host cwd."""
+        sandbox = TaskSandbox(root=tmp_path)
+        tool = SandboxedTool(FileWriteTool(), sandbox)
+        result = await tool.execute({"path": "answer.txt", "content": "42"})
+        assert result.success is True
+        assert (sandbox.root / "answer.txt").read_text() == "42"
+        assert not (os.getcwd() / Path("answer.txt")).exists()
+
+    async def test_file_read_is_confined(self, tmp_path):
+        """Reads resolve inside the sandbox."""
+        sandbox = TaskSandbox(root=tmp_path)
+        (sandbox.root / "note.txt").write_text("hello", encoding="utf-8")
+        read_tool = SandboxedTool(FileReadTool(), sandbox)
+        result = await read_tool.execute({"path": "note.txt"})
+        assert result.success is True
+        assert result.output == "hello"
+
+    async def test_escape_attempt_fails_execution(self, tmp_path):
+        """A traversal attempt surfaces as a failed tool result via the executor."""
+        sandbox = TaskSandbox(root=tmp_path)
+        registry = InMemoryToolRegistry()
+        registry.register(SandboxedTool(FileWriteTool(), sandbox))
+        executor = DefaultToolExecutor(registry=registry)
+        result = await executor.execute(
+            ToolCall(
+                name="file_write",
+                arguments={"path": "../evil.txt", "content": "x"},
+            )
+        )
+        assert result.success is False
+        assert not (tmp_path.parent / "evil.txt").exists()
+
+    async def test_shell_runs_in_sandbox_working_dir(self, tmp_path):
+        """shell commands run with the sandbox as their working directory."""
+        sandbox = TaskSandbox(root=tmp_path)
+        tool = SandboxedTool(ShellTool(), sandbox)
+        result = await tool.execute({"command": "pwd"})
+        assert result.success is True
+        assert str(sandbox.root) in result.output
+
+    async def test_shell_writes_stay_in_sandbox(self, tmp_path):
+        """Files created by shell land in the sandbox, not the host cwd."""
+        sandbox = TaskSandbox(root=tmp_path)
+        tool = SandboxedTool(ShellTool(), sandbox)
+        result = await tool.execute({"command": "echo hi > hello.txt"})
+        assert result.success is True
+        assert (sandbox.root / "hello.txt").read_text().strip() == "hi"
+        assert not os.path.exists(os.path.join(os.getcwd(), "hello.txt"))


### PR DESCRIPTION
Closes #88 (T2 — Eval harness core).

- src/cortex/eval/: YAML fixtures loader, per-task sandbox with tool confinement (traversal/absolute escapes fail the call), deterministic goal-state grader (ADR-0015: goal state is the only pass/fail oracle), LoopEvent-transcript metrics, versioned baseline (schema_version=1)
- tests/eval/: 59 tests with scripted fake LLM client (full LLMClient ABC), sample suite end-to-end; load_baseline returns None for every malformed root (shape-only validation, forward-compatible)
- Composes real AgentLoop + ContextBuilder + LoopExecutor + four meta tools from outside; zero new seams in existing modules (ADR-0014)
- CI: tests/eval appended to pytest + coverage invocations

Review: two-axis (standards+spec) zero fatal findings; 702 tests pass (79% coverage), mypy strict clean, ruff clean.