### PR TITLE
feat: CI eval workflow — nightly gate + E1 PR job (#94)

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,0 +1,350 @@
+# T8 (spec #85): CI eval workflow.
+#
+# Two levels:
+#   * E1 PR gate — the deterministic evidence-invariants suite runs on every
+#     PR that touches the eval harness (path-filtered). E1 is
+#     importorskip-gated on #83, so the evidence tests skip cleanly today
+#     and the job still passes; they go live the moment
+#     cortex.memory.evidence_store lands (zero workflow changes).
+#   * E2/E3/E6 nightly — the loop, capability, and refusal suites on a cron
+#     plus manual workflow_dispatch. The nightly validates the suites
+#     deterministically (pytest node selection, scripted goldens, no API),
+#     records each suite's metrics as a versioned baseline JSON via
+#     record_baseline (run_suite(baseline_path=...)), compares them against
+#     the stored versioned baseline through the gate module
+#     (src/cortex/eval/gate.py), and fails ONLY on a gross regression
+#     (>= 2 sd of the run-to-run difference) or a harness error — model
+#     noise on small sets never alarms (v1 gate rule).
+#
+# v1 baseline mechanism (documented, honest):
+#   The versioned baseline for each suite+version lives in the GitHub
+#   actions cache (key `eval-baseline-v1`) as one JSON file per
+#   suite-version: eval-baselines/<suite>-<version>.json, the same shape
+#   record_baseline writes (the file's suite_version field is the version).
+#   The FIRST successful nightly run has no baseline: the gate passes with
+#   "no versioned baseline yet — this run records it" and the run's metrics
+#   are stored as the baseline for the next night. Later runs restore the
+#   baseline and compare against it; a passing run never clobbers the
+#   known-good numbers. Baselines are not committed to git in v1 — the
+#   cache is the source of truth and the report artifact preserves every
+#   night's numbers (git-versioned baselines under tests/eval/ are the
+#   future path).
+#
+#   Record/save semantics (NOT cache-hit gated): the record step runs on
+#   EVERY nightly and skips a suite+version only when its baseline file
+#   already exists (or the run failed / produced no metrics), so a first
+#   run, a skipped first run (no API key), or a suite version bump
+#   (manifest change) can never permanently disable baselining. The save
+#   step persists the baselines dir only when the cache missed AND the dir
+#   actually contains files — an empty eval-baselines is never cached.
+#   Because actions/cache/save cannot overwrite an existing key, a
+#   version-bump baseline recorded on a cache-hit night is re-recorded
+#   idempotently each night; to persist it (or force a clean re-baseline),
+#   delete the cache entry (`gh actions-cache delete eval-baseline-v1`).
+
+name: Eval CI
+
+on:
+  pull_request:
+    paths:
+      - "src/cortex/eval/**"
+      - "tests/eval/**"
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: eval-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e1-pr-gate:
+    name: E1 deterministic invariants (PR gate)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --frozen --all-extras
+
+      # E1 is importorskip-gated on #83: today the evidence-invariants tests
+      # skip with reason "evidence engine #83 not landed" and this job still
+      # passes; once the engine lands they run and gate every PR touching
+      # the harness (path filter above).
+      - name: Run deterministic eval suites (E1)
+        run: uv run pytest tests/eval -q
+
+  nightly:
+    name: Nightly LLM suites (E2/E3/E6)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Sync dependencies
+        run: uv sync --frozen --all-extras
+
+      - name: Restore versioned baselines
+        id: baselines
+        uses: actions/cache/restore@v4
+        with:
+          path: eval-baselines
+          key: eval-baseline-v1
+
+      # Deterministic validation of the three LLM suites through the real
+      # harness with scripted goldens (no API): fixture, balance, manifest,
+      # and end-to-end goal-state grading.
+      - name: Run E2/E3/E6 suite validation (deterministic)
+        run: uv run pytest tests/eval/test_loop_suite.py tests/eval/test_capability_suite.py tests/eval/test_refusal_suite.py -q
+
+      # Real-model nightly run. Each suite is driven through run_suite with
+      # the settings-configured client (config.yaml llm.model; LLM_API_KEY
+      # from the secret above). run_suite(baseline_path=...) records the
+      # run's metrics as a versioned baseline JSON (record_baseline) into
+      # eval-metrics/<suite>.json. Without an API key the run is skipped
+      # (reported, never failed) so an unconfigured secret cannot alarm the
+      # nightly. A crash here (harness error) is caught downstream by the
+      # gate as missing metrics and fails the job.
+      - name: Run nightly suites and record metrics
+        id: run-suite
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p eval-metrics
+          if [ -z "${LLM_API_KEY:-}" ]; then
+            echo "LLM_API_KEY not configured — real-model run skipped" > eval-metrics/SKIPPED
+            exit 0
+          fi
+          uv run python - <<'PY'
+          import asyncio
+          import json
+          from pathlib import Path
+
+          from cortex.eval.fixtures import load_suite
+          from cortex.eval.runner import run_suite
+
+          SUITES = [
+              ("loop", Path("tests/eval/fixtures/loop_suite.yaml")),
+              ("capability", Path("tests/eval/fixtures/capability_suite.yaml")),
+              ("refusal", Path("tests/eval/fixtures/refusal_suite.yaml")),
+          ]
+          for name, path in SUITES:
+              suite = load_suite(path)
+              result = asyncio.run(
+                  run_suite(suite, baseline_path=Path("eval-metrics") / f"{name}.json")
+              )
+              print(
+                  json.dumps(
+                      {
+                          "suite": name,
+                          "version": suite.version,
+                          "task_count": result.metrics.task_count,
+                          "pass_count": result.metrics.pass_count,
+                          "pass_rate": result.metrics.pass_rate,
+                          "cost_usd": result.metrics.total_cost_usd,
+                          "latency_ms": result.metrics.total_latency_ms,
+                      }
+                  )
+              )
+          PY
+
+      # Compare every suite against its versioned baseline through the
+      # tested gate CLI (`uv run python -m cortex.eval.gate compare ...`),
+      # which owns ALL verdict logic — no untested re-implementation in
+      # YAML. The CLI prints the verdict JSON (same shape as the previous
+      # inline script) and exits 0 on pass / 1 on fail; the exit code is
+      # captured, not propagated, because this step never fails: per-suite
+      # verdicts are written to eval-report/<suite>.json and the final gate
+      # step fails the job only if a verdict failed. Missing or malformed
+      # run metrics count as a harness error (CLI, gate fail); a skipped
+      # run (no API key) reports pass with reason "skipped".
+      - name: Compare against versioned baselines
+        id: compare
+        run: |
+          set -euo pipefail
+          mkdir -p eval-report
+          uv run python - <<'PY'
+          import json
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          from cortex.eval.baseline import load_baseline
+
+          SUITES = ["loop", "capability", "refusal"]
+          metrics_dir = Path("eval-metrics")
+          baselines_dir = Path("eval-baselines")
+          report_dir = Path("eval-report")
+
+          skipped = (metrics_dir / "SKIPPED").exists()
+          for name in SUITES:
+              if skipped:
+                  verdict = {
+                      "suite": name,
+                      "suite_version": "skipped",
+                      "passed": True,
+                      "reason": "skipped: LLM_API_KEY not configured",
+                      "run_pass_rate": None,
+                      "baseline_pass_rate": None,
+                  }
+                  (report_dir / f"{name}.json").write_text(
+                      json.dumps(verdict) + "\n", encoding="utf-8"
+                  )
+                  continue
+              cmd = [
+                  "uv", "run", "python", "-m", "cortex.eval.gate",
+                  "compare", "--run", str(metrics_dir / f"{name}.json"),
+              ]
+              run = load_baseline(metrics_dir / f"{name}.json")
+              if run is not None:
+                  cmd += [
+                      "--baseline",
+                      str(baselines_dir / f"{name}-{run.suite_version}.json"),
+                  ]
+              proc = subprocess.run(cmd, capture_output=True, text=True)
+              lines = [ln for ln in proc.stdout.splitlines() if ln.strip()]
+              if not lines:
+                  print(proc.stderr, file=sys.stderr)
+                  sys.exit(f"gate CLI produced no verdict for {name}")
+              (report_dir / f"{name}.json").write_text(
+                  lines[-1] + "\n", encoding="utf-8"
+              )
+              if proc.returncode not in (0, 1):
+                  print(proc.stderr, file=sys.stderr)
+                  sys.exit(f"gate CLI crashed for {name}: {proc.stderr.strip()}")
+          PY
+
+      # Promote each suite's passing run to the versioned baseline. This
+      # step runs on EVERY nightly (no cache-hit guard — the cache-hit
+      # guard conflated "no cache entry" with "no baseline for this
+      # suite+version" and permanently disabled baselining after a first
+      # skipped/failed run); the per-suite+version skip is on FILE
+      # EXISTENCE below, so an already-stored baseline is never clobbered
+      # while a brand-new suite+version (first run, or after a manifest
+      # version bump) is baselined even on a cache hit. Failed/harness-
+      # error runs are not baselined — the next night retries.
+      - name: Record first known-good run as versioned baseline
+        run: |
+          set -euo pipefail
+          mkdir -p eval-baselines
+          uv run python - <<'PY'
+          import json
+          import shutil
+          from pathlib import Path
+
+          metrics_dir = Path("eval-metrics")
+          baselines_dir = Path("eval-baselines")
+          report_dir = Path("eval-report")
+          for name in ("loop", "capability", "refusal"):
+              run_path = metrics_dir / f"{name}.json"
+              verdict_path = report_dir / f"{name}.json"
+              if not run_path.exists() or not verdict_path.exists():
+                  continue
+              verdict = json.loads(verdict_path.read_text(encoding="utf-8"))
+              if not verdict["passed"]:
+                  continue
+              run = json.loads(run_path.read_text(encoding="utf-8"))
+              baseline_path = baselines_dir / f"{name}-{run['suite_version']}.json"
+              if baseline_path.exists():
+                  continue
+              shutil.copyfile(run_path, baseline_path)
+          PY
+
+      # Persist the baselines dir only when the cache missed (save@v4
+      # errors on an existing key) AND the dir actually contains files —
+      # an empty eval-baselines (skipped/failed first run) is never cached,
+      # so the next night can still establish the baseline.
+      - name: Save versioned baselines
+        if: steps.baselines.outputs.cache-hit != 'true' && hashFiles('eval-baselines/*.json') != ''
+        uses: actions/cache/save@v4
+        with:
+          path: eval-baselines
+          key: eval-baseline-v1
+
+      # Publish the report (job summary + report.json) and enforce the
+      # gate: the job fails only when a verdict failed — a gross regression
+      # (>= 2 sd drop) or a harness error. The report is written before the
+      # exit, so the artifact step below always captures it.
+      - name: Publish report and enforce gate
+        run: |
+          set -euo pipefail
+          uv run python - <<'PY'
+          import json
+          import os
+          from datetime import UTC, datetime
+          from pathlib import Path
+
+          report_dir = Path("eval-report")
+          suites = ["loop", "capability", "refusal"]
+          verdicts = [
+              json.loads((report_dir / f"{name}.json").read_text(encoding="utf-8"))
+              for name in suites
+          ]
+          failed = [v for v in verdicts if not v["passed"]]
+
+          report = {
+              "generated_at": datetime.now(UTC).isoformat(),
+              "workflow": "eval.yml",
+              "event": os.environ.get("GITHUB_EVENT_NAME", ""),
+              "run_id": os.environ.get("GITHUB_RUN_ID", ""),
+              "suites": verdicts,
+              "passed": not failed,
+          }
+          (report_dir / "report.json").write_text(
+              json.dumps(report, indent=2) + "\n", encoding="utf-8"
+          )
+
+          def pct(rate):
+              return f"{rate:.1%}" if isinstance(rate, (int, float)) else "-"
+
+          rows = [
+              "| {s} | {v} | {run} | {base} | {mark} | {reason} |".format(
+                  s=v["suite"],
+                  v=v["suite_version"],
+                  run=pct(v.get("run_pass_rate")),
+                  base=pct(v.get("baseline_pass_rate")),
+                  mark="PASS" if v["passed"] else "FAIL",
+                  reason=v["reason"],
+              )
+              for v in verdicts
+          ]
+          summary = "\n".join(
+              [
+                  "## Nightly eval report (E2/E3/E6)",
+                  "",
+                  "| Suite | Version | Pass rate | Baseline | Verdict | Reason |",
+                  "|---|---|---|---|---|---|",
+                  *rows,
+              ]
+          ) + "\n"
+          Path(os.environ["GITHUB_STEP_SUMMARY"]).write_text(summary, encoding="utf-8")
+          print(summary)
+          raise SystemExit(1 if failed else 0)
+          PY
+
+      # if-no-files-found: ignore — the always() step also runs on early
+      # failures/cancellation when eval-report/ and eval-metrics/ were
+      # never created; upload-artifact@v4 would otherwise error on no
+      # matching files and mask the root cause.
+      - name: Upload eval report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-report
+          path: |
+            eval-report
+            eval-metrics
+          if-no-files-found: ignore

--- a/src/cortex/eval/__init__.py
+++ b/src/cortex/eval/__init__.py
@@ -13,6 +13,9 @@ Public seam:
   injected (or factory-created) LLM client, grades goal states, records
   metrics and an optional versioned baseline
 * :func:`record_baseline` / :func:`load_baseline` — per-suite baseline JSON
+* :func:`compare_run_to_baseline` / :class:`GateVerdict` — CI gate (spec
+  #85): a run passes unless its pass-rate drop vs the versioned baseline
+  reaches 2 sd of the run-to-run difference, or a harness error occurred
 * :func:`load_manifest` — per-suite version pins (prompt/model/grading)
 * :func:`validate_suite_balance` — golden-set positive/negative balance guard
 * :class:`TaskSandbox` — per-task sandbox the tools execute against
@@ -38,6 +41,7 @@ from cortex.eval.fixtures import (
     load_suite,
     validate_suite_balance,
 )
+from cortex.eval.gate import GateVerdict, compare_run_to_baseline, sd_of_difference
 from cortex.eval.grader import GradingResult, grade_goal
 from cortex.eval.judge import (
     DEFAULT_DIMENSION_ORDER,
@@ -75,6 +79,7 @@ __all__ = [
     "EvalManifest",
     "EvalSuite",
     "EvalTask",
+    "GateVerdict",
     "GradingResult",
     "GoalFile",
     "GoalState",
@@ -104,6 +109,7 @@ __all__ = [
     "assert_balanced_refusal_suite",
     "build_judge_client",
     "collect_metrics",
+    "compare_run_to_baseline",
     "compute_pass_k",
     "grade_goal",
     "judge_trust_gate",
@@ -116,5 +122,6 @@ __all__ = [
     "record_baseline",
     "render_transcript",
     "run_suite",
+    "sd_of_difference",
     "validate_suite_balance",
 ]

--- a/src/cortex/eval/gate.py
+++ b/src/cortex/eval/gate.py
@@ -1,0 +1,199 @@
+"""CI gate: compare a suite run against its versioned baseline (spec #85).
+
+v1 rule: fail ONLY on a gross regression — a pass-rate drop at or beyond
+two standard deviations of the run-to-run difference — or on a harness
+error. Everything inside that band is model noise on small suites and must
+not alarm: the E2/E3/E6 suites run ~30 tasks each, where the sd of the
+difference between two independent runs at p=0.5 is sqrt(2*0.25/30) =
+12.9pp, so the gate tolerates drops up to ~26pp before failing.
+
+The logic is a pure function; the CI workflow (``.github/workflows/eval.yml``)
+calls the tiny CLI below (``uv run python -m cortex.eval.gate``) per suite,
+so the verdict logic lives here where ruff/mypy and the tests in
+``tests/eval/test_gate.py`` cover it — no untested gate logic in YAML.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from math import sqrt
+from pathlib import Path
+from typing import Any
+
+from cortex.eval.baseline import EvalBaseline, load_baseline
+
+#: How many standard deviations of the run-to-run difference a drop must
+#: reach before the gate fails (v1 gross-regression rule).
+SIGMA_MULTIPLIER = 2.0
+
+
+@dataclass(frozen=True)
+class GateVerdict:
+    """Outcome of comparing a run against its versioned baseline."""
+
+    passed: bool
+    reason: str
+
+
+def sd_of_difference(run_task_count: int, baseline_task_count: int, pooled_pass_rate: float) -> float:
+    """Standard deviation of the run-vs-baseline pass-rate difference.
+
+    Each run is an independent binomial sample, so
+    Var(p_hat_run - p_hat_base) = p(1-p)/n_run + p(1-p)/n_base with the
+    pooled pass rate as the estimate of p. At p=0.5 with
+    n_run = n_base = 30 this is sqrt(2*0.25/30) = 12.9pp — the spec's
+    worked example.
+
+    Empty suites carry no signal: returns 0.0, so a drop never exceeds the
+    threshold on its own (an empty *run* is caught separately as a harness
+    error).
+    """
+    if run_task_count <= 0 or baseline_task_count <= 0:
+        return 0.0
+    variance = pooled_pass_rate * (1.0 - pooled_pass_rate) * (
+        1.0 / run_task_count + 1.0 / baseline_task_count
+    )
+    return sqrt(variance)
+
+
+def compare_run_to_baseline(
+    run_metrics: EvalBaseline,
+    baseline: EvalBaseline | None,
+    *,
+    harness_error: str | None = None,
+) -> GateVerdict:
+    """Apply the v1 gate to one suite run.
+
+    Args:
+        run_metrics: This run's metrics, as recorded by the runner
+            (``run_suite(..., baseline_path=...)`` writes an
+            :class:`EvalBaseline`-shaped JSON whose task/pass counts are
+            the run's).
+        baseline: The versioned baseline (first known-good run) for the
+            same suite and version; ``None`` when none exists yet.
+        harness_error: Non-empty when the suite did not run to completion
+            (crash, missing or malformed metrics, ...). A harness error
+            fails the gate regardless of the numbers.
+
+    Returns:
+        ``passed=True`` when there is no baseline yet (the run records it),
+        the run is at least as good as the baseline, or the drop is within
+        2 sd of the run-to-run difference (model noise). ``passed=False``
+        only on a harness error or a drop at or beyond 2 sd (gross
+        regression).
+    """
+    if harness_error:
+        return GateVerdict(False, f"harness error: {harness_error}")
+    if baseline is None:
+        return GateVerdict(True, "no versioned baseline yet — this run records it")
+    if run_metrics.task_count <= 0:
+        return GateVerdict(False, "harness error: run recorded no tasks")
+
+    run_rate = run_metrics.metrics.pass_rate
+    baseline_rate = baseline.metrics.pass_rate
+    drop = baseline_rate - run_rate
+    if drop <= 0.0:
+        return GateVerdict(
+            True,
+            f"no regression: run pass rate {run_rate:.1%} >= baseline {baseline_rate:.1%}",
+        )
+    pooled = (run_metrics.pass_count + baseline.pass_count) / (
+        run_metrics.task_count + baseline.task_count
+    )
+    sd = sd_of_difference(run_metrics.task_count, baseline.task_count, pooled)
+    threshold = SIGMA_MULTIPLIER * sd
+    if drop >= threshold:
+        return GateVerdict(
+            False,
+            f"gross regression: pass rate dropped {drop:.1%} "
+            f"({baseline_rate:.1%} -> {run_rate:.1%}), "
+            f"at or beyond {SIGMA_MULTIPLIER:.0f} sd ({threshold:.1%})",
+        )
+    return GateVerdict(
+        True,
+        f"within noise: drop {drop:.1%} < {SIGMA_MULTIPLIER:.0f} sd ({threshold:.1%})",
+    )
+
+
+def _print_verdict(
+    verdict: GateVerdict,
+    *,
+    suite: str,
+    suite_version: str,
+    run_pass_rate: float,
+    baseline_pass_rate: float | None,
+) -> int:
+    """Print the verdict as one JSON line; return the process exit code."""
+    payload: dict[str, Any] = {
+        "suite": suite,
+        "suite_version": suite_version,
+        "passed": verdict.passed,
+        "reason": verdict.reason,
+        "run_pass_rate": run_pass_rate,
+        "baseline_pass_rate": baseline_pass_rate,
+    }
+    print(json.dumps(payload, sort_keys=True))
+    return 0 if verdict.passed else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: compare a run's metrics JSON to the versioned baseline."""
+    parser = argparse.ArgumentParser(
+        prog="python -m cortex.eval.gate",
+        description="CI gate (spec #85): fail only on gross regressions (>= 2 sd) "
+        "or harness errors; model noise on small suites never alarms.",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    compare = subparsers.add_parser(
+        "compare",
+        help="Compare a run's metrics JSON against the versioned baseline.",
+    )
+    compare.add_argument(
+        "--run",
+        required=True,
+        type=Path,
+        help="This run's metrics JSON (the baseline file the runner recorded).",
+    )
+    compare.add_argument(
+        "--baseline",
+        type=Path,
+        help="Versioned baseline JSON for the same suite+version; omit when none exists yet.",
+    )
+    compare.add_argument(
+        "--harness-error",
+        default=None,
+        help="Non-empty when the suite did not run to completion (crash, missing metrics).",
+    )
+    args = parser.parse_args(argv)
+
+    if args.command == "compare":
+        run = load_baseline(args.run)
+        if run is None:
+            return _print_verdict(
+                GateVerdict(
+                    False,
+                    f"harness error: run metrics JSON missing or malformed: {args.run}",
+                ),
+                suite="unknown",
+                suite_version="",
+                run_pass_rate=0.0,
+                baseline_pass_rate=None,
+            )
+        baseline = load_baseline(args.baseline) if args.baseline is not None else None
+        verdict = compare_run_to_baseline(run, baseline, harness_error=args.harness_error)
+        return _print_verdict(
+            verdict,
+            suite=run.suite_name,
+            suite_version=run.suite_version,
+            run_pass_rate=run.metrics.pass_rate,
+            baseline_pass_rate=baseline.metrics.pass_rate if baseline is not None else None,
+        )
+    return 2  # pragma: no cover - argparse enforces the subcommand
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/eval/test_gate.py
+++ b/tests/eval/test_gate.py
@@ -1,0 +1,262 @@
+"""Tests for the CI gate (T8): the >= 2 sd gross-regression rule.
+
+The gate compares a suite run against its versioned baseline. v1 fails only
+on a gross regression — a pass-rate drop at or beyond 2 sd of the
+run-to-run difference (12.9pp per 30-task suite at p=0.5, so a ~26pp
+threshold) — or on a harness error; everything inside the band is model
+noise and must pass. The workflow YAML's syntactic validity is also pinned
+here (yaml.safe_load) since actionlint is not available in this repo.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from cortex.eval.baseline import EvalBaseline, record_baseline
+from cortex.eval.gate import compare_run_to_baseline, main, sd_of_difference
+from cortex.eval.metrics import SuiteMetrics
+
+WORKFLOW = Path(__file__).parents[2] / ".github" / "workflows" / "eval.yml"
+
+
+def _baseline(*, task_count: int, pass_count: int) -> EvalBaseline:
+    """A versioned baseline (or run) with the given binomial outcome."""
+    return EvalBaseline(
+        suite_name="loop",
+        suite_version="1.0.0",
+        task_count=task_count,
+        pass_count=pass_count,
+        metrics=SuiteMetrics(task_count=task_count, pass_count=pass_count),
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+
+
+class TestSDOfDifference:
+    """The run-to-run difference sd follows binomial variance math."""
+
+    def test_30_tasks_at_p50_is_12_9pp(self) -> None:
+        """sqrt(2*0.25/30) = sqrt(1/60) = 0.1291 — the spec's worked example."""
+        assert sd_of_difference(30, 30, 0.5) == pytest.approx(0.1291, abs=1e-4)
+
+    def test_unequal_suite_sizes(self) -> None:
+        """sqrt(0.25/30 + 0.25/60) = sqrt(0.0125) = 0.1118."""
+        assert sd_of_difference(30, 60, 0.5) == pytest.approx(0.1118, abs=1e-4)
+
+    def test_empty_suite_has_no_signal(self) -> None:
+        assert sd_of_difference(0, 30, 0.5) == 0.0
+        assert sd_of_difference(30, 0, 0.5) == 0.0
+
+
+class TestCompareRunToBaseline:
+    """The gate: >= 2 sd gross regression or harness error fails; noise passes."""
+
+    def test_drop_of_26pp_on_30_tasks_fails(self) -> None:
+        """A 26.7pp drop (15/30 -> 7/30) is beyond 2 sd (~25pp) -> fail."""
+        verdict = compare_run_to_baseline(
+            _baseline(task_count=30, pass_count=7),
+            _baseline(task_count=30, pass_count=15),
+        )
+        assert verdict.passed is False
+        assert "gross regression" in verdict.reason
+
+    def test_drop_of_20pp_on_30_tasks_passes_as_noise(self) -> None:
+        """A 20pp drop (15/30 -> 9/30) is inside 2 sd (~25pp) -> noise, pass."""
+        verdict = compare_run_to_baseline(
+            _baseline(task_count=30, pass_count=9),
+            _baseline(task_count=30, pass_count=15),
+        )
+        assert verdict.passed is True
+        assert "noise" in verdict.reason
+
+    def test_small_suites_never_alarm_on_noise(self) -> None:
+        """A 2-task swing on an 8-task suite is inside 2 sd (~43pp) -> pass."""
+        verdict = compare_run_to_baseline(
+            _baseline(task_count=8, pass_count=5),
+            _baseline(task_count=8, pass_count=7),
+        )
+        assert verdict.passed is True
+
+    def test_harness_error_fails_regardless_of_numbers(self) -> None:
+        verdict = compare_run_to_baseline(
+            _baseline(task_count=30, pass_count=30),
+            _baseline(task_count=30, pass_count=30),
+            harness_error="suite crashed before grading",
+        )
+        assert verdict.passed is False
+        assert "harness error" in verdict.reason
+
+    def test_zero_failure_run_passes(self) -> None:
+        """Baseline and run both perfect: no drop, no alarm."""
+        verdict = compare_run_to_baseline(
+            _baseline(task_count=30, pass_count=30),
+            _baseline(task_count=30, pass_count=30),
+        )
+        assert verdict.passed is True
+
+    def test_no_baseline_yet_passes_and_records(self) -> None:
+        """First known-good run: nothing to compare against, always passes."""
+        verdict = compare_run_to_baseline(_baseline(task_count=30, pass_count=20), None)
+        assert verdict.passed is True
+        assert "records it" in verdict.reason
+
+    def test_run_better_than_baseline_passes(self) -> None:
+        verdict = compare_run_to_baseline(
+            _baseline(task_count=30, pass_count=20),
+            _baseline(task_count=30, pass_count=15),
+        )
+        assert verdict.passed is True
+        assert "no regression" in verdict.reason
+
+    def test_empty_run_is_a_harness_error(self) -> None:
+        verdict = compare_run_to_baseline(
+            _baseline(task_count=0, pass_count=0),
+            _baseline(task_count=30, pass_count=15),
+        )
+        assert verdict.passed is False
+        assert "harness error" in verdict.reason
+
+
+class TestGateCLI:
+    """The CLI the workflow can call via `uv run python -m cortex.eval.gate`."""
+
+    def _write_run(
+        self,
+        tmp_path: Path,
+        *,
+        pass_count: int,
+        task_count: int = 30,
+        name: str = "run.json",
+    ) -> Path:
+        path = tmp_path / name
+        record_baseline(
+            suite_name="loop",
+            suite_version="1.0.0",
+            metrics=SuiteMetrics(task_count=task_count, pass_count=pass_count),
+            path=path,
+            created_at="2026-01-02T00:00:00+00:00",
+        )
+        return path
+
+    def test_compare_pass_exits_zero(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        run = self._write_run(tmp_path, pass_count=9)
+        base = self._write_run(tmp_path, pass_count=15, name="baseline.json")
+        assert main(["compare", "--run", str(run), "--baseline", str(base)]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is True
+        assert payload["suite"] == "loop"
+
+    def test_compare_gross_regression_exits_one(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        run = self._write_run(tmp_path, pass_count=7)
+        base = self._write_run(tmp_path, pass_count=15, name="baseline.json")
+        assert main(["compare", "--run", str(run), "--baseline", str(base)]) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is False
+        assert payload["baseline_pass_rate"] == pytest.approx(0.5)
+
+    def test_no_baseline_file_exits_zero_and_records(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        run = self._write_run(tmp_path, pass_count=20)
+        assert main(["compare", "--run", str(run)]) == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is True
+        assert "records it" in payload["reason"]
+
+    def test_missing_run_metrics_is_harness_error(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        assert main(["compare", "--run", str(tmp_path / "nope.json")]) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is False
+        assert "harness error" in payload["reason"]
+
+    def test_harness_error_flag_fails(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        run = self._write_run(tmp_path, pass_count=30)
+        assert main(["compare", "--run", str(run), "--harness-error", "boom"]) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["passed"] is False
+
+
+class TestWorkflowYaml:
+    """eval.yml parses and declares the required triggers (T8 acceptance).
+
+    No actionlint is available, so the practical check is a YAML parse plus
+    assertions pinning the ticket's acceptance criteria: PR trigger for E1,
+    nightly cron + workflow_dispatch for E2/E3/E6, the nightly job shelling
+    out to the tested gate CLI, and the F1/A1/A3 review fixes.
+    """
+
+    def test_workflow_parses_and_declares_triggers(self) -> None:
+        raw = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        assert isinstance(raw, dict)
+        on_section = raw.get("on")
+        if on_section is None:
+            # PyYAML 1.1 parses the bare `on:` key as boolean True.
+            on_section = raw.get(True)
+        assert isinstance(on_section, dict)
+        assert "pull_request" in on_section
+        assert "schedule" in on_section
+        assert "workflow_dispatch" in on_section
+        assert isinstance(on_section["schedule"], list)
+        assert "cron" in on_section["schedule"][0]
+
+        jobs = raw["jobs"]
+        assert "e1-pr-gate" in jobs
+        assert "nightly" in jobs
+
+    def test_nightly_job_shells_out_to_the_tested_gate_cli(self) -> None:
+        """The compare step shells out to the gate CLI; the verdict logic is
+        not re-implemented untested in YAML (T8 advisory A2)."""
+        raw = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        steps = raw["jobs"]["nightly"]["steps"]
+        compare = next(
+            s for s in steps if s.get("name") == "Compare against versioned baselines"
+        )
+        assert "cortex.eval.gate" in compare["run"]
+        assert "compare_run_to_baseline" not in compare["run"]
+
+    def test_record_step_skips_per_file_not_per_cache_hit(self) -> None:
+        """T8 fatal F1: the record step must not be gated on the cache (a
+        first skipped/failed run would otherwise disable baselining forever);
+        the per-suite+version skip is on file existence inside the script,
+        and the save step is gated on a cache miss AND the baselines dir
+        containing files, so an empty eval-baselines is never cached."""
+        raw = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        steps = raw["jobs"]["nightly"]["steps"]
+        record = next(
+            s
+            for s in steps
+            if s.get("name") == "Record first known-good run as versioned baseline"
+        )
+        assert "if" not in record
+        assert "if baseline_path.exists():" in record["run"]
+        save = next(s for s in steps if s.get("name") == "Save versioned baselines")
+        save_if = save.get("if", "")
+        assert "cache-hit != 'true'" in save_if
+        assert "hashFiles('eval-baselines/*.json') != ''" in save_if
+
+    def test_upload_step_ignores_missing_files(self) -> None:
+        """T8 advisory A1: the always() upload step must not fail on early
+        failure/cancellation when the report dirs were never created."""
+        raw = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        steps = raw["jobs"]["nightly"]["steps"]
+        upload = next(s for s in steps if s.get("name") == "Upload eval report")
+        assert upload.get("if") == "always()"
+        assert upload["with"]["if-no-files-found"] == "ignore"
+
+    def test_all_sync_steps_use_all_extras(self) -> None:
+        """T8 advisory A3: eval.yml syncs with --all-extras like every ci.yml
+        job, so test-only deps in any extra are installed."""
+        raw = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        for job in ("e1-pr-gate", "nightly"):
+            steps = raw["jobs"][job]["steps"]
+            sync = next(s["run"] for s in steps if "uv sync" in s.get("run", ""))
+            assert "uv sync --frozen --all-extras" in sync
+
+    def test_pr_job_runs_the_deterministic_eval_suite(self) -> None:
+        """The E1 PR job runs pytest tests/eval (evidence suite skips until #83)."""
+        raw = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+        jobs = raw["jobs"]
+        steps = jobs["e1-pr-gate"]["steps"]
+        run_steps = [s["run"] for s in steps if "run" in s]
+        assert any("pytest tests/eval" in run for run in run_steps)


### PR DESCRIPTION
Closes #94 (T8 — CI eval workflow).

- eval.yml: E1 PR gate (path-filtered src/cortex/eval + tests/eval; evidence suite importorskip-gated pre-#83, passes while skipped), nightly cron 02:17 UTC + workflow_dispatch selecting E2/E3/E6 explicitly
- gate.py: compare_run_to_baseline — fail only on >=2 sd gross regression (sd of difference = sqrt(p(1-p)/n_run + p(1-p)/n_base); 26pp drop on 30 tasks fails, 20pp passes as noise) or harness error; tested CLI consumed by the workflow
- baseline mechanism: record per-suite+version on file existence (no clobber, version-bump safe, skipped/failed first run cannot poison the cache); save gated on non-empty baselines dir; empty dir never cached
- report: job summary table + report.json artifact (if-no-files-found: ignore); skipped nightly emits warning annotation; failures exit 1 only on gate fail
- ci.yml byte-identical

Review: two-axis — fatal baseline-cache defect + advisories found and fixed, final round zero findings, 5/5 criteria; 862 tests pass (79% coverage), mypy strict clean, ruff clean.