### PR TITLE
feat(agentic): token streaming + ask_user tool for clarifications

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       LOG_FORMAT: console
     volumes:
       - mosquitto_config:/mosquitto/config:rw
+      - ./src/cortex/api/static:/app/src/cortex/api/static:ro
     ports:
       - "8000:8000"
     depends_on:

--- a/src/cortex/agentic/__init__.py
+++ b/src/cortex/agentic/__init__.py
@@ -5,6 +5,7 @@ Provides the core agentic loop: Think → Act → Observe → Respond.
 
 from cortex.agentic.context_builder import ContextBuilder
 from cortex.agentic.events import (
+    AskUserEvent,
     ErrorEvent,
     LoopEvent,
     ResponseDoneEvent,
@@ -51,6 +52,7 @@ __all__ = [
     "GoalResult",
     "MaxIterationsError",
     # Streaming
+    "AskUserEvent",
     "ErrorEvent",
     "LoopEvent",
     "ResponseDoneEvent",

--- a/src/cortex/agentic/events.py
+++ b/src/cortex/agentic/events.py
@@ -11,6 +11,7 @@ table:
 * ``tool_start``  — a tool call is about to execute
 * ``tool_done``   — a tool call finished (success or failure)
 * ``done``        — the response is complete
+* ``ask_user``    — the loop paused to ask the user a clarifying question
 * ``error``       — the loop failed
 
 Instances are JSON-ready via :meth:`LoopEvent.to_dict`.
@@ -106,6 +107,21 @@ class ResponseDoneEvent(LoopEvent):
         if self.usage is not None:
             payload["usage"] = self.usage.model_dump()
         return payload
+
+
+@dataclass
+class AskUserEvent(LoopEvent):
+    """The loop is pausing to ask the user a clarifying question.
+
+    Emitted when the model calls the ``ask_user`` tool. `options`, when
+    non-empty, are model-suggested answers the UI can render as choices.
+    Terminal for the turn, like ``done`` — the loop stops and waits for the
+    user's next message.
+    """
+
+    event_type: ClassVar[str] = "ask_user"
+    question: str
+    options: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/cortex/agentic/loop.py
+++ b/src/cortex/agentic/loop.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
 from cortex.agentic.events import (
+    AskUserEvent,
     ErrorEvent,
     LoopEvent,
     ResponseDoneEvent,
@@ -19,6 +20,7 @@ from cortex.agentic.events import (
 )
 from cortex.agentic.models import (
     ChatResponse,
+    Decision,
     DecisionType,
     GoalResult,
     MaxIterationsError,
@@ -26,6 +28,7 @@ from cortex.agentic.models import (
 )
 from cortex.events import EventEmitter
 from cortex.sessions.models import Message, MessageRole, SessionState
+from cortex.tools.meta.ask_user import ASK_USER_CONTROL, ASK_USER_TOOL_NAME
 
 if TYPE_CHECKING:
     from cortex.agentic.context_builder import ContextBuilder
@@ -115,6 +118,10 @@ class AgentLoop:
             match event:
                 case TextDeltaEvent(delta=delta):
                     response_text += delta
+                case AskUserEvent(question=question):
+                    # A clarifying question is the turn's response text — no
+                    # TextDeltaEvent is emitted for it, so pick it up here.
+                    response_text += question
                 case ResponseDoneEvent(tools_used=used, iterations=iters):
                     tools_used, iterations = used, iters
                     usage, latency_ms = event.usage, event.latency_ms
@@ -136,9 +143,17 @@ class AgentLoop:
         user_message: str,
         *,
         max_iterations: int | None = None,
+        stream: bool = False,
     ) -> AsyncGenerator[LoopEvent, None]:
         """
         Run loop for chat mode, streaming progress events.
+
+        Args:
+            stream: When True, the response is produced token-by-token via
+                ``reasoner.reason_stream`` — each text delta is yielded as its
+                own ``TextDeltaEvent`` as it arrives. When False (default) the
+                whole response is emitted as a single ``TextDeltaEvent``, and
+                the event ordering is unchanged (``thinking`` before ``text``).
 
         Yields:
             LoopEvent progress signals as the loop runs: a ThinkingEvent per
@@ -194,8 +209,24 @@ class AgentLoop:
                 # Inject current messages into context
                 context.conversation = messages
 
-                # 2. Think - reason about what to do
-                decision = await self._reasoner.reason(context)
+                # 2. Think - reason about what to do.
+                # In stream mode the response text arrives as deltas before the
+                # final Decision; each delta is emitted as it lands. Tool-call
+                # turns carry no text, so `streamed_parts` stays empty there.
+                streamed_parts: list[str] = []
+                if stream:
+                    decision = None
+                    async for item in self._reasoner.reason_stream(context):
+                        if isinstance(item, Decision):
+                            decision = item
+                        else:
+                            streamed_parts.append(item)
+                            yield TextDeltaEvent(session_id, delta=item)
+                    if decision is None:
+                        raise ValueError("reason_stream ended without a Decision")
+                else:
+                    decision = await self._reasoner.reason(context)
+
                 # Accumulate per-call usage so the final done event carries
                 # the whole task's token spend (prompt/completion/total).
                 if decision.usage is not None:
@@ -205,37 +236,29 @@ class AgentLoop:
                         else decision.usage
                     )
 
-                # Emit the reasoning step for this iteration
+                # Emit the reasoning step for this iteration. In stream mode the
+                # response deltas have already been yielded, so this lands after
+                # them — harmless (consumers ignore it or no-op once the thinking
+                # placeholder is gone), and it keeps tool turns' ordering intact.
                 yield ThinkingEvent(session_id, message=decision.reasoning)
 
                 # Handle decision
                 match decision.decision_type:
                     case DecisionType.RESPOND:
-                        # Done! Stream the response
-                        text = decision.text or "I'm not sure how to respond."
-                        if self._session_repository is not None:
-                            await self._session_repository.add_message(
-                                session_id, MessageRole.ASSISTANT, text
-                            )
-                        yield TextDeltaEvent(session_id, delta=text)
-                        yield self._done_event(
-                            session_id,
-                            text,
-                            tools_used,
-                            iterations,
-                            total_usage=total_usage,
-                            started_at=started_at,
+                        # Prefer the streamed text; fall back to decision.text.
+                        text = (
+                            "".join(streamed_parts)
+                            if streamed_parts
+                            else (decision.text or "I'm not sure how to respond.")
                         )
-                        return
-
-                    case DecisionType.ASK_QUESTION:
-                        # Return the question
-                        text = decision.text or "Could you clarify?"
                         if self._session_repository is not None:
                             await self._session_repository.add_message(
                                 session_id, MessageRole.ASSISTANT, text
                             )
-                        yield TextDeltaEvent(session_id, delta=text)
+                        # Emit the full text as one delta unless it already
+                        # streamed out piece by piece.
+                        if not streamed_parts:
+                            yield TextDeltaEvent(session_id, delta=text)
                         yield self._done_event(
                             session_id,
                             text,
@@ -247,6 +270,61 @@ class AgentLoop:
                         return
 
                     case DecisionType.EXECUTE_TOOLS:
+                        # ask_user short-circuit (B2): a clarifying question is
+                        # not an executable tool round. If the model called
+                        # ask_user, halt and surface the question — persisting it
+                        # as a normal assistant message, with NO tool_call/
+                        # tool_result stored, so a provider never sees a dangling
+                        # tool call. Asking supersedes any other call this turn.
+                        ask_call = next(
+                            (
+                                c for c in (decision.tool_calls or [])
+                                if c.name == ASK_USER_TOOL_NAME
+                            ),
+                            None,
+                        )
+                        if ask_call is not None:
+                            # Executed once; the turn always halts here (never
+                            # falls through to the normal path, which would
+                            # re-execute the same call).
+                            result = await self._executor.execute_single(ask_call)
+                            if result.control == ASK_USER_CONTROL:
+                                question = result.output or "Could you clarify?"
+                                options = list(
+                                    (result.metadata or {}).get("options", [])
+                                )
+                                if self._session_repository is not None:
+                                    await self._session_repository.add_message(
+                                        session_id, MessageRole.ASSISTANT, question
+                                    )
+                                yield AskUserEvent(
+                                    session_id,
+                                    question=question,
+                                    options=options,
+                                )
+                            else:
+                                # Malformed ask_user (e.g. blank question): surface
+                                # the tool error as the turn's response instead of
+                                # asking, and stop.
+                                question = (
+                                    result.error
+                                    or "I couldn't ask a clarifying question."
+                                )
+                                if self._session_repository is not None:
+                                    await self._session_repository.add_message(
+                                        session_id, MessageRole.ASSISTANT, question
+                                    )
+                                yield TextDeltaEvent(session_id, delta=question)
+                            yield self._done_event(
+                                session_id,
+                                question,
+                                tools_used,
+                                iterations,
+                                total_usage=total_usage,
+                                started_at=started_at,
+                            )
+                            return
+
                         # 3. Act - execute tools
                         if decision.tool_calls:
                             # Record the assistant's tool-call decision in the
@@ -433,22 +511,6 @@ class AgentLoop:
                         message=decision.text or "Goal completed",
                         iterations=iterations,
                         steps_completed=steps_completed,
-                    )
-
-                case DecisionType.ASK_QUESTION:
-                    # Need clarification for goal
-                    await self._emit_goal_event(goal_id, "needs_input", {
-                        "question": decision.text,
-                        "timestamp": time.time(),
-                    })
-
-                    return GoalResult(
-                        goal_id=goal_id,
-                        success=False,
-                        message=decision.text or "Need more information",
-                        iterations=iterations,
-                        steps_completed=steps_completed,
-                        error="Needs clarification",
                     )
 
                 case DecisionType.EXECUTE_TOOLS:

--- a/src/cortex/agentic/models.py
+++ b/src/cortex/agentic/models.py
@@ -18,7 +18,8 @@ class DecisionType(Enum):
     """Types of decisions the agent can make."""
     RESPOND = "respond"           # Done, return text to user
     EXECUTE_TOOLS = "execute_tools"  # Execute tools, continue loop
-    ASK_QUESTION = "ask_question"    # Need clarification
+    # Clarification is no longer a decision type — the model asks the user by
+    # calling the ask_user tool, handled as an EXECUTE_TOOLS turn.
 
 
 class Mode(Enum):
@@ -43,7 +44,7 @@ class Decision:
 
     Attributes:
         decision_type: What type of decision was made
-        text: Text response (for RESPOND or ASK_QUESTION)
+        text: Text response (for RESPOND)
         tool_calls: Tools to execute (for EXECUTE_TOOLS)
         reasoning: Explanation of why this decision was made
         usage: Token usage of the reasoning call that produced this decision
@@ -70,16 +71,6 @@ class Decision:
         return cls(
             decision_type=DecisionType.EXECUTE_TOOLS,
             tool_calls=tool_calls,
-            reasoning=reasoning,
-            usage=usage,
-        )
-
-    @classmethod
-    def ask_question(cls, question: str, reasoning: str = "", usage: UsageStats | None = None) -> Decision:
-        """Create an ASK_QUESTION decision."""
-        return cls(
-            decision_type=DecisionType.ASK_QUESTION,
-            text=question,
             reasoning=reasoning,
             usage=usage,
         )

--- a/src/cortex/agentic/reasoner.py
+++ b/src/cortex/agentic/reasoner.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-import re
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
 
 from cortex.agentic.models import (
@@ -20,8 +20,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-QUESTION_PATTERN = re.compile(r"\[QUESTION\](.*?)\[/QUESTION\]", re.DOTALL)
-
 
 _MESSAGE_ROLE_TO_LLM_ROLE: dict[str, Role] = {
     MessageRole.SYSTEM.value: Role.SYSTEM,
@@ -37,8 +35,8 @@ class Reasoner:
 
     Given context, decides what to do next:
     - RESPOND: Done, return text to user
-    - EXECUTE_TOOLS: Execute tools, continue loop
-    - ASK_QUESTION: Need clarification
+    - EXECUTE_TOOLS: Execute tools, continue loop (clarifying questions are one
+      such tool — ask_user)
     """
 
     def __init__(
@@ -57,8 +55,8 @@ class Reasoner:
             "You are Cortex, an intelligent AI assistant. "
             "When a tool fits the user's request, call it; otherwise respond directly. "
             "Always be helpful, concise, and precise. "
-            "If you need clarification from the user, respond with "
-            "[QUESTION]your question here[/QUESTION] and nothing else."
+            "When you lack the information to proceed, call the ask_user tool to "
+            "ask a clarifying question instead of guessing."
         )
 
     async def reason(self, context: Context) -> Decision:
@@ -82,6 +80,43 @@ class Reasoner:
             return Decision.respond(
                 text="I encountered an error. Please try again.",
                 reasoning=f"LLM error: {str(e)}"
+            )
+
+    async def reason_stream(
+        self, context: Context
+    ) -> AsyncIterator[str | Decision]:
+        """
+        Streaming variant of ``reason()``.
+
+        Yields text deltas (``str``) as the LLM produces them, then yields the
+        final ``Decision`` as the terminal item — the same decision ``reason()``
+        would return, built by ``_parse_response`` on the assembled result.
+
+        Only a plain text answer streams token-by-token. Tool-call turns carry
+        no assistant text, so they surface solely through the final Decision —
+        this includes clarifying questions, which the model asks by calling the
+        ``ask_user`` tool (no text is streamed for them).
+        """
+        messages = self._build_prompt(context)
+        tools = context.tools if context.tools else None
+
+        try:
+            final_result: ChatResult | None = None
+
+            async for item in self._llm.chat_stream(messages, tools=tools):
+                if isinstance(item, ChatResult):
+                    final_result = item
+                else:
+                    yield item
+
+            if final_result is None:
+                raise ValueError("Stream ended without a final result")
+            yield self._parse_response(final_result, context)
+        except Exception as e:
+            logger.error(f"Reasoner streaming error: {e}")
+            yield Decision.respond(
+                text="I encountered an error. Please try again.",
+                reasoning=f"LLM error: {str(e)}",
             )
 
     def _build_prompt(self, context: Context) -> list[ChatMessage]:
@@ -176,17 +211,8 @@ class Reasoner:
                 usage=result.usage,
             )
 
-        match = QUESTION_PATTERN.search(content)
-        if match:
-            question = match.group(1).strip()
-            if not question:
-                raise ValueError("LLM signaled clarification with no question")
-            return Decision.ask_question(
-                question=question,
-                reasoning="LLM signaled need for clarification",
-                usage=result.usage,
-            )
-
+        # Clarifying questions are no longer parsed from text markers — the model
+        # asks via the ask_user tool, handled as a tool call above.
         return Decision.respond(
             text=content,
             reasoning="Direct response to user",

--- a/src/cortex/api/routes/chat.py
+++ b/src/cortex/api/routes/chat.py
@@ -11,6 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from fastapi.responses import StreamingResponse
 
 from cortex.agentic.events import (
+    AskUserEvent,
     ErrorEvent,
     ResponseDoneEvent,
     TextDeltaEvent,
@@ -149,6 +150,7 @@ async def chat_stream(
                 session_id=session_id,
                 user_message=request.message,
                 max_iterations=max_iterations,
+                stream=request.stream,
             ):
                 match event:
                     case ThinkingEvent():
@@ -173,6 +175,17 @@ async def chat_stream(
                                 "output": event.output,
                                 "error": event.error,
                                 "execution_time_ms": event.execution_time_ms,
+                            },
+                        )
+                    case AskUserEvent():
+                        # The loop paused to ask the user; carry the question and
+                        # any model-suggested options for the UI to render as
+                        # choices. A `done` frame still follows to close the turn.
+                        yield _sse_event(
+                            "ask_user",
+                            {
+                                "question": event.question,
+                                "options": event.options,
                             },
                         )
                     case ResponseDoneEvent():

--- a/src/cortex/api/schemas.py
+++ b/src/cortex/api/schemas.py
@@ -43,6 +43,13 @@ class ChatRequest(BaseModel):
     session_id: UUID | None = Field(None, description="Existing session ID")
     mode: Literal["chat", "goal"] = Field("chat", description="Execution mode")
     max_iterations: int | None = Field(None, description="Max iterations (default: 20)")
+    stream: bool = Field(
+        True,
+        description=(
+            "Stream the response token-by-token (SSE endpoint only). When False, "
+            "the response text arrives as a single text event."
+        ),
+    )
 
 
 class ChatResponse(BaseModel):

--- a/src/cortex/api/static/index.html
+++ b/src/cortex/api/static/index.html
@@ -127,7 +127,22 @@
   }
   .tool.ok { color: var(--accent); border-color: rgba(94,234,212,.3); }
   .tool.fail { color: var(--danger); border-color: rgba(248,113,113,.3); }
-  .tool pre { display: none; }
+  .tool { cursor: default; }
+  .tool.expandable { cursor: pointer; border-radius: 8px; }
+  .tool pre { display: none; white-space: pre-wrap; overflow-wrap: anywhere; margin-top: 6px; background: rgba(0,0,0,.4); border: 1px solid var(--border); border-radius: 6px; padding: 6px 8px; font-size: 11px; line-height: 1.4; max-width: 520px; }
+  .tool.expanded { border-radius: 8px; }
+  .tool.expanded pre { display: block; }
+  .options { align-self: flex-start; display: flex; flex-wrap: wrap; gap: 8px; max-width: 82%; }
+  .option {
+    font-size: 13px; color: var(--accent); background: var(--accent-dim);
+    border: 1px solid rgba(94,234,212,.35); border-radius: 999px; padding: 6px 14px;
+    cursor: pointer; transition: background .15s, color .15s;
+  }
+  .option:hover { background: #17483f; color: #d9fbf3; }
+  .think-toggle { align-self: flex-start; background: none; border: none; color: var(--muted); font-size: 12px; cursor: pointer; padding: 0; display: flex; align-items: center; gap: 4px; }
+  .think-toggle:hover { color: var(--text); }
+  .think-block { display: none; align-self: flex-start; max-width: 82%; background: rgba(255,255,255,.02); border: 1px solid var(--border); border-radius: 8px; padding: 8px 12px; font-size: 12px; color: var(--muted); white-space: pre-wrap; overflow-wrap: anywhere; font-style: italic; line-height: 1.5; }
+  .think-block.visible { display: block; }
   footer { border-top: 1px solid var(--border); background: var(--surface); padding: 12px 20px 16px; }
   .bar { max-width: 760px; margin: 0 auto; display: flex; gap: 10px; align-items: flex-end; }
   textarea {
@@ -184,7 +199,16 @@ const LS = {
 
 const inner = $("inner"), input = $("input"), sendBtn = $("send"), banner = $("banner");
 let busy = false;
-let toolChips = []; // {el, count} current turn's tool chips
+// Streaming render state for the current assistant turn. Text runs and tool
+// output interleave in DOM order: each text run is its own bubble, opened
+// lazily when text arrives, and closed when a tool (or ask_user) interrupts —
+// so the next text lands *below* the tools, chronologically.
+let curTextEl = null;   // open assistant text bubble, or null
+let curRaw = "";        // raw text accumulated into curTextEl
+let curToggle = null;   // <think> toggle button for the current bubble
+let curThink = null;    // <think> content block for the current bubble
+let toolGroup = null;   // current tools row wrap, or null
+let thinkingEl = null;  // transient "sto pensando…" indicator, or null
 
 function setStatus(on, text) { $("dot").classList.toggle("on", on); $("stext").textContent = text; }
 function showBanner(msg) { if (!msg) { banner.style.display = "none"; return; } banner.textContent = msg; banner.style.display = "block"; }
@@ -298,6 +322,50 @@ function renderMarkdown(text) {
   return out.join("").replace(/\u0000B(\d+)\u0000/g, (m, n) => blocks[+n]);
 }
 
+function extractThink(text) {
+  const parts = [];
+  let clean = text.replace(/<think>([\s\S]*?)<\/think>/g, (_, c) => { parts.push(c); return ""; });
+  clean = clean.replace(/<think>([\s\S]*)$/, (_, c) => { parts.push(c); return ""; });
+  return { clean: clean.replace(/^\s+/, ""), think: parts.join("\n\n") };
+}
+
+// Text-segment lifecycle: open a fresh assistant bubble lazily, close it so a
+// following tool round (or the next text run) lands below it in DOM order.
+function openText() {
+  if (curTextEl) return curTextEl;
+  curTextEl = addMsg("assistant", "");
+  curRaw = ""; curToggle = null; curThink = null;
+  toolGroup = null;  // tools after this text start a new row below it
+  return curTextEl;
+}
+function closeText() { curTextEl = null; }
+
+// Render the current segment's raw text, splitting off any <think> block into a
+// collapsible toggle attached to the current bubble.
+function renderCurrent() {
+  const { clean, think } = extractThink(curRaw);
+  if (think) { ensureThink(); curThink.textContent = think; }
+  curTextEl.dataset.raw = clean;
+  curTextEl.innerHTML = renderMarkdown(clean);
+}
+
+function ensureThink() {
+  if (curToggle) return;
+  curToggle = document.createElement("button");
+  curToggle.className = "think-toggle";
+  curToggle.textContent = "▸ mostra ragionamento";
+  curThink = document.createElement("div");
+  curThink.className = "think-block";
+  curTextEl.after(curToggle);
+  curToggle.after(curThink);
+  curToggle.addEventListener("click", () => {
+    const vis = curThink.classList.toggle("visible");
+    curToggle.textContent = (vis ? "▾ nascondi" : "▸ mostra") + " ragionamento";
+  });
+}
+
+function dropThinking() { if (thinkingEl) { thinkingEl.remove(); thinkingEl = null; } }
+
 function addMsg(cls, text) {
   const el = document.createElement("div");
   el.className = "msg " + cls;
@@ -317,12 +385,40 @@ function addThinking() {
 }
 
 function addTool(name, ok, out) {
-  const wrap = toolChips.length ? toolChips[toolChips.length - 1].wrap : null;
   const chip = document.createElement("span");
   chip.className = "tool " + (ok ? "ok" : "fail");
   chip.textContent = (ok ? "✓ " : "✗ ") + name;
-  if (out) { const pre = document.createElement("pre"); pre.textContent = out; chip.appendChild(pre); chip.title = out.slice(0, 300); }
-  if (wrap) wrap.appendChild(chip); else { const w = document.createElement("div"); w.className = "tools"; w.appendChild(chip); inner.appendChild(w); toolChips.push({ wrap: w }); }
+  if (out) {
+    chip.classList.add("expandable");
+    chip.classList.add("expanded");  // output visible by default; click to collapse
+    const pre = document.createElement("pre");
+    pre.textContent = out;
+    chip.appendChild(pre);
+    chip.addEventListener("click", () => chip.classList.toggle("expanded"));
+  }
+  // Consecutive tool results (same iteration) share a row; a text run in
+  // between resets toolGroup, so the next round opens a fresh row below it.
+  if (!toolGroup) { toolGroup = document.createElement("div"); toolGroup.className = "tools"; inner.appendChild(toolGroup); }
+  toolGroup.appendChild(chip);
+  scroll();
+}
+
+function renderOptions(options) {
+  const wrap = document.createElement("div");
+  wrap.className = "options";
+  for (const opt of options) {
+    const btn = document.createElement("button");
+    btn.className = "option";
+    btn.textContent = opt;
+    btn.addEventListener("click", () => {
+      if (busy) return;              // wait until the turn finished
+      wrap.remove();                 // consume the choices once one is picked
+      input.value = opt;
+      send();
+    });
+    wrap.appendChild(btn);
+  }
+  inner.appendChild(wrap);
   scroll();
 }
 
@@ -336,7 +432,7 @@ function renderHistory(messages) {
   }
 }
 
-function handleFrame(frame, assistantEl, thinkingEl, onDone) {
+function handleFrame(frame, onDone) {
   const ev = /^event: (.*)$/m.exec(frame)?.[1];
   const dl = frame.split("\n").find((l) => l.startsWith("data: "));
   if (!ev || !dl) return;
@@ -346,27 +442,51 @@ function handleFrame(frame, assistantEl, thinkingEl, onDone) {
       if (thinkingEl) thinkingEl.textContent = data.message || "sto pensando…";
       break;
     case "text":
-      if (thinkingEl) { thinkingEl.remove(); thinkingEl = null; }
-      assistantEl.classList.add("streaming");
-      assistantEl.dataset.raw = (assistantEl.dataset.raw || "") + (data.delta || "");
-      assistantEl.innerHTML = renderMarkdown(assistantEl.dataset.raw);
+      dropThinking();
+      openText();                       // lazily create the bubble (below any tools)
+      curTextEl.classList.add("streaming");
+      curRaw += data.delta || "";
+      renderCurrent();
       scroll();
       break;
     case "tool_start":
-      if (thinkingEl) { thinkingEl.remove(); thinkingEl = null; }
+      dropThinking();
+      closeText();                      // next text run opens a fresh bubble below
       break;
     case "tool_done":
-      addTool(data.tool_name, !!data.success, data.error || (data.success ? "" : ""));
+      dropThinking();
+      closeText();
+      addTool(data.tool_name, !!data.success, data.output || data.error || "");
+      break;
+    case "ask_user":
+      dropThinking();
+      closeText();
+      openText();                       // question in its own bubble, below tools
+      curRaw = data.question || "";
+      renderCurrent();
+      if (Array.isArray(data.options) && data.options.length) {
+        renderOptions(data.options);    // separate sibling; survives re-render
+      }
+      closeText();
+      scroll();
       break;
     case "done":
-      if (assistantEl.classList.contains("streaming")) assistantEl.classList.remove("streaming");
-      if (!assistantEl.dataset.raw && data.final_message) assistantEl.dataset.raw = data.final_message;
-      assistantEl.innerHTML = renderMarkdown(assistantEl.dataset.raw || data.final_message || "");
+      if (curTextEl) {
+        curTextEl.classList.remove("streaming");
+        renderCurrent();
+      } else if (data.final_message) {
+        // No text streamed this turn — render the final message as a bubble.
+        openText();
+        curRaw = data.final_message;
+        renderCurrent();
+      }
+      closeText();
       onDone();
       break;
     case "error":
-      if (thinkingEl) thinkingEl.remove();
-      assistantEl.remove();
+      dropThinking();
+      if (curTextEl && !curTextEl.dataset.raw && !curTextEl.textContent) curTextEl.remove();
+      closeText();
       addMsg("error", data.error || "Errore sconosciuto");
       onDone();
       break;
@@ -401,9 +521,9 @@ async function send() {
   showBanner("");
   input.value = ""; autoSize();
   addMsg("user", text);
-  const assistantEl = addMsg("assistant", "");
-  const thinkingEl = addThinking();
-  toolChips = [];
+  // Reset the streaming render state for this turn; bubbles are created lazily.
+  curTextEl = null; curRaw = ""; curToggle = null; curThink = null; toolGroup = null;
+  thinkingEl = addThinking();
   busy = true; setBusy(true);
 
   try {
@@ -421,15 +541,15 @@ async function send() {
       buf += decoder.decode(value, { stream: true });
       let idx;
       while ((idx = buf.indexOf("\n\n")) >= 0) {
-        handleFrame(buf.slice(0, idx), assistantEl, thinkingEl, () => {});
+        handleFrame(buf.slice(0, idx), () => {});
         buf = buf.slice(idx + 2);
       }
     }
-    if (thinkingEl) thinkingEl.remove();
-    if (!assistantEl.dataset.raw && !assistantEl.textContent) assistantEl.remove();
+    dropThinking();
+    if (curTextEl && !curTextEl.dataset.raw && !curTextEl.textContent) curTextEl.remove();
   } catch (e) {
-    if (thinkingEl) thinkingEl.remove();
-    assistantEl.remove();
+    dropThinking();
+    if (curTextEl && !curTextEl.dataset.raw && !curTextEl.textContent) curTextEl.remove();
     if (e.status === 404) { LS.session = ""; addMsg("error", "Sessione scaduta — riprova."); }
     else addMsg("error", String(e.message || e));
   } finally {

--- a/src/cortex/eval/runner.py
+++ b/src/cortex/eval/runner.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, cast
 from uuid import UUID, uuid4
 
 from cortex.agentic.context_builder import ContextBuilder
-from cortex.agentic.events import LoopEvent, TextDeltaEvent
+from cortex.agentic.events import AskUserEvent, LoopEvent, TextDeltaEvent
 from cortex.agentic.executor import LoopExecutor
 from cortex.agentic.loop import AgentLoop
 from cortex.agentic.reasoner import Reasoner
@@ -378,13 +378,16 @@ async def _drive_turn(
     """Run one scripted user turn, recording the transcript.
 
     Returns the final response text, accumulated from TextDeltaEvent deltas
-    in order — consumers must never assume chunk size.
+    in order — consumers must never assume chunk size. A clarifying
+    ``AskUserEvent`` (no text deltas) contributes its question as the response.
     """
     final_text = ""
     async for event in loop.stream_chat(session_id, turn):
         events.append(event)
         if isinstance(event, TextDeltaEvent):
             final_text += event.delta
+        elif isinstance(event, AskUserEvent):
+            final_text += event.question
     return final_text
 
 

--- a/src/cortex/eval/sandbox.py
+++ b/src/cortex/eval/sandbox.py
@@ -19,7 +19,13 @@ from typing import Any
 
 from cortex.eval.fixtures import SandboxFile
 from cortex.tools.interfaces import Tool, ToolDefinition, ToolResult
-from cortex.tools.meta import FileReadTool, FileWriteTool, GrepTool, ShellTool
+from cortex.tools.meta import (
+    AskUserTool,
+    FileReadTool,
+    FileWriteTool,
+    GrepTool,
+    ShellTool,
+)
 
 
 class SandboxEscapeError(ValueError):
@@ -125,8 +131,12 @@ class SandboxedTool(Tool):
 
 
 def build_sandboxed_tools(sandbox: TaskSandbox) -> list[Tool]:
-    """The four meta tools (file_read, file_write, grep, shell), sandboxed."""
+    """The four file/shell meta tools, sandboxed, plus ask_user.
+
+    ``ask_user`` needs no sandboxing (it touches no filesystem or shell), so it
+    is added unwrapped — the agent can ask a clarifying question in any task.
+    """
     return [
         SandboxedTool(tool, sandbox)
         for tool in (FileReadTool(), FileWriteTool(), GrepTool(), ShellTool())
-    ]
+    ] + [AskUserTool()]

--- a/src/cortex/execution/module.py
+++ b/src/cortex/execution/module.py
@@ -108,6 +108,7 @@ class ExecutionModule:
         user_message: str,
         *,
         max_iterations: int | None = None,
+        stream: bool = False,
     ) -> AsyncGenerator[LoopEvent, None]:
         """
         Stream chat progress events as a transparent passthrough.
@@ -121,6 +122,8 @@ class ExecutionModule:
             session_id: Current session
             user_message: User's message
             max_iterations: Optional iteration limit
+            stream: When True, the response text is emitted token-by-token
+                (one TextDeltaEvent per delta); forwarded to the agent loop.
 
         Yields:
             LoopEvent progress signals (thinking, tool_start, tool_done,
@@ -130,6 +133,7 @@ class ExecutionModule:
             session_id=session_id,
             user_message=user_message,
             max_iterations=max_iterations,
+            stream=stream,
         ):
             yield event
 

--- a/src/cortex/llm/base.py
+++ b/src/cortex/llm/base.py
@@ -1,6 +1,7 @@
 """Abstract base class for LLM clients."""
 
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from typing import Any
 
 from cortex.config.models import Settings
@@ -35,6 +36,33 @@ class LLMClient(ABC):
 
         Returns:
             ChatResult with response message and optional tool calls
+        """
+        ...
+
+    @abstractmethod
+    def chat_stream(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        generation_config: GenerationConfig | None = None,
+    ) -> AsyncIterator[str | ChatResult]:
+        """
+        Stream a chat completion.
+
+        Yields text deltas (``str``) as the provider produces them, then a
+        single final ``ChatResult`` as the terminal item — content, tool calls
+        and usage assembled from the stream. Callers iterate and collect the
+        ``str`` deltas; the only non-``str`` item, yielded last, is the
+        complete ``ChatResult``.
+
+        Args:
+            messages: Conversation history
+            tools: Optional list of tool definitions for function calling
+            generation_config: Optional generation parameters
+
+        Yields:
+            ``str`` text deltas, then a final ``ChatResult``.
         """
         ...
 

--- a/src/cortex/llm/providers/openai.py
+++ b/src/cortex/llm/providers/openai.py
@@ -1,6 +1,7 @@
 """OpenAI LLM client implementation."""
 
 import logging
+from collections.abc import AsyncIterator
 from typing import Any
 
 import openai
@@ -18,6 +19,26 @@ from cortex.llm.models import (
 from cortex.tools.interfaces import ToolCall, ToolDefinition
 
 logger = logging.getLogger(__name__)
+
+
+def _reasoning_delta(delta: Any) -> str | None:
+    """Extract a reasoning-token delta from a streaming chunk.
+
+    Reasoning models that deliver chain-of-thought out-of-band use a dedicated
+    field (``reasoning_content`` on DeepSeek-R1, ``reasoning`` on some others)
+    rather than inline ``<think>`` tags. The typed SDK delta may expose it as an
+    attribute or only via ``model_extra``; both are checked. Returns None for
+    models that put reasoning inline in ``content`` (nothing to normalize).
+    """
+    for name in ("reasoning_content", "reasoning"):
+        val = getattr(delta, name, None)
+        if val is None:
+            extra = getattr(delta, "model_extra", None)
+            if extra:
+                val = extra.get(name)
+        if val:
+            return val
+    return None
 
 
 class OpenAIClient(LLMClient):
@@ -110,6 +131,146 @@ class OpenAIClient(LLMClient):
         except openai.APIError as e:
             logger.error(f"OpenAI API error: {e}")
             raise
+
+    async def chat_stream(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        generation_config: GenerationConfig | None = None,
+    ) -> AsyncIterator[str | ChatResult]:
+        """
+        Streaming variant of ``chat()``.
+
+        Yields text deltas (``str``) as they arrive from the provider, then
+        yields a single final ``ChatResult`` as the terminal item — content,
+        tool calls and usage assembled from the stream. Callers iterate and
+        collect the ``str`` deltas; the only non-``str`` item, yielded last,
+        is the complete ``ChatResult``.
+
+        The same request as ``chat()`` is sent with ``stream=True``; tool-call
+        fragments (spread across chunks by ``index``) are accumulated and
+        re-assembled into internal ``ToolCall`` objects at the end.
+
+        Out-of-band reasoning (a separate ``reasoning_content`` field, not inline
+        ``<think>`` tags) is normalized to the inline convention: it is wrapped in
+        a single ``<think>...</think>`` block and emitted as content deltas, so
+        every downstream consumer — and the UI's reasoning toggle — treats both
+        reasoning-delivery styles identically.
+        """
+        request_kwargs: dict[str, Any] = {
+            "model": self._model,
+            "messages": [self._to_openai_message(m) for m in messages],
+            "stream": True,
+            # Ask for usage on the final chunk (OpenAI-compatible providers).
+            "stream_options": {"include_usage": True},
+        }
+
+        if tools:
+            request_kwargs["tools"] = self.translate_tools(tools)
+
+        if generation_config:
+            request_kwargs.update(generation_config.model_dump(exclude_none=True))
+
+        logger.debug(
+            f"OpenAI stream request: {request_kwargs.get('model')}, {len(messages)} messages"
+        )
+
+        content_parts: list[str] = []
+        # index -> {"id", "name", "arguments"} accumulated across chunks
+        tool_fragments: dict[int, dict[str, str]] = {}
+        finish_reason: str | None = None
+        model_name: str | None = None
+        usage: UsageStats | None = None
+        think_open = False  # True while inside a synthesized <think> block
+
+        try:
+            stream = await self._client.chat.completions.create(**request_kwargs)
+
+            async for chunk in stream:
+                if chunk.model:
+                    model_name = chunk.model
+                if chunk.usage:
+                    usage = UsageStats(
+                        prompt_tokens=chunk.usage.prompt_tokens,
+                        completion_tokens=chunk.usage.completion_tokens,
+                        total_tokens=chunk.usage.total_tokens,
+                    )
+                # The usage-only final chunk carries no choices.
+                if not chunk.choices:
+                    continue
+
+                choice = chunk.choices[0]
+                if choice.finish_reason:
+                    finish_reason = choice.finish_reason
+
+                delta = choice.delta
+
+                # Out-of-band reasoning: open a <think> block on first token.
+                reasoning = _reasoning_delta(delta)
+                if reasoning:
+                    if not think_open:
+                        content_parts.append("<think>")
+                        yield "<think>"
+                        think_open = True
+                    content_parts.append(reasoning)
+                    yield reasoning
+
+                if delta.content:
+                    # Answer text has started — close any open reasoning block.
+                    if think_open:
+                        content_parts.append("</think>")
+                        yield "</think>"
+                        think_open = False
+                    content_parts.append(delta.content)
+                    yield delta.content
+
+                if delta.tool_calls:
+                    for tc in delta.tool_calls:
+                        frag = tool_fragments.setdefault(
+                            tc.index, {"id": "", "name": "", "arguments": ""}
+                        )
+                        if tc.id:
+                            frag["id"] = tc.id
+                        if tc.function and tc.function.name:
+                            frag["name"] = tc.function.name
+                        if tc.function and tc.function.arguments:
+                            frag["arguments"] += tc.function.arguments
+
+        except openai.APIError as e:
+            logger.error(f"OpenAI streaming error: {e}")
+            raise
+
+        # Reasoning with no trailing content (e.g. reasoning then a tool call, or
+        # reasoning-only): close the block so the <think> tag is always balanced.
+        if think_open:
+            content_parts.append("</think>")
+            yield "</think>"
+            think_open = False
+
+        tool_calls = None
+        if tool_fragments:
+            tool_calls = [
+                self.translate_tool_call(
+                    {
+                        "id": frag["id"],
+                        "function": {
+                            "name": frag["name"],
+                            "arguments": frag["arguments"],
+                        },
+                    }
+                )
+                for _, frag in sorted(tool_fragments.items())
+            ]
+
+        content = "".join(content_parts) or None
+        yield ChatResult(
+            message=ChatMessage(role=Role.ASSISTANT, content=content),
+            tool_calls=tool_calls,
+            usage=usage,
+            model=model_name,
+            finish_reason=finish_reason,
+        )
 
     def translate_tools(self, tools: list[ToolDefinition]) -> list[dict[str, Any]]:
         """

--- a/src/cortex/llm/providers/openai.py
+++ b/src/cortex/llm/providers/openai.py
@@ -37,7 +37,7 @@ def _reasoning_delta(delta: Any) -> str | None:
             if extra:
                 val = extra.get(name)
         if val:
-            return val
+            return str(val)
     return None
 
 

--- a/src/cortex/llm/wrapper.py
+++ b/src/cortex/llm/wrapper.py
@@ -8,6 +8,7 @@ via ``__getattr__`` pass-through.
 from __future__ import annotations
 
 import logging
+from collections.abc import AsyncIterator
 from typing import Any
 
 from cortex.llm.base import LLMClient
@@ -69,6 +70,27 @@ class CircuitBreakerLLMClient(LLMClient):
                 "Circuit breaker failure for module '%s'", self._module,
             )
             raise
+
+    async def chat_stream(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        generation_config: GenerationConfig | None = None,
+    ) -> AsyncIterator[str | ChatResult]:
+        """Forwards streaming directly to the underlying client.
+
+        Streaming is NOT routed through the circuit breaker: the breaker's
+        ``call()`` guards a single awaitable resolving to one value, whereas a
+        stream is a long-lived async generator. Wrapping it there would give no
+        meaningful success/failure signal, so deltas pass straight through.
+        """
+        async for item in self._client.chat_stream(
+            messages,
+            tools=tools,
+            generation_config=generation_config,
+        ):
+            yield item
 
     # -- Explicit pass-through for abstract methods ---------------------------
 

--- a/src/cortex/tools/interfaces.py
+++ b/src/cortex/tools/interfaces.py
@@ -40,6 +40,10 @@ class ToolResult:
     error_severity: ToolErrorSeverity | None = None
     execution_time_ms: float | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    # Optional control signal that interrupts the agent loop instead of feeding
+    # the result back for another iteration (e.g. "ask_user" halts to ask the
+    # user a clarifying question). None for ordinary tools that just return data.
+    control: str | None = None
 
 
 @dataclass

--- a/src/cortex/tools/meta/__init__.py
+++ b/src/cortex/tools/meta/__init__.py
@@ -1,12 +1,14 @@
 """Meta tools - built-in tools for the agent."""
 
 from cortex.tools.interfaces import Tool, ToolRegistry
+from cortex.tools.meta.ask_user import AskUserTool
 from cortex.tools.meta.file_read import FileReadTool
 from cortex.tools.meta.file_write import FileWriteTool
 from cortex.tools.meta.grep import GrepTool
 from cortex.tools.meta.shell import ShellTool
 
 __all__ = [
+    "AskUserTool",
     "FileReadTool",
     "FileWriteTool",
     "GrepTool",
@@ -24,6 +26,7 @@ def register_meta_tools(registry: ToolRegistry) -> list[str]:
         FileWriteTool(),
         GrepTool(),
         ShellTool(),
+        AskUserTool(),
     ])
 
     return registrar.registered
@@ -36,4 +39,5 @@ def get_meta_tools() -> list[Tool]:
         FileWriteTool(),
         GrepTool(),
         ShellTool(),
+        AskUserTool(),
     ]

--- a/src/cortex/tools/meta/ask_user.py
+++ b/src/cortex/tools/meta/ask_user.py
@@ -1,0 +1,89 @@
+"""ask_user tool — pause the loop to ask the user a clarifying question.
+
+Unlike ordinary tools, ``ask_user`` produces no data to feed back into the
+loop: it returns a ``ToolResult`` carrying the ``control="ask_user"`` signal so
+the :class:`~cortex.agentic.loop.AgentLoop` halts and surfaces the question to
+the user instead of iterating. Replaces the older ``[QUESTION]...[/QUESTION]``
+text-marker convention with a structured tool call.
+"""
+
+from typing import Any
+
+from cortex.tools.interfaces import ToolErrorSeverity, ToolResult
+from cortex.tools.meta.base import BaseMetaTool
+
+# Tool name and the control signal it emits, kept in one place so the tool and
+# the loop agree on the exact strings (they share the literal, but are distinct
+# concepts: one identifies the tool, the other flags the loop-halt behavior).
+ASK_USER_TOOL_NAME = "ask_user"
+ASK_USER_CONTROL = "ask_user"
+
+
+class AskUserTool(BaseMetaTool):
+    """Ask the user for clarification when information is missing.
+
+    The model calls this instead of guessing when it cannot proceed. Optional
+    ``options`` are model-suggested answers the UI can render as choices.
+    """
+
+    @property
+    def name(self) -> str:
+        return ASK_USER_TOOL_NAME
+
+    @property
+    def description(self) -> str:
+        return (
+            "Ask the user a clarifying question when you lack the information "
+            "to proceed. Prefer this over guessing. Optionally provide a short "
+            "list of suggested answers as `options`. Calling this ends your turn "
+            "and waits for the user's reply."
+        )
+
+    @property
+    def input_schema(self) -> dict[str, Any]:
+        return {
+            "type": "object",
+            "properties": {
+                "question": {
+                    "type": "string",
+                    "description": "The clarifying question to ask the user.",
+                },
+                "options": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional suggested answers to present to the user as "
+                        "selectable choices."
+                    ),
+                },
+            },
+            "required": ["question"],
+        }
+
+    @property
+    def tags(self) -> list[str]:
+        return ["clarification", "interaction", "control"]
+
+    async def execute(self, arguments: dict[str, Any]) -> ToolResult:
+        question = arguments.get("question", "")
+        if not isinstance(question, str) or not question.strip():
+            return ToolResult(
+                tool_call_id="",
+                tool_name=self.name,
+                success=False,
+                error="`question` is required and must be a non-empty string.",
+                error_severity=ToolErrorSeverity.ERROR,
+            )
+
+        # Normalize options: keep only non-empty strings; drop anything else.
+        raw_options = arguments.get("options") or []
+        options = [o for o in raw_options if isinstance(o, str) and o.strip()]
+
+        return ToolResult(
+            tool_call_id="",
+            tool_name=self.name,
+            success=True,
+            output=question,
+            control=ASK_USER_CONTROL,
+            metadata={"options": options},
+        )

--- a/src/cortex/tools/meta/file_read.py
+++ b/src/cortex/tools/meta/file_read.py
@@ -41,7 +41,7 @@ class FileReadTool(BaseMetaTool, FileToolMixin):
                     "description": "Text encoding to use (default: utf-8).",
                     "default": "utf-8",
                 },
-                " max_lines": {
+                "max_lines": {
                     "type": "integer",
                     "description": "Maximum number of lines to read (default: all).",
                     "default": 0,

--- a/tests/eval/fakes.py
+++ b/tests/eval/fakes.py
@@ -66,6 +66,24 @@ class ScriptedLLMClient(LLMClient):
             raise AssertionError("ScriptedLLMClient ran out of scripted responses")
         return self._responses.pop(0)
 
+    async def chat_stream(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        generation_config: GenerationConfig | None = None,
+    ):
+        """Streaming mirror of ``chat``: emits the scripted response's text as a
+        single delta, then the ``ChatResult`` itself as the terminal item."""
+        self.calls.append(list(messages))
+        if not self._responses:
+            raise AssertionError("ScriptedLLMClient ran out of scripted responses")
+        result = self._responses.pop(0)
+        content = result.message.content if result.message else None
+        if content:
+            yield content
+        yield result
+
     def translate_tools(self, tools: list[ToolDefinition]) -> list[dict[str, Any]]:
         return [{"name": tool.name} for tool in tools]
 

--- a/tests/eval/fixtures/loop_manifest.yaml
+++ b/tests/eval/fixtures/loop_manifest.yaml
@@ -10,7 +10,7 @@ suite:
 # SHA-256 of the reasoner default system prompt
 # (src/cortex/agentic/reasoner.py, Reasoner._default_system_prompt()).
 # Recompute and bump whenever the prompt text changes.
-prompt_version: a7e52a6d5839c8443e272e5cf57722ed6c4ae2062e31d60e1c996edcd5508021
+prompt_version: fb36a12b6618b91717d4dc8526321f018219488cc9e7d58ea5461d3d9a8dd7eb
 
 # The model this suite targets — settings llm_model (config.yaml: llm.model).
 model: deepseek-v4-flash

--- a/tests/eval/fixtures/loop_suite.yaml
+++ b/tests/eval/fixtures/loop_suite.yaml
@@ -14,8 +14,8 @@
 #   behavior is to use the four meta tools (file_read / file_write / grep /
 #   shell) against the sandbox files to reach the goal files state.
 # - 8 negative tasks (name prefix `neg-`): the right behavior is to NOT use
-#   tools — ask clarification via [QUESTION], or respond without writing the
-#   artifact. Encoded via goal.answer clarification/refusal variants +
+#   file/shell tools — ask clarification via the ask_user tool, or respond
+#   without writing the artifact. Encoded via goal.answer clarification/refusal variants +
 #   goal.absent paths (must-not-happen artifacts); any goal.files check on a
 #   negative only asserts a sandbox input is preserved.
 # - Every task is achievable with the tools: reference solutions are scripted

--- a/tests/eval/test_loop_suite.py
+++ b/tests/eval/test_loop_suite.py
@@ -6,8 +6,9 @@ goal state (expected sandbox filesystem state). Pass/fail is the
 deterministic goal-state comparison (ADR-0015) — no LLM judge. The golden
 set is balanced: 22 positive tool-using tasks (file_read / file_write /
 grep / shell) and 8 negative tasks whose correct behavior is to NOT use
-tools — ask clarification via [QUESTION] or respond without writing the
-artifact (goal.answer clarification variants + goal.absent).
+file/shell tools — ask clarification via the ask_user tool or respond
+without writing the artifact (goal.answer clarification variants +
+goal.absent).
 
 All tests run through the real harness with the scripted LLM client —
 never a real API.
@@ -58,8 +59,8 @@ COST_PER_CALL = 0.000325
 #: reach the goal state through the real loop, in order. Each step is one
 #: chat call: ("tool", name, arguments) executes a real tool call,
 #: ("text", ...) ends the turn with a response, ("question", ...) ends the
-#: turn via the [QUESTION] clarification path. Reference solutions are
-#: verified end-to-end by TestLoopSuiteEndToEnd.
+#: turn by calling the ask_user tool to ask for clarification. Reference
+#: solutions are verified end-to-end by TestLoopSuiteEndToEnd.
 GOLDEN: dict[str, list[tuple[str, ...]]] = {
     # ── Positive: tool-using tasks (file_read / file_write / grep / shell) ──
     "read-sum-numbers": [
@@ -214,7 +215,7 @@ def _queue_golden(client: ScriptedLLMClient, steps: list[tuple[str, ...]], usage
         elif kind == "text":
             client.queue_text(step[1], usage=usage)
         elif kind == "question":
-            client.queue_text(f"[QUESTION]{step[1]}[/QUESTION]", usage=usage)
+            client.queue_tool_call("ask_user", {"question": step[1]}, usage=usage)
         else:
             raise AssertionError(f"unknown golden step kind: {kind!r}")
 

--- a/tests/unit/agentic/test_loop.py
+++ b/tests/unit/agentic/test_loop.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 import pytest
 
 from cortex.agentic.events import (
+    AskUserEvent,
     ErrorEvent,
     LoopEvent,
     ResponseDoneEvent,
@@ -160,26 +161,6 @@ class TestAgentLoop:
 
         assert isinstance(response, ChatResponse)
         assert response.message == "Hello!"
-        assert response.iterations == 0
-        assert response.tools_used == []
-        assert response.session_id == session_id
-
-    @pytest.mark.asyncio
-    async def test_run_chat_ask_question_returns_complete_response(
-        self, loop, mock_context_builder, mock_reasoner
-    ) -> None:
-        """ASK_QUESTION path returns a complete ChatResponse with the question."""
-        session_id = uuid4()
-
-        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
-        mock_reasoner.reason = AsyncMock(return_value=Decision.ask_question(
-            "Did you mean file A or file B?"
-        ))
-
-        response = await loop.run_chat(session_id, "Open the file")
-
-        assert isinstance(response, ChatResponse)
-        assert response.message == "Did you mean file A or file B?"
         assert response.iterations == 0
         assert response.tools_used == []
         assert response.session_id == session_id
@@ -519,29 +500,6 @@ class TestAgentLoopEdgeCases:
             await loop.run_chat(uuid4(), "Hello")
 
     @pytest.mark.asyncio
-    async def test_run_chat_with_ask_question(self):
-        """Run chat handles ask_question decision."""
-        mock_context_builder = MagicMock()
-        mock_context_builder.build = AsyncMock(return_value=Context(session_id=uuid4()))
-
-        mock_reasoner = MagicMock()
-        mock_reasoner.reason = AsyncMock(return_value=Decision.ask_question(
-            "Did you mean file A or file B?"
-        ))
-
-        loop = AgentLoop(
-            context_builder=mock_context_builder,
-            reasoner=mock_reasoner,
-            executor=MagicMock(),
-            event_bus=MagicMock(),
-        )
-
-        response = await loop.run_chat(uuid4(), "Open the file")
-
-        # Should return the question
-        assert "file A or file B" in response.message or response.message is not None
-
-    @pytest.mark.asyncio
     async def test_run_chat_preserves_conversation(self):
         """Run chat should preserve conversation for context."""
         mock_context_builder = MagicMock()
@@ -635,28 +593,6 @@ class TestStreamChat:
         assert events[2].iterations == 0
         assert events[2].tools_used == []
         assert all(e.session_id == session_id for e in events)
-
-    @pytest.mark.asyncio
-    async def test_ask_question_event_sequence(
-        self, loop, mock_context_builder, mock_reasoner
-    ) -> None:
-        """ASK_QUESTION yields thinking -> text -> done with the question."""
-        session_id = uuid4()
-
-        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
-        mock_reasoner.reason = AsyncMock(return_value=Decision.ask_question(
-            "Did you mean file A or file B?", reasoning="need clarification",
-        ))
-
-        events = [e async for e in loop.stream_chat(session_id, "Open the file")]
-
-        assert [e.event_type for e in events] == ["thinking", "text", "done"]
-        assert isinstance(events[1], TextDeltaEvent)
-        assert events[1].delta == "Did you mean file A or file B?"
-        assert isinstance(events[2], ResponseDoneEvent)
-        assert events[2].message == "Did you mean file A or file B?"
-        assert events[2].iterations == 0
-        assert events[2].tools_used == []
 
     @pytest.mark.asyncio
     async def test_tool_round_interleaves_start_result(
@@ -907,6 +843,209 @@ class TestStreamChat:
         assert done_event.iterations == 1
         assert done_event.tools_used == ["search", "read"]
 
+    # -- stream=True: token-by-token response via reason_stream ---------------
+
+    @staticmethod
+    def _reason_stream(*items):
+        """Build an async generator over `items` (str deltas + terminal Decision),
+        mimicking Reasoner.reason_stream(context)."""
+        async def gen(_context):
+            for it in items:
+                yield it
+        return gen
+
+    @pytest.mark.asyncio
+    async def test_stream_respond_emits_one_delta_per_token(
+        self, loop, mock_context_builder, mock_reasoner
+    ) -> None:
+        """stream=True yields a TextDeltaEvent per delta (no duplicate full-text
+        delta); done carries the joined text. Thinking lands after the deltas."""
+        session_id = uuid4()
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason_stream = self._reason_stream(
+            "Hello", " ", "world",
+            Decision.respond("Hello world", reasoning="direct"),
+        )
+
+        events = [e async for e in loop.stream_chat(session_id, "Hi", stream=True)]
+
+        assert [e.event_type for e in events] == [
+            "text", "text", "text", "thinking", "done",
+        ]
+        deltas = [e.delta for e in events if isinstance(e, TextDeltaEvent)]
+        assert deltas == ["Hello", " ", "world"]  # exactly the streamed pieces
+        done = events[-1]
+        assert isinstance(done, ResponseDoneEvent)
+        assert done.message == "Hello world"  # accumulated, not duplicated
+
+    @pytest.mark.asyncio
+    async def test_stream_respond_no_deltas_falls_back_to_decision_text(
+        self, loop, mock_context_builder, mock_reasoner
+    ) -> None:
+        """A RESPOND stream with no content deltas emits the decision text once,
+        keeping the non-stream ordering (thinking -> text -> done)."""
+        session_id = uuid4()
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason_stream = self._reason_stream(
+            Decision.respond("Fallback text", reasoning="direct"),
+        )
+
+        events = [e async for e in loop.stream_chat(session_id, "Hi", stream=True)]
+
+        assert [e.event_type for e in events] == ["thinking", "text", "done"]
+        deltas = [e.delta for e in events if isinstance(e, TextDeltaEvent)]
+        assert deltas == ["Fallback text"]
+        assert events[-1].message == "Fallback text"
+
+    @pytest.mark.asyncio
+    async def test_stream_tool_turn_carries_no_premature_text(
+        self, loop, mock_context_builder, mock_reasoner, mock_executor
+    ) -> None:
+        """A tool-call turn streams no text; the shared EXECUTE_TOOLS path runs,
+        then the follow-up turn streams the response deltas."""
+        from unittest.mock import MagicMock as _MagicMock
+
+        session_id = uuid4()
+        call_a = ToolCall(id="call_a", name="tool_a", arguments={"x": 1})
+
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        # First call: only a tool Decision (no deltas). Second: text deltas + respond.
+        mock_reasoner.reason_stream = _MagicMock(side_effect=[
+            self._reason_stream(
+                Decision.execute_tools([call_a], reasoning="need tools"),
+            )(None),
+            self._reason_stream(
+                "All ", "done.",
+                Decision.respond("All done.", reasoning="finished"),
+            )(None),
+        ])
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_a", tool_name="tool_a", success=True, output="out_a",
+        ))
+
+        events = [e async for e in loop.stream_chat(session_id, "Run tools", stream=True)]
+
+        assert [e.event_type for e in events] == [
+            "thinking", "tool_start", "tool_done",
+            "text", "text", "thinking", "done",
+        ]
+        done = events[-1]
+        assert isinstance(done, ResponseDoneEvent)
+        assert done.message == "All done."
+        assert done.iterations == 1
+        assert done.tools_used == ["tool_a"]
+
+    @pytest.mark.asyncio
+    async def test_stream_matches_run_chat_message(
+        self, loop, mock_context_builder, mock_reasoner
+    ) -> None:
+        """Draining the stream deltas reconstructs the same text run_chat would
+        return for the equivalent non-stream decision."""
+        session_id = uuid4()
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+
+        mock_reasoner.reason_stream = self._reason_stream(
+            "The ", "answer ", "is ", "42.",
+            Decision.respond("The answer is 42.", reasoning="direct"),
+        )
+        stream_events = [
+            e async for e in loop.stream_chat(session_id, "Q", stream=True)
+        ]
+        joined = "".join(
+            e.delta for e in stream_events if isinstance(e, TextDeltaEvent)
+        )
+
+        mock_reasoner.reason = AsyncMock(return_value=Decision.respond(
+            "The answer is 42.", reasoning="direct",
+        ))
+        response = await loop.run_chat(session_id, "Q")
+
+        assert joined == response.message == "The answer is 42."
+
+    # -- ask_user tool (B2): clarifying question halts the turn ---------------
+
+    @pytest.mark.asyncio
+    async def test_ask_user_halts_and_emits_ask_user_event(
+        self, loop, mock_context_builder, mock_reasoner, mock_executor
+    ) -> None:
+        """An ask_user tool call yields thinking -> ask_user -> done, carrying
+        the question and options; no tool_start/tool_done, and ask_user is not
+        counted among tools_used."""
+        session_id = uuid4()
+        ask_call = ToolCall(
+            id="call_1", name="ask_user",
+            arguments={"question": "Which file?", "options": ["a.txt", "b.txt"]},
+        )
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.execute_tools(
+            [ask_call], reasoning="need info",
+        ))
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_1", tool_name="ask_user", success=True,
+            output="Which file?", control="ask_user",
+            metadata={"options": ["a.txt", "b.txt"]},
+        ))
+
+        events = [e async for e in loop.stream_chat(session_id, "Open the file")]
+
+        assert [e.event_type for e in events] == ["thinking", "ask_user", "done"]
+        ask = events[1]
+        assert isinstance(ask, AskUserEvent)
+        assert ask.question == "Which file?"
+        assert ask.options == ["a.txt", "b.txt"]
+        done = events[-1]
+        assert isinstance(done, ResponseDoneEvent)
+        assert done.message == "Which file?"
+        assert done.tools_used == []  # ask_user is a control signal, not a tool
+
+    @pytest.mark.asyncio
+    async def test_ask_user_malformed_falls_back_to_error_text(
+        self, loop, mock_context_builder, mock_reasoner, mock_executor
+    ) -> None:
+        """A failed ask_user (no control signal) surfaces the tool error as the
+        turn's response and halts — without re-executing the call."""
+        session_id = uuid4()
+        ask_call = ToolCall(id="call_1", name="ask_user", arguments={"question": "  "})
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.execute_tools(
+            [ask_call], reasoning="need info",
+        ))
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_1", tool_name="ask_user", success=False,
+            error="`question` is required and must be a non-empty string.",
+            control=None,
+        ))
+
+        events = [e async for e in loop.stream_chat(session_id, "Open the file")]
+
+        assert [e.event_type for e in events] == ["thinking", "text", "done"]
+        assert "question" in events[1].delta
+        # Executed exactly once (no fall-through re-execution).
+        assert mock_executor.execute_single.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_run_chat_returns_ask_user_question(
+        self, loop, mock_context_builder, mock_reasoner, mock_executor
+    ) -> None:
+        """The drain (run_chat) picks up the ask_user question as the message,
+        even though it arrives as an AskUserEvent, not a TextDeltaEvent."""
+        session_id = uuid4()
+        ask_call = ToolCall(
+            id="call_1", name="ask_user", arguments={"question": "A or B?"},
+        )
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.execute_tools(
+            [ask_call], reasoning="need info",
+        ))
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_1", tool_name="ask_user", success=True,
+            output="A or B?", control="ask_user", metadata={"options": []},
+        ))
+
+        response = await loop.run_chat(session_id, "Pick")
+
+        assert response.message == "A or B?"
+
 
 class TestStreamChatPersistence:
     """Tests for AgentLoop.stream_chat message persistence."""
@@ -1086,29 +1225,6 @@ class TestStreamChatPersistence:
         assert len(conv) == 3
 
     @pytest.mark.asyncio
-    async def test_ask_question_persists_as_assistant(
-        self, mock_context_builder, mock_reasoner, mock_executor, mock_event_bus, repo
-    ) -> None:
-        """ASK_QUESTION persists the question text as an ASSISTANT message."""
-        session_id = uuid4()
-
-        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
-        mock_reasoner.reason = AsyncMock(return_value=Decision.ask_question(
-            "Did you mean file A or file B?", reasoning="need clarification",
-        ))
-
-        loop = self.make_loop(
-            mock_context_builder, mock_reasoner, mock_executor, mock_event_bus, repo
-        )
-
-        events = [e async for e in loop.stream_chat(session_id, "Open the file")]
-
-        assert [e.event_type for e in events] == ["thinking", "text", "done"]
-        calls = repo.add_message.await_args_list
-        assert [c.args[1] for c in calls] == [MessageRole.USER, MessageRole.ASSISTANT]
-        assert calls[1].args[2] == "Did you mean file A or file B?"
-
-    @pytest.mark.asyncio
     async def test_without_repository_skips_persistence(
         self, loop, mock_context_builder, mock_reasoner
     ) -> None:
@@ -1125,3 +1241,36 @@ class TestStreamChatPersistence:
 
         assert [e.event_type for e in events] == ["thinking", "text", "done"]
         assert loop._session_repository is None
+
+    @pytest.mark.asyncio
+    async def test_ask_user_persists_question_as_assistant_no_tool_call(
+        self, mock_context_builder, mock_reasoner, mock_executor, mock_event_bus, repo
+    ) -> None:
+        """B2: the ask_user question is persisted as a plain ASSISTANT message —
+        USER then ASSISTANT — with NO tool_call/tool_result stored, so providers
+        never see a dangling tool call."""
+        session_id = uuid4()
+        ask_call = ToolCall(
+            id="call_1", name="ask_user", arguments={"question": "A or B?"},
+        )
+        mock_context_builder.build = AsyncMock(return_value=Context(session_id=session_id))
+        mock_reasoner.reason = AsyncMock(return_value=Decision.execute_tools(
+            [ask_call], reasoning="need info",
+        ))
+        mock_executor.execute_single = AsyncMock(return_value=ToolResult(
+            tool_call_id="call_1", tool_name="ask_user", success=True,
+            output="A or B?", control="ask_user", metadata={"options": []},
+        ))
+
+        loop = self.make_loop(
+            mock_context_builder, mock_reasoner, mock_executor, mock_event_bus, repo
+        )
+
+        _ = [e async for e in loop.stream_chat(session_id, "Pick")]
+
+        calls = repo.add_message.await_args_list
+        # Exactly USER then ASSISTANT — no TOOL_RESULT round.
+        assert [c.args[1] for c in calls] == [MessageRole.USER, MessageRole.ASSISTANT]
+        assert calls[1].args[2] == "A or B?"
+        # No persisted message carries tool_calls (no dangling assistant call).
+        assert all(c.kwargs.get("tool_calls") is None for c in calls)

--- a/tests/unit/agentic/test_loop_events.py
+++ b/tests/unit/agentic/test_loop_events.py
@@ -7,6 +7,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from cortex.agentic.events import (
+    AskUserEvent,
     ErrorEvent,
     LoopEvent,
     ResponseDoneEvent,
@@ -23,6 +24,7 @@ WIRE_NAMES = {
     ToolStartEvent: "tool_start",
     ToolResultEvent: "tool_done",
     ResponseDoneEvent: "done",
+    AskUserEvent: "ask_user",
     ErrorEvent: "error",
 }
 
@@ -48,6 +50,11 @@ def _sample_events(session_id: UUID) -> list[LoopEvent]:
             message="All done",
             tools_used=["web_search", "calculator"],
             iterations=3,
+        ),
+        AskUserEvent(
+            session_id=session_id,
+            question="Which file did you mean?",
+            options=["a.txt", "b.txt"],
         ),
         ErrorEvent(session_id=session_id, error="boom", code="max_iterations"),
     ]
@@ -95,6 +102,7 @@ class TestEventContract:
             "tool_start",
             "tool_done",
             "done",
+            "ask_user",
             "error",
         }
         for cls, name in WIRE_NAMES.items():
@@ -335,6 +343,32 @@ class TestResponseDoneEvent:
         assert payload["usage"] is None
         assert payload["latency_ms"] is None
         json.dumps(payload)
+
+
+class TestAskUserEvent:
+    """Tests for AskUserEvent."""
+
+    def test_wire_name(self):
+        event = AskUserEvent(session_id=uuid4(), question="Which one?")
+        assert event.event_type == "ask_user"
+
+    def test_question_required(self):
+        with pytest.raises(TypeError):
+            AskUserEvent(session_id=uuid4())  # type: ignore[call-arg]
+
+    def test_options_default_empty(self):
+        event = AskUserEvent(session_id=uuid4(), question="Which one?")
+        assert event.options == []
+
+    def test_options_carried_in_payload(self):
+        event = AskUserEvent(
+            session_id=uuid4(), question="Which file?", options=["a.txt", "b.txt"]
+        )
+        payload = event.to_dict()
+        assert payload["event_type"] == "ask_user"
+        assert payload["question"] == "Which file?"
+        assert payload["options"] == ["a.txt", "b.txt"]
+        json.dumps(payload)  # JSON-ready
 
 
 class TestErrorEvent:

--- a/tests/unit/agentic/test_models.py
+++ b/tests/unit/agentic/test_models.py
@@ -41,9 +41,6 @@ class TestDecisionType:
     def test_execute_tools_type_exists(self):
         assert DecisionType.EXECUTE_TOOLS == DecisionType.EXECUTE_TOOLS
 
-    def test_ask_question_type_exists(self):
-        assert DecisionType.ASK_QUESTION == DecisionType.ASK_QUESTION
-
 
 class TestDecision:
     """Tests for Decision dataclass."""
@@ -80,18 +77,6 @@ class TestDecision:
         assert len(decision.tool_calls) == 1
         assert decision.tool_calls[0].name == "file_read"
 
-    def test_ask_question_decision(self):
-        """Decision to ask for clarification."""
-        decision = Decision(
-            decision_type=DecisionType.ASK_QUESTION,
-            text="Did you mean the project in /home or /work?",
-            tool_calls=None,
-            reasoning="Ambiguous request needs clarification",
-        )
-
-        assert decision.decision_type == DecisionType.ASK_QUESTION
-        assert "Ambiguous" in decision.reasoning
-
     def test_respond_factory(self):
         """Factory method for RESPOND decisions."""
         decision = Decision.respond("Simple response")
@@ -109,12 +94,6 @@ class TestDecision:
 
         assert decision.decision_type == DecisionType.EXECUTE_TOOLS
         assert decision.tool_calls == calls
-
-    def test_ask_question_factory(self):
-        """Factory method for ASK_QUESTION decisions."""
-        decision = Decision.ask_question("Which file did you mean?")
-
-        assert decision.decision_type == DecisionType.ASK_QUESTION
 
 
 class TestContext:

--- a/tests/unit/agentic/test_reasoner.py
+++ b/tests/unit/agentic/test_reasoner.py
@@ -26,6 +26,27 @@ def _chat_result(content: str | None = None, tool_calls=None) -> ChatResult:
     )
 
 
+def _chat_stream(*items):
+    """Return a callable mimicking llm.chat_stream: an async generator over
+    `items` (str deltas, then a terminal ChatResult)."""
+    async def gen(messages, *, tools=None, generation_config=None):
+        for it in items:
+            yield it
+    return gen
+
+
+async def _drain_reason_stream(agen):
+    """Split reason_stream output into (text deltas, terminal Decision)."""
+    deltas: list[str] = []
+    decision = None
+    async for item in agen:
+        if isinstance(item, Decision):
+            decision = item
+        else:
+            deltas.append(item)
+    return deltas, decision
+
+
 class TestReasoner:
     """Tests for Reasoner."""
 
@@ -369,6 +390,135 @@ class TestReasonerEdgeCases:
         assert len(decision.tool_calls) == 2
 
 
+class TestReasonerStream:
+    """Tests for Reasoner.reason_stream (streaming variant of reason)."""
+
+    @pytest.fixture
+    def mock_llm_client(self):
+        client = MagicMock()
+        client.chat_stream = MagicMock()
+        return client
+
+    @pytest.fixture
+    def reasoner(self, mock_llm_client):
+        return Reasoner(
+            llm_client=mock_llm_client,
+            tool_registry=MagicMock(),
+            system_prompt="You are a helpful assistant.",
+        )
+
+    @pytest.mark.asyncio
+    async def test_yields_deltas_then_respond_decision(self, reasoner, mock_llm_client):
+        """Text deltas are yielded in order, then a RESPOND Decision built from
+        the assembled ChatResult."""
+        mock_llm_client.chat_stream = _chat_stream(
+            "Hello", " world", _chat_result(content="Hello world", tool_calls=[]),
+        )
+
+        deltas, decision = await _drain_reason_stream(
+            reasoner.reason_stream(Context(session_id=uuid4()))
+        )
+
+        assert deltas == ["Hello", " world"]
+        assert decision is not None
+        assert decision.decision_type == DecisionType.RESPOND
+        assert decision.text == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_tool_call_turn_yields_no_deltas(self, reasoner, mock_llm_client):
+        """A tool-call turn carries no assistant text: no str deltas, only the
+        final EXECUTE_TOOLS Decision."""
+        from cortex.tools.interfaces import ToolCall
+
+        tc = ToolCall(id="call_1", name="file_read", arguments={"path": "/x"})
+        mock_llm_client.chat_stream = _chat_stream(
+            _chat_result(content=None, tool_calls=[tc]),
+        )
+
+        deltas, decision = await _drain_reason_stream(
+            reasoner.reason_stream(Context(session_id=uuid4()))
+        )
+
+        assert deltas == []
+        assert decision.decision_type == DecisionType.EXECUTE_TOOLS
+        assert decision.tool_calls[0] is tc
+
+    @pytest.mark.asyncio
+    async def test_streamed_text_with_marker_like_content_is_plain_respond(
+        self, reasoner, mock_llm_client
+    ):
+        """[QUESTION] markers are obsolete: text that happens to contain them
+        streams verbatim and yields a plain RESPOND (clarification is a tool)."""
+        mock_llm_client.chat_stream = _chat_stream(
+            "[QUESTION]", "Quale budget?", "[/QUESTION]",
+            _chat_result(content="[QUESTION]Quale budget?[/QUESTION]", tool_calls=[]),
+        )
+
+        deltas, decision = await _drain_reason_stream(
+            reasoner.reason_stream(Context(session_id=uuid4()))
+        )
+
+        assert "".join(deltas) == "[QUESTION]Quale budget?[/QUESTION]"
+        assert decision.decision_type == DecisionType.RESPOND
+        assert decision.text == "[QUESTION]Quale budget?[/QUESTION]"
+
+    @pytest.mark.asyncio
+    async def test_stream_without_final_result_yields_error_decision(
+        self, reasoner, mock_llm_client
+    ):
+        """If the stream ends without a terminal ChatResult, reason_stream does
+        not raise — it yields a fallback RESPOND Decision after the deltas."""
+        mock_llm_client.chat_stream = _chat_stream("partial")  # no ChatResult
+
+        deltas, decision = await _drain_reason_stream(
+            reasoner.reason_stream(Context(session_id=uuid4()))
+        )
+
+        assert deltas == ["partial"]
+        assert decision.decision_type == DecisionType.RESPOND
+        assert "try again" in decision.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_stream_error_yields_error_decision(self, reasoner, mock_llm_client):
+        """An exception raised while streaming is caught and surfaced as a
+        fallback RESPOND Decision, mirroring reason()'s error handling."""
+        async def boom(messages, *, tools=None, generation_config=None):
+            raise RuntimeError("stream exploded")
+            yield  # pragma: no cover - marks this a generator
+
+        mock_llm_client.chat_stream = boom
+
+        deltas, decision = await _drain_reason_stream(
+            reasoner.reason_stream(Context(session_id=uuid4()))
+        )
+
+        assert deltas == []
+        assert decision.decision_type == DecisionType.RESPOND
+        assert "try again" in decision.text.lower()
+
+    @pytest.mark.asyncio
+    async def test_stream_passes_tools_via_structured_argument(self, reasoner, mock_llm_client):
+        """Tools are advertised via llm.chat_stream(tools=...), same as reason()."""
+        from cortex.tools.interfaces import ToolDefinition
+
+        mock_llm_client.chat_stream = MagicMock(
+            side_effect=_chat_stream(_chat_result(content="ok", tool_calls=[]))
+        )
+        tool_def = ToolDefinition(
+            name="file_read",
+            description="Read a file",
+            input_schema={"type": "object", "properties": {}},
+        )
+        context = Context(session_id=uuid4(), tools=[tool_def])
+
+        await _drain_reason_stream(reasoner.reason_stream(context))
+
+        call_kwargs = mock_llm_client.chat_stream.call_args.kwargs
+        assert call_kwargs.get("tools") is not None
+        assert len(call_kwargs["tools"]) == 1
+        assert call_kwargs["tools"][0].name == "file_read"
+
+
 class TestReasonerParseResponse:
     """Tests for Reasoner._parse_response parsing rules (issues #24, #25)."""
 
@@ -414,57 +564,34 @@ class TestReasonerParseResponse:
         source = inspect.getsource(Reasoner._parse_response)
         assert "getattr(" not in source
 
-    def test_question_marker_routes_to_ask_question(self, reasoner, context):
-        """[QUESTION] marker routes to Decision.ask_question (#25)."""
-        result = _chat_result("What budget? [QUESTION]Quale budget?[/QUESTION]")
-
-        decision = reasoner._parse_response(result, context)
-
-        assert decision.decision_type == DecisionType.ASK_QUESTION
-        assert decision.text == "Quale budget?"
-
-    def test_multiline_question_captured_fully_and_stripped(self, reasoner, context):
-        """Multi-line questions inside markers are captured fully and stripped (#25)."""
-        result = _chat_result("[QUESTION]\nWhat budget\nshould we use?\n[/QUESTION]")
-
-        decision = reasoner._parse_response(result, context)
-
-        assert decision.decision_type == DecisionType.ASK_QUESTION
-        assert decision.text == "What budget\nshould we use?"
-
-    def test_tool_calls_take_priority_over_question_marker(self, reasoner, context):
-        """Tool calls win over [QUESTION] markers (#25, note 3)."""
+    def test_tool_calls_take_priority_over_content(self, reasoner, context):
+        """Tool calls win over any assistant content."""
         from cortex.tools.interfaces import ToolCall
 
         tool_call = ToolCall(id="call-1", name="file_read", arguments={"path": "/x"})
-        result = _chat_result(
-            content="[QUESTION]Should I?[/QUESTION]",
-            tool_calls=[tool_call],
-        )
+        result = _chat_result(content="Some text", tool_calls=[tool_call])
 
         decision = reasoner._parse_response(result, context)
 
         assert decision.decision_type == DecisionType.EXECUTE_TOOLS
 
-    def test_empty_question_marker_raises_value_error(self, reasoner, context):
-        """[QUESTION][/QUESTION] with no question raises ValueError (#25)."""
-        result = _chat_result("[QUESTION][/QUESTION]")
+    def test_question_markers_are_no_longer_parsed(self, reasoner, context):
+        """[QUESTION] markers are obsolete: text that contains them is a plain
+        RESPOND now (clarification goes through the ask_user tool)."""
+        result = _chat_result("[QUESTION]Quale budget?[/QUESTION]")
 
-        with pytest.raises(ValueError, match="LLM signaled clarification with no question"):
-            reasoner._parse_response(result, context)
+        decision = reasoner._parse_response(result, context)
 
-    def test_whitespace_only_question_marker_raises_value_error(self, reasoner, context):
-        """Whitespace-only [QUESTION] marker raises ValueError (#25)."""
-        result = _chat_result("[QUESTION]   [/QUESTION]")
+        assert decision.decision_type == DecisionType.RESPOND
+        assert decision.text == "[QUESTION]Quale budget?[/QUESTION]"
 
-        with pytest.raises(ValueError, match="LLM signaled clarification with no question"):
-            reasoner._parse_response(result, context)
-
-    def test_default_system_prompt_includes_question_convention(self):
-        """Default system prompt teaches the [QUESTION] convention (#25)."""
+    def test_default_system_prompt_points_to_ask_user_tool(self):
+        """The default prompt steers clarification to the ask_user tool and no
+        longer teaches the old [QUESTION] marker convention."""
         reasoner = Reasoner(
             llm_client=MagicMock(),
             tool_registry=MagicMock(),
         )
 
-        assert "[QUESTION]your question here[/QUESTION]" in reasoner._system_prompt
+        assert "ask_user" in reasoner._system_prompt
+        assert "[QUESTION]" not in reasoner._system_prompt

--- a/tests/unit/agentic/test_usage_flow.py
+++ b/tests/unit/agentic/test_usage_flow.py
@@ -76,18 +76,6 @@ class TestReasonerThreadsUsage:
         )
 
     @pytest.mark.asyncio
