### PR TITLE
feat: capability smoke suite E3 (#89)

### DIFF
--- a/src/cortex/eval/__init__.py
+++ b/src/cortex/eval/__init__.py
@@ -13,17 +13,22 @@ Public seam:
   injected (or factory-created) LLM client, grades goal states, records
   metrics and an optional versioned baseline
 * :func:`record_baseline` / :func:`load_baseline` — per-suite baseline JSON
+* :func:`load_manifest` — per-suite version pins (prompt/model/grading)
+* :func:`validate_suite_balance` — golden-set positive/negative balance guard
 * :class:`TaskSandbox` — per-task sandbox the tools execute against
 """
 
 from cortex.eval.baseline import EvalBaseline, load_baseline, record_baseline
 from cortex.eval.fixtures import (
+    EvalManifest,
     EvalSuite,
     EvalTask,
     GoalFile,
     GoalState,
     SandboxFile,
+    load_manifest,
     load_suite,
+    validate_suite_balance,
 )
 from cortex.eval.grader import GradingResult, grade_goal
 from cortex.eval.metrics import SuiteMetrics, TaskMetrics, collect_metrics
@@ -32,6 +37,7 @@ from cortex.eval.sandbox import SandboxedTool, SandboxEscapeError, TaskSandbox
 
 __all__ = [
     "EvalBaseline",
+    "EvalManifest",
     "EvalSuite",
     "EvalTask",
     "GradingResult",
@@ -48,7 +54,9 @@ __all__ = [
     "collect_metrics",
     "grade_goal",
     "load_baseline",
+    "load_manifest",
     "load_suite",
     "record_baseline",
     "run_suite",
+    "validate_suite_balance",
 ]

--- a/src/cortex/eval/fixtures.py
+++ b/src/cortex/eval/fixtures.py
@@ -25,10 +25,16 @@ A fixture file is a YAML document with a ``suite`` header and a non-empty
               contains: "4" # substring match (optional, alternative to equals)
           absent:           # optional paths that must not exist
             - tmp/scratch.txt
-          answer: "42"      # optional exact final-response text match
+          answer: "42"      # optional final-response match: one exact string,
+                            # or a list of accepted strings matched
+                            # case/whitespace-insensitively (normalized)
 
 The goal state is graded deterministically against the sandbox directory
 after the run (and, for ``answer``, against the final response text).
+
+Suites may ship a sibling manifest (see :func:`load_manifest`) pinning the
+prompt, model, and grading versions the suite's baselines assume, and may be
+checked for golden-set balance with :func:`validate_suite_balance`.
 """
 
 from __future__ import annotations
@@ -59,11 +65,16 @@ class GoalFile:
 
 @dataclass
 class GoalState:
-    """Annotated goal state — the deterministic pass/fail oracle (ADR-0015)."""
+    """Annotated goal state — the deterministic pass/fail oracle (ADR-0015).
+
+    ``answer`` matches the final response text: either one exact string
+    (matched verbatim) or a list of accepted strings matched
+    case/whitespace-insensitively (graded by :mod:`cortex.eval.grader`).
+    """
 
     files: list[GoalFile] = field(default_factory=list)
     absent: list[str] = field(default_factory=list)
-    answer: str | None = None
+    answer: str | list[str] | None = None
 
 
 @dataclass
@@ -86,6 +97,21 @@ class EvalSuite:
     tasks: list[EvalTask]
 
 
+@dataclass
+class EvalManifest:
+    """Version pins for a suite: prompt, model, and grading versions.
+
+    Recorded in a plain YAML file beside the fixture so baselines and
+    nightly runs stay comparable over time (CONTEXT.md: Eval Baseline).
+    """
+
+    suite_name: str
+    suite_version: str
+    prompt_version: str
+    model: str
+    grading_version: str
+
+
 def load_suite(path: str | Path) -> EvalSuite:
     """Load an :class:`EvalSuite` from a YAML fixture file.
 
@@ -95,6 +121,89 @@ def load_suite(path: str | Path) -> EvalSuite:
     """
     raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
     return _parse_suite(raw, str(path))
+
+
+def load_manifest(path: str | Path) -> EvalManifest:
+    """Load an :class:`EvalManifest` from a plain YAML manifest file.
+
+    Expected shape::
+
+        suite:
+          name: capability
+          version: 1.0.0
+        prompt_version: <sha256 of the reasoner system prompt>
+        model: <settings llm_model>
+        grading_version: <grader GRADING_SCHEMA_VERSION>
+
+    Raises:
+        OSError: If the file cannot be read.
+        ValueError: If the document does not match the manifest shape.
+    """
+    raw = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    source = str(path)
+    if not isinstance(raw, dict) or not isinstance(raw.get("suite"), dict):
+        raise ValueError(f"{source}: manifest must have a 'suite' mapping")
+
+    suite = raw["suite"]
+    name = suite.get("name")
+    version = suite.get("version")
+    if not isinstance(name, str) or not name:
+        raise ValueError(f"{source}: manifest suite.name must be a non-empty string")
+    if not isinstance(version, str) or not version:
+        raise ValueError(f"{source}: manifest suite.version must be a non-empty string")
+
+    prompt_version = raw.get("prompt_version")
+    if not isinstance(prompt_version, str) or not prompt_version:
+        raise ValueError(
+            f"{source}: manifest prompt_version must be a non-empty string"
+        )
+
+    model = raw.get("model")
+    if not isinstance(model, str) or not model:
+        raise ValueError(f"{source}: manifest model must be a non-empty string")
+
+    grading_version = raw.get("grading_version")
+    if isinstance(grading_version, bool) or not isinstance(
+        grading_version, (str, int)
+    ):
+        raise ValueError(
+            f"{source}: manifest grading_version must be a string or int"
+        )
+    grading_version_str = str(grading_version)
+    if not grading_version_str:
+        raise ValueError(f"{source}: manifest grading_version must be non-empty")
+
+    return EvalManifest(
+        suite_name=name,
+        suite_version=version,
+        prompt_version=prompt_version,
+        model=model,
+        grading_version=grading_version_str,
+    )
+
+
+def validate_suite_balance(suite: EvalSuite) -> list[str]:
+    """Return balance violations for a golden set; an empty list means balanced.
+
+    The golden set must contain both kinds of cases (one-sided-optimization
+    guard, CONTEXT.md: Golden Set): positive cases whose goal declares
+    something that must happen (``files`` or ``answer``) and negative cases
+    whose goal declares something that must NOT happen (``absent``) — the
+    not-answer / must-not-tool-use tasks.
+    """
+    violations: list[str] = []
+    has_positive = any(t.goal.files or t.goal.answer is not None for t in suite.tasks)
+    has_negative = any(t.goal.absent for t in suite.tasks)
+    if not has_positive:
+        violations.append(
+            "suite has no positive cases (tasks whose goal requires files or an answer)"
+        )
+    if not has_negative:
+        violations.append(
+            "suite has no negative cases (tasks whose goal declares absent paths — "
+            "the not-answer / must-not-tool-use behavior)"
+        )
+    return violations
 
 
 def _parse_suite(raw: Any, source: str) -> EvalSuite:
@@ -152,9 +261,7 @@ def _parse_task(raw: Any, source: str, index: int) -> EvalTask:
     files_raw = sandbox_raw.get("files", [])
     if not isinstance(files_raw, list):
         raise ValueError(f"{where}: sandbox.files must be a list")
-    sandbox = [
-        _parse_sandbox_file(f, where) for f in files_raw
-    ]
+    sandbox = [_parse_sandbox_file(f, where) for f in files_raw]
 
     return EvalTask(
         name=name,
@@ -202,10 +309,20 @@ def _parse_goal(raw: dict[str, Any], where: str) -> GoalState:
         raise ValueError(f"{where}: goal.absent must be a list of strings")
 
     answer = raw.get("answer")
-    if answer is not None and not isinstance(answer, str):
-        raise ValueError(f"{where}: goal.answer must be a string")
+    if isinstance(answer, str):
+        parsed_answer: str | list[str] | None = answer
+    elif isinstance(answer, list) and answer and all(
+        isinstance(variant, str) and variant for variant in answer
+    ):
+        parsed_answer = [str(variant) for variant in answer]
+    elif answer is not None:
+        raise ValueError(
+            f"{where}: goal.answer must be a string or a non-empty list of strings"
+        )
+    else:
+        parsed_answer = None
 
-    goal = GoalState(files=files, absent=list(absent), answer=answer)
-    if not (files or absent or answer):
+    goal = GoalState(files=files, absent=list(absent), answer=parsed_answer)
+    if not (files or absent or parsed_answer):
         raise ValueError(f"{where}: goal must declare at least one check")
     return goal

--- a/src/cortex/eval/grader.py
+++ b/src/cortex/eval/grader.py
@@ -4,6 +4,12 @@ The annotated goal state — sandbox filesystem state and, optionally, the
 exact final answer — is the only pass/fail oracle. Grading compares the
 sandbox directory (and final response text) against the goal with plain
 executable checks: file existence, exact content, substring, absence.
+
+``goal.answer`` accepts either one exact string (matched verbatim, the
+original behavior) or a list of accepted strings matched
+case/whitespace-insensitively via :func:`normalize_answer` — the shape the
+capability smoke suite uses. :data:`GRADING_SCHEMA_VERSION` pins the
+grading semantics so suites can record which grader their baselines assume.
 """
 
 from __future__ import annotations
@@ -12,6 +18,19 @@ from dataclasses import dataclass, field
 
 from cortex.eval.fixtures import GoalState
 from cortex.eval.sandbox import TaskSandbox
+
+#: Version of the grading semantics; bump on any behavioral change. Suites
+#: pin this in their manifest (``grading_version``).
+GRADING_SCHEMA_VERSION = 1
+
+
+def normalize_answer(text: str) -> str:
+    """Normalize an answer for comparison: strip, lowercase, collapse whitespace.
+
+    Makes exact-match grading insensitive to capitalization, leading/trailing
+    whitespace, and irregular spacing between words.
+    """
+    return " ".join(text.strip().lower().split())
 
 
 @dataclass
@@ -49,6 +68,16 @@ def grade_goal(
     for absent_path in goal.absent:
         if sandbox.confine(absent_path).exists():
             failures.append(f"unexpected file: {absent_path}")
-    if goal.answer is not None and final_message != goal.answer:
-        failures.append(f"final answer {final_message!r} != expected {goal.answer!r}")
+    if goal.answer is not None:
+        if isinstance(goal.answer, list):
+            accepted = {normalize_answer(variant) for variant in goal.answer}
+            if normalize_answer(final_message) not in accepted:
+                failures.append(
+                    f"final answer {final_message!r} not in accepted variants "
+                    f"{goal.answer!r}"
+                )
+        elif final_message != goal.answer:
+            failures.append(
+                f"final answer {final_message!r} != expected {goal.answer!r}"
+            )
     return GradingResult(passed=not failures, failures=failures)

--- a/src/cortex/eval/metrics.py
+++ b/src/cortex/eval/metrics.py
@@ -1,10 +1,11 @@
 """Task and suite metrics from the LoopEvent transcript.
 
-Metrics are recorded from the loop's streaming events — what the
-transcript carries today: ``ResponseDoneEvent.iterations``,
-``ToolStartEvent`` tool names, ``ToolResultEvent`` success flags. Usage and
-latency fields are intentionally not depended on (a sibling ticket adds
-them to the transcript).
+Metrics are recorded from the loop's streaming events — what the transcript
+carries today: ``ResponseDoneEvent.iterations`` and the response ``usage``
+and ``latency_ms`` it carries, ``ToolStartEvent`` tool names, and
+``ToolResultEvent`` success flags. Per-question cost is derived from usage
+tokens × per-model pricing (:func:`cortex.config.models.derive_cost`) when
+pricing is supplied; per-question latency is the loop's wall time.
 """
 
 from __future__ import annotations
@@ -17,6 +18,7 @@ from cortex.agentic.events import (
     ToolResultEvent,
     ToolStartEvent,
 )
+from cortex.config.models import ModelPricing, derive_cost
 
 
 @dataclass
@@ -27,6 +29,8 @@ class TaskMetrics:
     tools_used: list[str] = field(default_factory=list)  # unique, first-use order
     tool_calls: int = 0
     failed_calls: int = 0
+    cost: float = 0.0  # USD, usage tokens × pricing (0 when pricing unknown)
+    latency_ms: float = 0.0  # loop wall time across the task's responses
 
 
 @dataclass
@@ -50,14 +54,30 @@ class SuiteMetrics:
         return self.total_iterations / self.task_count if self.task_count else 0.0
 
 
-def collect_metrics(events: list[LoopEvent]) -> TaskMetrics:
-    """Reduce a task's event transcript to :class:`TaskMetrics`."""
+def collect_metrics(
+    events: list[LoopEvent], pricing: ModelPricing | None = None
+) -> TaskMetrics:
+    """Reduce a task's event transcript to :class:`TaskMetrics`.
+
+    ``cost`` estimates each response's token usage at ``pricing``; pass the
+    suite model's pricing (settings ``llm_pricing``) to get nonzero
+    per-question cost. ``latency_ms`` sums the per-response loop wall time
+    carried by ``ResponseDoneEvent``.
+    """
     metrics = TaskMetrics()
     seen: set[str] = set()
+    cost = 0.0
+    latency_ms = 0.0
     for event in events:
         match event:
-            case ResponseDoneEvent(iterations=iterations):
+            case ResponseDoneEvent(
+                iterations=iterations, usage=usage, latency_ms=latency
+            ):
                 metrics.iterations += iterations
+                if usage is not None and pricing is not None:
+                    cost += derive_cost(usage, pricing)
+                if latency is not None:
+                    latency_ms += latency
             case ToolStartEvent(tool_name=name):
                 metrics.tool_calls += 1
                 if name not in seen:
@@ -66,4 +86,6 @@ def collect_metrics(events: list[LoopEvent]) -> TaskMetrics:
             case ToolResultEvent(success=success):
                 if not success:
                     metrics.failed_calls += 1
+    metrics.cost = cost
+    metrics.latency_ms = latency_ms
     return metrics

--- a/src/cortex/eval/runner.py
+++ b/src/cortex/eval/runner.py
@@ -34,6 +34,7 @@ from cortex.tools.executor import DefaultToolExecutor
 from cortex.tools.registry import InMemoryToolRegistry
 
 if TYPE_CHECKING:
+    from cortex.config.models import ModelPricing
     from cortex.llm.base import LLMClient
     from cortex.memory.context_provider import ContextProvider
 
@@ -156,6 +157,7 @@ async def run_suite(
     *,
     max_iterations: int = 20,
     baseline_path: str | Path | None = None,
+    pricing: ModelPricing | None = None,
 ) -> SuiteResult:
     """Run every task in ``suite`` through the real AgentLoop.
 
@@ -167,13 +169,25 @@ async def run_suite(
         max_iterations: Per-turn iteration cap for the loop.
         baseline_path: When given, a versioned baseline JSON is recorded
             for the suite at this path.
+        pricing: Per-model token pricing used to estimate per-task LLM cost
+            from usage. When None and a real client is created from settings,
+            the configured model's pricing is used; when None with an
+            injected client, cost is reported as zero.
 
     Returns:
         A :class:`SuiteResult` with per-task results and suite metrics.
     """
-    client = llm_client if llm_client is not None else _default_llm_client()
+    client = llm_client
+    if client is None:
+        from cortex.config.loader import get_settings
+        from cortex.llm.factory import LLMClientFactory
+
+        settings = get_settings()
+        client = LLMClientFactory(settings).create()
+        if pricing is None:
+            pricing = settings.llm_pricing.get(settings.llm_model)
     results = [
-        await _run_task(task, client, max_iterations=max_iterations)
+        await _run_task(task, client, max_iterations=max_iterations, pricing=pricing)
         for task in suite.tasks
     ]
     metrics = _suite_metrics(results)
@@ -195,19 +209,12 @@ async def run_suite(
     return suite_result
 
 
-def _default_llm_client() -> LLMClient:
-    """Create a real LLM client from settings (requires LLM_API_KEY etc.)."""
-    from cortex.config.loader import get_settings
-    from cortex.llm.factory import LLMClientFactory
-
-    return LLMClientFactory(get_settings()).create()
-
-
 async def _run_task(
     task: EvalTask,
     llm_client: LLMClient,
     *,
     max_iterations: int,
+    pricing: ModelPricing | None,
 ) -> TaskResult:
     sandbox = TaskSandbox()
     events: list[LoopEvent] = []
@@ -238,7 +245,7 @@ async def _run_task(
         passed=grade.passed and error is None,
         message=error or final_message,
         failures=failures,
-        metrics=collect_metrics(events),
+        metrics=collect_metrics(events, pricing=pricing),
     )
 
 

--- a/tests/eval/fakes.py
+++ b/tests/eval/fakes.py
@@ -12,7 +12,7 @@ from typing import Any
 from cortex.config.models import Settings
 from cortex.llm.base import LLMClient
 from cortex.llm.config import GenerationConfig
-from cortex.llm.models import ChatMessage, ChatResult, Role
+from cortex.llm.models import ChatMessage, ChatResult, Role, UsageStats
 from cortex.tools.interfaces import ToolCall, ToolDefinition
 
 
@@ -23,19 +23,29 @@ class ScriptedLLMClient(LLMClient):
         self._responses: list[ChatResult] = list(responses or [])
         self.calls: list[list[ChatMessage]] = []
 
-    def queue_tool_call(self, name: str, arguments: dict[str, Any]) -> None:
+    def queue_tool_call(
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        *,
+        usage: UsageStats | None = None,
+    ) -> None:
         """Queue a response that tells the loop to call a tool."""
         self._responses.append(
             ChatResult(
                 message=ChatMessage(role=Role.ASSISTANT, content=""),
                 tool_calls=[ToolCall(name=name, arguments=arguments)],
+                usage=usage,
             )
         )
 
-    def queue_text(self, text: str) -> None:
+    def queue_text(self, text: str, *, usage: UsageStats | None = None) -> None:
         """Queue a response that ends the loop with the given text."""
         self._responses.append(
-            ChatResult(message=ChatMessage(role=Role.ASSISTANT, content=text))
+            ChatResult(
+                message=ChatMessage(role=Role.ASSISTANT, content=text),
+                usage=usage,
+            )
         )
 
     @property

--- a/tests/eval/fixtures/capability_suite.manifest.yaml
+++ b/tests/eval/fixtures/capability_suite.manifest.yaml
@@ -1,0 +1,20 @@
+# Manifest for the capability smoke suite (E3).
+#
+# Plain YAML the harness reads (load_manifest); pins every version that
+# determines what a pass/fail means, so baselines and nightly runs stay
+# comparable over time.
+suite:
+  name: capability
+  version: 1.0.0
+
+# SHA-256 of the reasoner default system prompt
+# (src/cortex/agentic/reasoner.py, Reasoner._default_system_prompt()).
+# Recompute and bump whenever the prompt text changes.
+prompt_version: a7e52a6d5839c8443e272e5cf57722ed6c4ae2062e31d60e1c996edcd5508021
+
+# The model this suite targets — settings llm_model (config.yaml: llm.model).
+model: deepseek-chat
+
+# Grading logic version — must equal GRADING_SCHEMA_VERSION in
+# src/cortex/eval/grader.py. Bump when grader semantics change.
+grading_version: 1

--- a/tests/eval/fixtures/capability_suite.yaml
+++ b/tests/eval/fixtures/capability_suite.yaml
@@ -1,0 +1,218 @@
+# Capability smoke suite (E3): 20 GAIA-style questions graded by exact match
+# on the final response. Self-contained — no sandbox files, no environment,
+# cheap to run. Every question uses the goal.answer list form: accepted
+# variants matched case/whitespace-insensitively.
+#
+# The golden set is balanced (one-sided-optimization guard): 15 positive
+# cases (the right behavior is to answer) and 5 negative cases (name prefix
+# `refuse-`; the right behavior is to refuse, ask for clarification, or state
+# that the question is unanswerable — a definitive answer must NOT be given,
+# and no answer artifact may be written: goal.absent).
+suite:
+  name: capability
+  version: 1.0.0
+
+tasks:
+  # ── Positive cases: the right behavior is to answer ────────────────────
+  - name: arithmetic-17x23
+    description: GAIA-style multiplication with a single numeric answer
+    turns:
+      - "What is 17 times 23?"
+    goal:
+      answer:
+        - "391"
+
+  - name: train-distance
+    description: Rate × time word problem (60 mph for 2.5 hours)
+    turns:
+      - "A train travels at 60 miles per hour for 2.5 hours. How far does it travel?"
+    goal:
+      answer:
+        - "150 miles"
+        - "150"
+
+  - name: seconds-in-3-hours
+    description: Unit conversion; comma-formatting variant accepted
+    turns:
+      - "How many seconds are in 3 hours?"
+    goal:
+      answer:
+        - "10800"
+        - "10,800"
+
+  - name: tallest-person
+    description: Transitive ordering — Alice over Bob over Carol
+    turns:
+      - "Alice is taller than Bob, and Bob is taller than Carol. Who is the tallest?"
+    goal:
+      answer:
+        - "Alice"
+
+  - name: romeo-and-juliet
+    description: Trivia — full and surname-only forms accepted
+    turns:
+      - "Who wrote the play Romeo and Juliet?"
+    goal:
+      answer:
+        - "William Shakespeare"
+        - "Shakespeare"
+
+  - name: capital-of-france
+    description: Trivia — single-word answer
+    turns:
+      - "What is the capital of France?"
+    goal:
+      answer:
+        - "Paris"
+
+  - name: chemical-symbol-gold
+    description: Science — case-insensitive so AU/au match Au
+    turns:
+      - "What is the chemical symbol for the element gold?"
+    goal:
+      answer:
+        - "Au"
+
+  - name: sqrt-144
+    description: Math — principal square root
+    turns:
+      - "What is the square root of 144?"
+    goal:
+      answer:
+        - "12"
+
+  - name: percent-25-of-80
+    description: Percent arithmetic
+    turns:
+      - "What is 25 percent of 80?"
+    goal:
+      answer:
+        - "20"
+
+  - name: ww2-end-year
+    description: History — single year
+    turns:
+      - "In what year did World War II end?"
+    goal:
+      answer:
+        - "1945"
+
+  - name: largest-ocean
+    description: Geography — article-free and article variants accepted
+    turns:
+      - "What is the largest ocean on Earth?"
+    goal:
+      answer:
+        - "Pacific Ocean"
+        - "the Pacific Ocean"
+        - "Pacific"
+
+  - name: next-in-sequence
+    description: Number sequence — doubling pattern
+    turns:
+      - "What is the next number in the sequence 2, 4, 8, 16?"
+    goal:
+      answer:
+        - "32"
+
+  - name: letters-in-encyclopedia
+    description: Letter counting — no external knowledge needed
+    turns:
+      - "How many letters are in the word encyclopedia?"
+    goal:
+      answer:
+        - "12"
+
+  - name: algebra-x-plus-5
+    description: Simple linear equation
+    turns:
+      - "If x + 5 = 12, what is the value of x?"
+    goal:
+      answer:
+        - "7"
+
+  - name: original-price
+    description: Reverse percentage — 45 is 75% of the original price
+    turns:
+      - "A shirt costs $45 after a 25% discount. What was its original price?"
+    goal:
+      answer:
+        - "$60"
+        - "60 dollars"
+        - "60"
+
+  # ── Negative cases: the right behavior is NOT to answer ────────────────
+  - name: refuse-subjective-best-player
+    description: >-
+      Subjective question — must refuse or ask for criteria, never name a
+      definitive "best" player, and must not write an answer artifact.
+    turns:
+      - "Who is the best football player of all time?"
+    goal:
+      answer:
+        - "There is no objective answer"
+        - "This is subjective"
+        - "There is no single best player"
+        - "What criteria should I use?"
+      absent:
+        - "best-player.txt"
+
+  - name: refuse-underspecified-weather
+    description: >-
+      Under-specified — no location given, so the right behavior is to ask
+      for it rather than invent a forecast.
+    turns:
+      - "What is the weather like today?"
+    goal:
+      answer:
+        - "Which location?"
+        - "What city?"
+        - "I need a location"
+        - "You haven't specified a location"
+      absent:
+        - "weather.txt"
+
+  - name: refuse-private-breakfast
+    description: >-
+      Unanswerable from available information — must say so, not invent a
+      plausible-sounding meal.
+    turns:
+      - "What did I have for breakfast yesterday?"
+    goal:
+      answer:
+        - "I don't know"
+        - "I don't have access to that information"
+        - "I have no way of knowing"
+        - "I can't know what you ate"
+      absent:
+        - "breakfast.txt"
+
+  - name: refuse-future-winner
+    description: >-
+      Future event — unknowable; must refuse to predict rather than guess a
+      winner.
+    turns:
+      - "Who will win the 2030 FIFA World Cup?"
+    goal:
+      answer:
+        - "I can't predict the future"
+        - "It is impossible to predict"
+        - "Nobody knows yet"
+        - "The outcome is unknown"
+      absent:
+        - "winner.txt"
+
+  - name: refuse-unsolvable-equation
+    description: >-
+      Contradiction — x + 3 = x + 5 has no solution; the right behavior is
+      to say so, not produce a bogus value.
+    turns:
+      - "What is the solution to x + 3 = x + 5?"
+    goal:
+      answer:
+        - "There is no solution"
+        - "No solution"
+        - "The equation has no solution"
+        - "It is impossible"
+      absent:
+        - "solution.txt"

--- a/tests/eval/test_capability_suite.py
+++ b/tests/eval/test_capability_suite.py
@@ -1,0 +1,205 @@
+"""Tests for the capability smoke suite (E3): fixture, balance, manifest, e2e.
+
+The suite is 20 GAIA-style questions with normalized exact-match grading,
+balanced between positive answer cases and negative refuse/not-answer cases.
+All tests run against the real harness with the scripted LLM client — never
+a real API.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from cortex.agentic.reasoner import Reasoner
+from cortex.config.models import ModelPricing
+from cortex.eval.fixtures import (
+    EvalSuite,
+    EvalTask,
+    GoalState,
+    load_manifest,
+    load_suite,
+    validate_suite_balance,
+)
+from cortex.eval.grader import GRADING_SCHEMA_VERSION
+from cortex.eval.runner import run_suite
+from cortex.llm.models import UsageStats
+from cortex.tools.registry import InMemoryToolRegistry
+from tests.eval.fakes import ScriptedLLMClient
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SUITE_PATH = FIXTURES / "capability_suite.yaml"
+MANIFEST_PATH = FIXTURES / "capability_suite.manifest.yaml"
+
+
+@pytest.fixture(scope="module")
+def capability_suite() -> EvalSuite:
+    return load_suite(SUITE_PATH)
+
+
+class TestCapabilityFixture:
+    """The golden set is a 20-question, environment-free fixture."""
+
+    def test_loads_20_questions(self, capability_suite: EvalSuite) -> None:
+        assert capability_suite.name == "capability"
+        assert capability_suite.version == "1.0.0"
+        assert len(capability_suite.tasks) == 20
+
+    def test_every_question_is_single_turn_with_answer_variants(
+        self, capability_suite: EvalSuite
+    ) -> None:
+        for task in capability_suite.tasks:
+            assert len(task.turns) == 1
+            assert task.sandbox == []  # no environment
+            assert isinstance(task.goal.answer, list)
+            assert len(task.goal.answer) >= 1
+
+    def test_golden_set_is_balanced(self, capability_suite: EvalSuite) -> None:
+        """Positive and negative cases coexist (one-sided-optimization guard)."""
+        negatives = [t for t in capability_suite.tasks if t.name.startswith("refuse-")]
+        positives = [t for t in capability_suite.tasks if not t.name.startswith("refuse-")]
+        assert len(negatives) == 5
+        assert len(positives) == 15
+        for task in negatives:
+            assert task.goal.absent, "negative cases declare must-not-happen paths"
+        for task in positives:
+            assert task.goal.answer is not None
+
+    def test_balance_validator_accepts_suite(self, capability_suite: EvalSuite) -> None:
+        assert validate_suite_balance(capability_suite) == []
+
+
+class TestBalanceValidation:
+    """The balance guard flags one-sided golden sets."""
+
+    def test_positive_only_suite_is_unbalanced(self) -> None:
+        suite = EvalSuite(
+            name="one-sided",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="answer-1",
+                    turns=["What is 1 + 1?"],
+                    goal=GoalState(answer=["2"]),
+                )
+            ],
+        )
+        violations = validate_suite_balance(suite)
+        assert any("negative" in v for v in violations)
+
+    def test_negative_only_suite_is_unbalanced(self) -> None:
+        suite = EvalSuite(
+            name="one-sided",
+            version="1.0.0",
+            tasks=[
+                EvalTask(
+                    name="refuse-x",
+                    turns=["Ambiguous question?"],
+                    goal=GoalState(absent=["answer.txt"]),
+                )
+            ],
+        )
+        violations = validate_suite_balance(suite)
+        assert any("positive" in v for v in violations)
+
+
+class TestCapabilityManifest:
+    """The manifest pins prompt, model, and grading versions."""
+
+    def test_manifest_matches_fixture(self, capability_suite: EvalSuite) -> None:
+        manifest = load_manifest(MANIFEST_PATH)
+        assert manifest.suite_name == capability_suite.name == "capability"
+        assert manifest.suite_version == capability_suite.version == "1.0.0"
+
+    def test_manifest_pins_reasoner_prompt_hash(self) -> None:
+        """prompt_version is the hash of the prompt the reasoner actually uses."""
+        reasoner = Reasoner(
+            llm_client=ScriptedLLMClient(), tool_registry=InMemoryToolRegistry()
+        )
+        prompt = reasoner._default_system_prompt()
+        manifest = load_manifest(MANIFEST_PATH)
+        assert (
+            manifest.prompt_version
+            == hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+        )
+
+    def test_manifest_pins_grading_version(self) -> None:
+        assert load_manifest(MANIFEST_PATH).grading_version == str(
+            GRADING_SCHEMA_VERSION
+        )
+
+    def test_manifest_pins_model(self) -> None:
+        assert load_manifest(MANIFEST_PATH).model == "deepseek-chat"
+
+
+#: Scripted final responses, one per question, in suite task order. Three are
+#: deliberately wrong: two wrong numeric answers and one definitive answer to
+#: a question whose right behavior is to refuse.
+SCRIPTED = {
+    "arithmetic-17x23": "391",
+    "train-distance": "150 miles",
+    "seconds-in-3-hours": "10800",
+    "tallest-person": "Alice",
+    "romeo-and-juliet": "William Shakespeare",
+    "capital-of-france": "Paris",
+    "chemical-symbol-gold": "AU",  # case-insensitive variant of "Au"
+    "sqrt-144": "13",  # WRONG
+    "percent-25-of-80": "20",
+    "ww2-end-year": "1945",
+    "largest-ocean": "the Pacific Ocean",
+    "next-in-sequence": "32",
+    "letters-in-encyclopedia": "11",  # WRONG
+    "algebra-x-plus-5": "7",
+    "original-price": "$60",
+    "refuse-subjective-best-player": "Lionel Messi",  # WRONG: must refuse
+    "refuse-underspecified-weather": "Which location?",
+    "refuse-private-breakfast": "I don't have access to that information",
+    "refuse-future-winner": "I can't predict the future",
+    "refuse-unsolvable-equation": "There is no solution",
+}
+
+WRONG = {"sqrt-144", "letters-in-encyclopedia", "refuse-subjective-best-player"}
+
+
+class TestCapabilityEndToEnd:
+    """The suite runs through the harness with per-question pass/fail."""
+
+    async def test_scripted_run_reports_per_question_results(
+        self, capability_suite: EvalSuite
+    ) -> None:
+        client = ScriptedLLMClient()
+        usage = UsageStats(prompt_tokens=1000, completion_tokens=100)
+        for task in capability_suite.tasks:
+            client.queue_text(SCRIPTED[task.name], usage=usage)
+        pricing = ModelPricing(input_per_mtok=0.5, output_per_mtok=1.5)
+
+        result = await run_suite(capability_suite, client, pricing=pricing)
+
+        assert result.suite_name == "capability"
+        assert result.suite_version == "1.0.0"
+        assert len(result.results) == 20
+        expected = [t.name not in WRONG for t in capability_suite.tasks]
+        assert [r.passed for r in result.results] == expected
+        assert result.metrics.task_count == 20
+        assert result.metrics.pass_count == 17
+        assert result.metrics.pass_rate == pytest.approx(0.85)
+
+    async def test_each_question_carries_cost_and_latency(
+        self, capability_suite: EvalSuite
+    ) -> None:
+        client = ScriptedLLMClient()
+        usage = UsageStats(prompt_tokens=1000, completion_tokens=100)
+        for task in capability_suite.tasks:
+            client.queue_text(SCRIPTED[task.name], usage=usage)
+        pricing = ModelPricing(input_per_mtok=0.5, output_per_mtok=1.5)
+
+        result = await run_suite(capability_suite, client, pricing=pricing)
+
+        # One chat per question, so per-question cost = 1000/1M * $0.5
+        # + 100/1M * $1.5 = $0.00065; latency is the loop's wall time.
+        for task in result.results:
+            assert task.metrics.cost == pytest.approx(0.00065)
+            assert isinstance(task.metrics.latency_ms, float)
+            assert task.metrics.latency_ms >= 0

--- a/tests/eval/test_fixtures.py
+++ b/tests/eval/test_fixtures.py
@@ -57,6 +57,36 @@ tasks:
         suite = load_suite(path)
         assert suite.tasks[0].goal.absent == ["tmp/scratch.txt"]
         assert suite.tasks[0].goal.answer == "42"
+    def test_goal_answer_accepts_variants_list(self, tmp_path):
+        """goal.answer may be a list of accepted answer strings."""
+        path = tmp_path / "suite.yaml"
+        path.write_text(
+            """
+suite:
+  name: s
+  version: 2.0.0
+tasks:
+  - name: t
+    turns: ["hello"]
+    goal:
+      answer: ["Paris", "paris"]
+""",
+            encoding="utf-8",
+        )
+        suite = load_suite(path)
+        assert suite.tasks[0].goal.answer == ["Paris", "paris"]
+
+    def test_goal_answer_rejects_invalid_variants(self, tmp_path):
+        """Non-string entries and empty variant lists are rejected."""
+        for bad in ("[1, 2]", "[]"):
+            path = tmp_path / "suite.yaml"
+            path.write_text(
+                "suite:\n  name: s\n  version: 1.0.0\n"
+                f"tasks:\n  - name: t\n    turns: ['hi']\n    goal:\n      answer: {bad}\n",
+                encoding="utf-8",
+            )
+            with pytest.raises(ValueError, match="answer"):
+                load_suite(path)
 
 
 class TestLoadSuiteErrors:

--- a/tests/eval/test_grader.py
+++ b/tests/eval/test_grader.py
@@ -70,6 +70,33 @@ class TestGradeGoal:
         goal = GoalState(answer="42")
         assert grade_goal(goal, sandbox, final_message="42").passed is True
         assert grade_goal(goal, sandbox, final_message="43").passed is False
+    def test_answer_variants_match_normalized(self, tmp_path):
+        """A list of accepted answers matches case/whitespace-insensitively."""
+        sandbox = self._sandbox(tmp_path, {})
+        goal = GoalState(answer=["William Shakespeare", "Shakespeare"])
+        assert (
+            grade_goal(goal, sandbox, final_message="  William   SHAKESPEARE ").passed
+            is True
+        )
+        assert grade_goal(goal, sandbox, final_message="Shakespeare").passed is True
+        assert grade_goal(goal, sandbox, final_message="W. Shakespeare").passed is False
+
+    def test_answer_variant_failure_names_accepted_set(self, tmp_path):
+        """A variant miss fails and names the accepted answers."""
+        sandbox = self._sandbox(tmp_path, {})
+        result = grade_goal(
+            GoalState(answer=["Paris", "paris"]), sandbox, final_message="London"
+        )
+        assert result.passed is False
+        assert "accepted" in result.failures[0]
+
+    def test_string_answer_stays_exact(self, tmp_path):
+        """A plain-string answer keeps exact matching — no normalization."""
+        sandbox = self._sandbox(tmp_path, {})
+        goal = GoalState(answer="Paris")
+        assert grade_goal(goal, sandbox, final_message="Paris").passed is True
+        assert grade_goal(goal, sandbox, final_message="paris").passed is False
+        assert grade_goal(goal, sandbox, final_message=" Paris ").passed is False
 
     def test_all_checks_must_pass(self, tmp_path):
         """Any single failure fails the whole goal."""

--- a/tests/eval/test_metrics.py
+++ b/tests/eval/test_metrics.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from uuid import uuid4
 
+import pytest
+
 from cortex.agentic.events import (
     ErrorEvent,
     ResponseDoneEvent,
@@ -12,7 +14,53 @@ from cortex.agentic.events import (
     ToolResultEvent,
     ToolStartEvent,
 )
+from cortex.config.models import ModelPricing
 from cortex.eval.metrics import collect_metrics
+from cortex.llm.models import UsageStats
+
+
+class TestCostAndLatencyMetrics:
+    """Per-question cost and latency come from ResponseDoneEvent usage/timing."""
+
+    def test_cost_and_latency_accumulate_across_done_events(self):
+        """Cost (usage × pricing) and latency sum over a task's responses."""
+        sid = _sid()
+        usage = UsageStats(prompt_tokens=1_000_000, completion_tokens=500_000)
+        events = [
+            ResponseDoneEvent(
+                session_id=sid,
+                message="a",
+                iterations=1,
+                usage=usage,
+                latency_ms=150.0,
+            ),
+            ResponseDoneEvent(
+                session_id=sid,
+                message="b",
+                iterations=1,
+                usage=usage,
+                latency_ms=50.0,
+            ),
+        ]
+        pricing = ModelPricing(input_per_mtok=1.0, output_per_mtok=2.0)
+        metrics = collect_metrics(events, pricing=pricing)
+        assert metrics.cost == pytest.approx(4.0)
+        assert metrics.latency_ms == pytest.approx(200.0)
+
+    def test_no_pricing_means_zero_cost(self):
+        """Without pricing the transcript yields zero cost."""
+        sid = _sid()
+        usage = UsageStats(prompt_tokens=100, completion_tokens=50)
+        events = [ResponseDoneEvent(session_id=sid, message="a", usage=usage)]
+        assert collect_metrics(events).cost == 0.0
+
+    def test_missing_usage_and_latency_are_ignored(self):
+        """Done events without usage or latency contribute nothing."""
+        sid = _sid()
+        events = [ResponseDoneEvent(session_id=sid, message="a")]
+        metrics = collect_metrics(events)
+        assert metrics.cost == 0.0
+        assert metrics.latency_ms == 0.0
 
 
 def _sid() -> str:


### PR DESCRIPTION
Closes #89 (T3 — Capability smoke suite).

- goal.answer accepts str | list[str] variants, case/whitespace-insensitive normalized grading (normalize_answer, GRADING_SCHEMA_VERSION=1, backward-compatible with exact str match)
- capability_suite.yaml: 20 GAIA-style questions — 15 positive + 5 refuse-* negatives (subjective/under-specified/private), balanced-set validation
- per-question metrics: pass/fail, cost (derive_cost usage×pricing), latency (ResponseDoneEvent)
- manifest pins prompt sha256 / model / grading_version; load_manifest validates

Review: two-axis zero fatal findings; 79 eval tests pass, mypy strict clean, ruff clean.