-    async def test_respond_decision_carries_usage(self, reasoner, client):
-        client.chat = AsyncMock(return_value=_chat_result(
-            content="Here is the answer.",
-            usage=UsageStats(prompt_tokens=5, completion_tokens=1, total_tokens=6),
-        ))
-        decision = await reasoner.reason(Context(session_id=uuid4()))
-        assert decision.decision_type == DecisionType.RESPOND
-        assert decision.usage == UsageStats(
-            prompt_tokens=5, completion_tokens=1, total_tokens=6
-        )
-
-    @pytest.mark.asyncio
     async def test_missing_usage_yields_none(self, reasoner, client):
         client.chat = AsyncMock(return_value=_chat_result(content="ok", usage=None))
         decision = await reasoner.reason(Context(session_id=uuid4()))

--- a/tests/unit/agentic/test_usage_flow.py
+++ b/tests/unit/agentic/test_usage_flow.py
@@ -76,13 +76,13 @@ class TestReasonerThreadsUsage:
         )
 
     @pytest.mark.asyncio
-    async def test_ask_question_decision_carries_usage(self, reasoner, client):
+    async def test_respond_decision_carries_usage(self, reasoner, client):
         client.chat = AsyncMock(return_value=_chat_result(
-            content="[QUESTION]Which file?[/QUESTION]",
+            content="Here is the answer.",
             usage=UsageStats(prompt_tokens=5, completion_tokens=1, total_tokens=6),
         ))
         decision = await reasoner.reason(Context(session_id=uuid4()))
-        assert decision.decision_type == DecisionType.ASK_QUESTION
+        assert decision.decision_type == DecisionType.RESPOND
         assert decision.usage == UsageStats(
             prompt_tokens=5, completion_tokens=1, total_tokens=6
         )
@@ -153,19 +153,6 @@ class TestLoopStreamsUsage:
         done = events[-1]
         assert done.usage == UsageStats(
             prompt_tokens=110, completion_tokens=55, total_tokens=165
-        )
-
-    @pytest.mark.asyncio
-    async def test_ask_question_done_event_carries_usage(self):
-        loop, _cb, reasoner, _ex = self._loop()
-        reasoner.reason = AsyncMock(return_value=Decision.ask_question(
-            "Which?",
-            usage=UsageStats(prompt_tokens=4, completion_tokens=2, total_tokens=6),
-        ))
-        events = [e async for e in loop.stream_chat(uuid4(), "Hmm")]
-        done = events[-1]
-        assert done.usage == UsageStats(
-            prompt_tokens=4, completion_tokens=2, total_tokens=6
         )
 
     @pytest.mark.asyncio

--- a/tests/unit/api/test_chat_stream.py
+++ b/tests/unit/api/test_chat_stream.py
@@ -15,6 +15,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from cortex.agentic.events import (
+    AskUserEvent,
     ErrorEvent,
     ResponseDoneEvent,
     TextDeltaEvent,
@@ -59,7 +60,7 @@ class FakeExecutionModule:
     ):
         self._events = events or []
         self._exc = exc
-        self.calls: list[tuple[UUID, str, int | None]] = []
+        self.calls: list[tuple[UUID, str, int | None, bool]] = []
 
     async def stream_chat(
         self,
@@ -67,8 +68,9 @@ class FakeExecutionModule:
         user_message: str,
         *,
         max_iterations: int | None = None,
+        stream: bool = False,
     ):
-        self.calls.append((session_id, user_message, max_iterations))
+        self.calls.append((session_id, user_message, max_iterations, stream))
         if self._exc is not None:
             raise self._exc
         for event in self._events:
@@ -150,7 +152,40 @@ class TestChatStreamSSE:
             ("text", {"delta": "Hello there!"}),
             ("done", {"final_message": "Hello there!", "tool_calls": [], "iterations": 1}),
         ]
-        assert fake_exec.calls == [(session_id, "hi", 20)]
+        assert fake_exec.calls == [(session_id, "hi", 20, True)]
+
+    def test_stream_flag_defaults_true_and_honors_false(self):
+        """The `stream` flag reaches execution_module.stream_chat: defaults to
+        True, and a request setting it False is forwarded as False."""
+        session_id = uuid4()
+
+        # Default (omitted) -> True
+        fake_default = FakeExecutionModule([
+            ResponseDoneEvent(session_id=session_id, message="ok", tools_used=[], iterations=0),
+        ])
+        client = build_client(
+            fake_default, FakeInteractionService(existing_session=Session(id=session_id))
+        )
+        client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+        assert fake_default.calls[0][3] is True
+
+        # Explicit stream=False -> False
+        fake_off = FakeExecutionModule([
+            ResponseDoneEvent(session_id=session_id, message="ok", tools_used=[], iterations=0),
+        ])
+        client = build_client(
+            fake_off, FakeInteractionService(existing_session=Session(id=session_id))
+        )
+        client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(session_id), "stream": False},
+            headers=AUTH_HEADERS,
+        )
+        assert fake_off.calls[0][3] is False
 
     def test_multiple_text_deltas_yield_one_frame_each_in_order(self):
         """Two TextDeltaEvents produce two text frames in order — text
@@ -180,6 +215,67 @@ class TestChatStreamSSE:
             ("text", {"delta": "world!"}),
             ("done", {"final_message": "Hello world!", "tool_calls": [], "iterations": 1}),
         ]
+
+    def test_ask_user_frame_carries_question_and_options(self):
+        """An AskUserEvent maps to an `ask_user` frame with question + options,
+        followed by the terminal `done` frame."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            ThinkingEvent(session_id=session_id, message="Need info."),
+            AskUserEvent(
+                session_id=session_id,
+                question="Which file did you mean?",
+                options=["a.txt", "b.txt"],
+            ),
+            ResponseDoneEvent(
+                session_id=session_id,
+                message="Which file did you mean?",
+                tools_used=[],
+                iterations=0,
+            ),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "open the file", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        assert parse_sse(response.text) == [
+            ("thinking", {"message": "Need info."}),
+            ("ask_user", {
+                "question": "Which file did you mean?",
+                "options": ["a.txt", "b.txt"],
+            }),
+            ("done", {
+                "final_message": "Which file did you mean?",
+                "tool_calls": [],
+                "iterations": 0,
+            }),
+        ]
+
+    def test_ask_user_frame_options_default_empty(self):
+        """An ask_user with no options serializes options as an empty list."""
+        session_id = uuid4()
+        fake_exec = FakeExecutionModule([
+            AskUserEvent(session_id=session_id, question="A or B?"),
+            ResponseDoneEvent(
+                session_id=session_id, message="A or B?", tools_used=[], iterations=0
+            ),
+        ])
+        fake_interaction = FakeInteractionService(existing_session=Session(id=session_id))
+        client = build_client(fake_exec, fake_interaction)
+
+        response = client.post(
+            "/chat/stream",
+            json={"message": "pick", "session_id": str(session_id)},
+            headers=AUTH_HEADERS,
+        )
+
+        frames = parse_sse(response.text)
+        assert frames[0] == ("ask_user", {"question": "A or B?", "options": []})
 
     def test_tool_round_interleaves_start_done_pairs(self):
         """ToolStartEvent/ToolResultEvent interleave as paired frames carrying

--- a/tests/unit/execution/test_module.py
+++ b/tests/unit/execution/test_module.py
@@ -378,7 +378,7 @@ class TestExecutionModuleStreamChat:
         ]
 
         class FakeLoop:
-            calls: list[tuple[UUID, str, int | None]] = []
+            calls: list[tuple[UUID, str, int | None, bool]] = []
 
             async def stream_chat(
                 self,
@@ -386,8 +386,9 @@ class TestExecutionModuleStreamChat:
                 user_message: str,
                 *,
                 max_iterations: int | None = None,
+                stream: bool = False,
             ):
-                FakeLoop.calls.append((session_id, user_message, max_iterations))
+                FakeLoop.calls.append((session_id, user_message, max_iterations, stream))
                 for event in scripted:
                     yield event
 
@@ -396,7 +397,34 @@ class TestExecutionModuleStreamChat:
         seen = [event async for event in module.stream_chat(session_id, "hello")]
 
         assert seen == scripted
-        assert FakeLoop.calls == [(session_id, "hello", None)]
+        assert FakeLoop.calls == [(session_id, "hello", None, False)]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_forwards_stream_flag_to_loop(self):
+        """The `stream` flag is passed through to the agent loop unchanged."""
+        session_id = uuid4()
+
+        class FakeLoop:
+            calls: list[bool] = []
+
+            async def stream_chat(
+                self,
+                session_id: UUID,
+                user_message: str,
+                *,
+                max_iterations: int | None = None,
+                stream: bool = False,
+            ):
+                FakeLoop.calls.append(stream)
+                if False:
+                    yield  # make this an async generator
+
+        module = ExecutionModule(agent_loop=FakeLoop())
+
+        _ = [e async for e in module.stream_chat(session_id, "hi", stream=True)]
+        _ = [e async for e in module.stream_chat(session_id, "hi", stream=False)]
+
+        assert FakeLoop.calls == [True, False]
 
     @pytest.mark.asyncio
     async def test_stream_chat_reraises_max_iterations_after_error_event(self):
@@ -412,6 +440,7 @@ class TestExecutionModuleStreamChat:
                 user_message: str,
                 *,
                 max_iterations: int | None = None,
+                stream: bool = False,
             ):
                 yield ErrorEvent(
                     session_id=session_id,

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -16,7 +16,6 @@ from cortex.llm import (
 from cortex.llm.models import ChatResult
 from cortex.llm.providers import OpenAIClient
 
-
 # -- Streaming test helpers: mimic OpenAI ChatCompletionChunk shapes ----------
 
 

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -1,5 +1,6 @@
 """Tests for the LLM Client."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,7 +13,55 @@ from cortex.llm import (
     ToolCall,
     ToolDefinition,
 )
+from cortex.llm.models import ChatResult
 from cortex.llm.providers import OpenAIClient
+
+
+# -- Streaming test helpers: mimic OpenAI ChatCompletionChunk shapes ----------
+
+
+def _usage(prompt, completion, total):
+    return SimpleNamespace(
+        prompt_tokens=prompt, completion_tokens=completion, total_tokens=total
+    )
+
+
+def _tc(index, id=None, name=None, args=None):
+    """A streaming tool-call fragment."""
+    return SimpleNamespace(
+        index=index, id=id, function=SimpleNamespace(name=name, arguments=args)
+    )
+
+
+def _chunk(
+    content=None, tool_calls=None, finish=None, usage=None, model="MiniMax-M3",
+    reasoning=None,
+):
+    """A ChatCompletionChunk; usage-only chunks carry no choices. `reasoning`
+    populates the out-of-band `reasoning_content` field on the delta."""
+    if (
+        content is None and tool_calls is None and finish is None
+        and reasoning is None and usage is not None
+    ):
+        choices = []
+    else:
+        delta = SimpleNamespace(
+            content=content, tool_calls=tool_calls, reasoning_content=reasoning
+        )
+        choices = [SimpleNamespace(delta=delta, finish_reason=finish)]
+    return SimpleNamespace(model=model, usage=usage, choices=choices)
+
+
+async def _drain_stream(agen):
+    """Collect str deltas and the terminal ChatResult from chat_stream()."""
+    deltas = []
+    final = None
+    async for item in agen:
+        if isinstance(item, ChatResult):
+            final = item
+        else:
+            deltas.append(item)
+    return deltas, final
 
 
 class TestChatMessage:
@@ -191,6 +240,139 @@ class TestOpenAIClient:
             "function": {"name": "shell", "arguments": json.dumps({"command": "echo hi"})},
         }]
         assert "content" not in assistant_msg  # falsy content omitted for tool-call turns
+
+    async def test_chat_stream_text_only(self):
+        """Text deltas are yielded in order, then a final ChatResult with the
+        joined content and stream usage."""
+        from unittest.mock import AsyncMock, patch
+
+        client = OpenAIClient(api_key="test", model="MiniMax-M3")
+
+        async def fake_stream():
+            yield _chunk(content="Ciao ")
+            yield _chunk(content="mondo", finish="stop")
+            yield _chunk(usage=_usage(4, 2, 6))  # usage-only final chunk, no choices
+
+        with patch.object(
+            client._client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=fake_stream()),
+        ):
+            deltas, final = await _drain_stream(
+                client.chat_stream([ChatMessage(role=Role.USER, content="hi")])
+            )
+
+        assert deltas == ["Ciao ", "mondo"]
+        assert final.message.content == "Ciao mondo"
+        assert final.tool_calls is None
+        assert final.finish_reason == "stop"
+        assert final.usage.total_tokens == 6
+
+    async def test_chat_stream_assembles_fragmented_tool_call(self):
+        """Tool-call fragments spread across chunks (by index) are re-assembled
+        into a single internal ToolCall with parsed arguments."""
+        from unittest.mock import AsyncMock, patch
+
+        client = OpenAIClient(api_key="test", model="MiniMax-M3")
+
+        async def fake_stream():
+            yield _chunk(tool_calls=[_tc(0, id="call_1", name="get_", args='{"a"')])
+            yield _chunk(tool_calls=[_tc(0, args=":1}")])
+            yield _chunk(finish="tool_calls")
+
+        with patch.object(
+            client._client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=fake_stream()),
+        ):
+            deltas, final = await _drain_stream(
+                client.chat_stream([ChatMessage(role=Role.USER, content="hi")])
+            )
+
+        assert deltas == []  # no text deltas on a pure tool-call turn
+        assert final.message.content is None
+        assert final.tool_calls is not None
+        assert len(final.tool_calls) == 1
+        assert final.tool_calls[0].name == "get_"
+        assert final.tool_calls[0].arguments == {"a": 1}
+        assert final.finish_reason == "tool_calls"
+
+    async def test_chat_stream_wraps_out_of_band_reasoning_in_think_tags(self):
+        """Reasoning delivered via reasoning_content is normalized to an inline
+        <think>...</think> block: opened on the first reasoning token, closed
+        when the answer content starts."""
+        from unittest.mock import AsyncMock, patch
+
+        client = OpenAIClient(api_key="test", model="MiniMax-M3")
+
+        async def fake_stream():
+            yield _chunk(reasoning="Let me ")
+            yield _chunk(reasoning="think.")
+            yield _chunk(content="Hello ")
+            yield _chunk(content="world", finish="stop")
+
+        with patch.object(
+            client._client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=fake_stream()),
+        ):
+            deltas, final = await _drain_stream(
+                client.chat_stream([ChatMessage(role=Role.USER, content="hi")])
+            )
+
+        # <think> opens, reasoning streams, </think> closes before the answer.
+        assert deltas == ["<think>", "Let me ", "think.", "</think>", "Hello ", "world"]
+        assert final.message.content == "<think>Let me think.</think>Hello world"
+        assert final.finish_reason == "stop"
+
+    async def test_chat_stream_closes_think_when_reasoning_has_no_content(self):
+        """Reasoning followed by a tool call (no answer text) still yields a
+        balanced <think>...</think> block, closed at end of stream."""
+        from unittest.mock import AsyncMock, patch
+
+        client = OpenAIClient(api_key="test", model="MiniMax-M3")
+
+        async def fake_stream():
+            yield _chunk(reasoning="I should call a tool.")
+            yield _chunk(tool_calls=[_tc(0, id="call_1", name="search", args="{}")])
+            yield _chunk(finish="tool_calls")
+
+        with patch.object(
+            client._client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=fake_stream()),
+        ):
+            deltas, final = await _drain_stream(
+                client.chat_stream([ChatMessage(role=Role.USER, content="hi")])
+            )
+
+        assert deltas == ["<think>", "I should call a tool.", "</think>"]
+        assert final.message.content == "<think>I should call a tool.</think>"
+        assert final.tool_calls is not None
+        assert final.tool_calls[0].name == "search"
+
+    async def test_chat_stream_leaves_inline_think_untouched(self):
+        """A model that already emits inline <think> in content is passed
+        through verbatim — no double-wrapping."""
+        from unittest.mock import AsyncMock, patch
+
+        client = OpenAIClient(api_key="test", model="MiniMax-M3")
+
+        async def fake_stream():
+            yield _chunk(content="<think>inline</think>")
+            yield _chunk(content="Answer", finish="stop")
+
+        with patch.object(
+            client._client.chat.completions,
+            "create",
+            new=AsyncMock(return_value=fake_stream()),
+        ):
+            deltas, final = await _drain_stream(
+                client.chat_stream([ChatMessage(role=Role.USER, content="hi")])
+            )
+
+        assert deltas == ["<think>inline</think>", "Answer"]
+        assert final.message.content == "<think>inline</think>Answer"
 
 
 class TestLLMClientFactory:

--- a/tests/unit/test_tools_interfaces.py
+++ b/tests/unit/test_tools_interfaces.py
@@ -92,6 +92,22 @@ class TestToolResult:
         )
         assert result.error_severity == ToolErrorSeverity.WARNING
 
+    def test_control_defaults_to_none(self):
+        """Ordinary tool results carry no control signal."""
+        result = ToolResult(tool_call_id="call-123", tool_name="read", success=True)
+        assert result.control is None
+
+    def test_control_signal_can_be_set(self):
+        """A tool can flag a loop-interrupting control signal (e.g. ask_user)."""
+        result = ToolResult(
+            tool_call_id="call-123",
+            tool_name="ask_user",
+            success=True,
+            output="Which file?",
+            control="ask_user",
+        )
+        assert result.control == "ask_user"
+
 
 class TestToolDefinition:
     """Tests for ToolDefinition dataclass."""

--- a/tests/unit/test_tools_meta.py
+++ b/tests/unit/test_tools_meta.py
@@ -7,6 +7,7 @@ import tempfile
 import pytest
 
 from cortex.tools.meta import (
+    AskUserTool,
     FileReadTool,
     FileWriteTool,
     GrepTool,
@@ -22,6 +23,13 @@ class TestFileReadTool:
     @pytest.fixture
     def tool(self):
         return FileReadTool()
+
+    def test_schema_property_names_have_no_whitespace(self, tool):
+        """Schema keys must match the names execute() reads — a stray space
+        (e.g. ' max_lines') would silently break the argument (regression)."""
+        for name in tool.input_schema["properties"]:
+            assert name == name.strip(), f"schema key has whitespace: {name!r}"
+        assert "max_lines" in tool.input_schema["properties"]
 
     @pytest.mark.asyncio
     async def test_read_file(self, tool):
@@ -272,6 +280,49 @@ class TestGrepTool:
             assert result.metadata["files_searched"] == 1
 
 
+class TestAskUserTool:
+    """Tests for AskUserTool."""
+
+    @pytest.fixture
+    def tool(self):
+        return AskUserTool()
+
+    def test_schema_requires_question_and_allows_options(self, tool):
+        schema = tool.input_schema
+        assert schema["required"] == ["question"]
+        assert schema["properties"]["options"]["type"] == "array"
+
+    @pytest.mark.asyncio
+    async def test_returns_control_signal_and_question(self, tool):
+        """A valid call returns success with control='ask_user' and the
+        question echoed as output."""
+        result = await tool.execute({"question": "Which file did you mean?"})
+
+        assert result.success is True
+        assert result.control == "ask_user"
+        assert result.output == "Which file did you mean?"
+        assert result.metadata["options"] == []
+
+    @pytest.mark.asyncio
+    async def test_normalizes_options(self, tool):
+        """Options are carried in metadata; blanks/non-strings are dropped."""
+        result = await tool.execute({
+            "question": "Pick one",
+            "options": ["a.txt", "", "b.txt", None, 42],
+        })
+
+        assert result.metadata["options"] == ["a.txt", "b.txt"]
+
+    @pytest.mark.asyncio
+    async def test_empty_question_fails_without_control(self, tool):
+        """A blank question is an error and carries no control signal."""
+        result = await tool.execute({"question": "   "})
+
+        assert result.success is False
+        assert result.control is None
+        assert "question" in result.error
+
+
 class TestRegisterMetaTools:
     """Tests for registering meta tools."""
 
@@ -280,11 +331,12 @@ class TestRegisterMetaTools:
         registry = InMemoryToolRegistry()
         registered = register_meta_tools(registry)
 
-        assert len(registered) == 4
+        assert len(registered) == 5
         assert "file_read" in registered
         assert "file_write" in registered
         assert "shell" in registered
         assert "grep" in registered
+        assert "ask_user" in registered
 
     def test_all_tools_work(self):
         """All registered meta tools execute successfully."""
@@ -292,8 +344,8 @@ class TestRegisterMetaTools:
         register_meta_tools(registry)
 
         tools = registry.list_all()
-        assert len(tools) == 4
+        assert len(tools) == 5
 
         # Check all can be retrieved
-        for name in ["file_read", "file_write", "shell", "grep"]:
+        for name in ["file_read", "file_write", "shell", "grep", "ask_user"]:
             assert registry.get(name) is not None


### PR DESCRIPTION
Stream responses token-by-token end-to-end and replace the fragile [QUESTION] text-marker clarification path with a structured ask_user tool.

Streaming:
- OpenAIClient.chat_stream() streams deltas and reassembles a ChatResult; out-of-band reasoning (reasoning_content) is normalized to inline <think>
- LLMClient.chat_stream contract + circuit-breaker passthrough
- Reasoner.reason_stream(), AgentLoop.stream_chat(stream=...), wired through the execution module to the SSE route (ChatRequest.stream, default on)

ask_user tool (replaces [QUESTION] markers):
- AskUserTool returns ToolResult.control="ask_user" with optional options
- loop halts on the control signal (B2): persists the question as a plain assistant message, no dangling tool_call; ask_user excluded from tools_used
- new AskUserEvent -> SSE ask_user frame {question, options}
- reasoner marker parsing + QUESTION_PATTERN removed; prompt points to ask_user
- dead DecisionType.ASK_QUESTION / Decision.ask_question machinery removed

UI (index.html):
- text runs and tool output interleave in DOM order (lazy text bubbles)
- tool output shown by default; per-segment reasoning toggle
- ask_user renders the question with clickable option buttons

Fixes:
- file_read schema key " max_lines" -> "max_lines" (stray leading space)

Docker: mount static/ as a volume so UI changes need no rebuild.

Tests: streaming, ask_user (tool/loop/SSE), reasoner cleanup, eval golden migrated to ask_user + manifest prompt hash bumped. Full suite green (924).