### PR TITLE
feat(trace): capture loop events pseudonymized via rizzo-pii (#112)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ LLM_API_KEY=your-api-key-here
 LLM_MODEL=deepseek-v4-flash
 LLM_JUDGE_MODEL=deepseek-v4-pro
 
+# Trace capture (rizzo-pii sidecar)
+TRACE_SIDECAR_URL=http://127.0.0.1:5005
+TRACE_SIDECAR_TIMEOUT_S=10.0
+
 # MQTT Broker
 MQTT_BROKER_URL=mqtt://localhost:1883
 

--- a/config.yaml
+++ b/config.yaml
@@ -14,6 +14,12 @@ llm:
   model: "deepseek-v4-flash"
   timeout: 60
 
+trace:
+  # Local rizzo-pii instance used to pseudonymize captured traces
+  # (docker compose --profile trace)
+  sidecar_url: "http://127.0.0.1:5005"
+  sidecar_timeout_s: 10.0
+
 mqtt:
   broker_url: "mqtt://localhost:1883"
   keepalive: 60

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,36 @@ services:
       retries: 3
       start_period: 30s
 
+  # rizzo-pii pseudonymization sidecar (issue #112 T2) — trace capture only.
+  # Loop-trace capture pseudonymizes PII before storing loop_events, so traced
+  # sessions need this sidecar reachable at the configured TRACE_SIDECAR_URL
+  # (default http://127.0.0.1:5005). Opt-in via the "trace" compose profile so
+  # the default `docker compose up` is unaffected:
+  #
+  #   docker compose --profile trace up -d rizzo-pii
+  #   curl http://127.0.0.1:5005/health     # 200 = model ready (503 until then)
+  #
+  # Built from the pinned upstream repo (Rizzo-AI-Academy/rizzo-pii @ v2.0.0):
+  # the image bakes the CPU-only model at build time and serves POST /analyze;
+  # the client always sends include_mapping=false, so real values never leave
+  # the sidecar. Run cortex on the host (or point TRACE_SIDECAR_URL at this
+  # service) to verify trace capture end to end.
+  rizzo-pii:
+    profiles: ["trace"]
+    build:
+      context: https://github.com/Rizzo-AI-Academy/rizzo-pii.git#v2.0.0
+    container_name: cortex-rizzo-pii
+    ports:
+      - "127.0.0.1:5005:5005"
+    healthcheck:
+      # Same readiness probe as the upstream image: /health is 503 until the
+      # model is loaded (model load can take 1-2 minutes on CPU).
+      test: ["CMD", "python", "-c", 'import urllib.request, sys; sys.exit(0 if urllib.request.urlopen("http://127.0.0.1:5005/health", timeout=4).status == 200 else 1)']
+      interval: 30s
+      timeout: 5s
+      start_period: 120s
+      retries: 3
+
 volumes:
   postgres_data:
   mosquitto_data:

--- a/src/cortex/api/routes/chat.py
+++ b/src/cortex/api/routes/chat.py
@@ -151,6 +151,9 @@ async def chat_stream(
                 user_message=request.message,
                 max_iterations=max_iterations,
                 stream=request.stream,
+                # The session is resolved before the stream starts; its opt-in
+                # trace flag gates loop-event capture for this turn (#112 T2).
+                trace_enabled=session.trace_enabled,
             ):
                 match event:
                     case ThinkingEvent():

--- a/src/cortex/config/loader.py
+++ b/src/cortex/config/loader.py
@@ -120,6 +120,7 @@ def load_settings(config_path: Path | None = None) -> Settings:
         "llm": {},
         "mqtt": {},
         "app": {},
+        "trace": {},
         "log_level": None,
         "log_format": None,
         "log_include_trace_id": None,
@@ -171,6 +172,13 @@ def load_settings(config_path: Path | None = None) -> Settings:
             settings_data["app_reload"] = app["reload"]
         if "workers" in app:
             settings_data["app_workers"] = app["workers"]
+
+    if "trace" in yaml_config:
+        trace = yaml_config["trace"]
+        if "sidecar_url" in trace:
+            settings_data["trace_sidecar_url"] = trace["sidecar_url"]
+        if "sidecar_timeout_s" in trace:
+            settings_data["trace_sidecar_timeout_s"] = trace["sidecar_timeout_s"]
 
     if "logging" in yaml_config:
         log = yaml_config["logging"]

--- a/src/cortex/config/models.py
+++ b/src/cortex/config/models.py
@@ -119,6 +119,20 @@ class Settings(BaseSettings):
     app_reload: bool = Field(default=False)
     app_workers: int = Field(default=1, ge=1)
 
+    # ─── Trace capture ─────────────────────────────────────────
+    # Local rizzo-pii pseudonymization sidecar for loop-trace capture (issue
+    # #112 T2). Flat, env-overridable (TRACE_SIDECAR_URL / TRACE_SIDECAR_TIMEOUT_S)
+    # like LLM_PRICING. Capture fails closed when the sidecar is unreachable.
+    trace_sidecar_url: str = Field(
+        default="http://127.0.0.1:5005",
+        description="Base URL of the rizzo-pii pseudonymization sidecar",
+    )
+    trace_sidecar_timeout_s: float = Field(
+        default=10.0,
+        gt=0,
+        description="Per-request timeout in seconds for sidecar /analyze calls",
+    )
+
     # ─── Logging ──────────────────────────────────────────────
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
         default="INFO"

--- a/src/cortex/execution/module.py
+++ b/src/cortex/execution/module.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, AsyncIterable
 from typing import TYPE_CHECKING, Any
 from uuid import UUID, uuid4
 
@@ -23,6 +23,7 @@ from cortex.goals.interfaces import GoalRepository
 if TYPE_CHECKING:
     from cortex.agentic.events import LoopEvent
     from cortex.events import EventBus
+    from cortex.trace.recorder import TraceRecorder
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +57,7 @@ class ExecutionModule:
         agent_loop: AgentLoop,
         event_bus: EventBus | None = None,
         goal_repository: GoalRepository | None = None,
+        trace_recorder: TraceRecorder | None = None,
     ):
         # Imported lazily so importers of execution.module do not pull in
         # the in-memory implementation (and its asyncpg dependency chain)
@@ -67,6 +69,11 @@ class ExecutionModule:
         self._emitter = EventEmitter(event_bus, source_module="execution_module")
         self._goal_repository = goal_repository or InMemoryGoalRepository()
         self._goal_results: dict[UUID, GoalResult] = {}
+        # Trace capture (issue #112 T2): the recorder is injected by the
+        # composition root (src/cortex/main.py) — the module never constructs
+        # trace machinery itself. None means capture is disabled even when a
+        # session's trace flag is on.
+        self._trace_recorder = trace_recorder
         # Strong references to background goal tasks so they are never
         # garbage-collected before running (the dropped-task anti-pattern);
         # each task removes itself once it finishes.
@@ -109,6 +116,7 @@ class ExecutionModule:
         *,
         max_iterations: int | None = None,
         stream: bool = False,
+        trace_enabled: bool = False,
     ) -> AsyncGenerator[LoopEvent, None]:
         """
         Stream chat progress events as a transparent passthrough.
@@ -118,23 +126,44 @@ class ExecutionModule:
         contract: ``MaxIterationsError`` (and any other exception) is NOT
         swallowed, unlike ``run_chat()``'s fallback.
 
+        When ``trace_enabled`` (the resolved session opted into loop-trace
+        capture, issue #111/#112) AND a ``trace_recorder`` was injected at the
+        composition root, each yielded event is handed to the TraceRecorder:
+        PII-bearing fields are pseudonymized via the rizzo-pii sidecar and the
+        event is persisted to ``loop_events`` in seq order before being
+        yielded. Capture is fail-closed — pseudonymizer or persistence
+        failures never alter or interrupt the stream delivered to the caller.
+        Without an injected recorder, trace-enabled turns run untraced (pure
+        passthrough); untraced sessions always persist nothing.
+
         Args:
             session_id: Current session
             user_message: User's message
             max_iterations: Optional iteration limit
             stream: When True, the response text is emitted token-by-token
                 (one TextDeltaEvent per delta); forwarded to the agent loop.
+            trace_enabled: Forwarded from the resolved session; gates trace
+                capture for this turn (capture additionally requires an
+                injected recorder). Goal-mode and drain paths are out of
+                scope in v1.
 
         Yields:
             LoopEvent progress signals (thinking, tool_start, tool_done,
             text, done, error).
         """
-        async for event in self._agent_loop.stream_chat(
+        loop_stream: AsyncIterable[LoopEvent] = self._agent_loop.stream_chat(
             session_id=session_id,
             user_message=user_message,
             max_iterations=max_iterations,
             stream=stream,
-        ):
+        )
+        recorder = self._trace_recorder
+        events: AsyncIterable[LoopEvent] = (
+            recorder.capture(session_id, loop_stream)
+            if trace_enabled and recorder is not None
+            else loop_stream
+        )
+        async for event in events:
             yield event
 
     async def create_goal(

--- a/src/cortex/main.py
+++ b/src/cortex/main.py
@@ -155,6 +155,22 @@ async def initialize_app() -> CortexApp:
 
     goal_repo: GoalRepository = PostgresGoalRepository()
 
+    # 5b'. Create the loop-trace recorder (issue #112 T2). It is injected here
+    # at the composition root — ExecutionModule never constructs trace
+    # machinery itself. Recorder/HTTP-client ctors do no I/O, so wiring this
+    # adds no startup dependency on the rizzo-pii sidecar.
+    from cortex.trace.pseudonymizer import RizzoPseudonymizer
+    from cortex.trace.recorder import TraceRecorder
+    from cortex.trace.repository import PostgresTraceRepository
+
+    trace_recorder = TraceRecorder(
+        repository=PostgresTraceRepository(),
+        pseudonymizer=RizzoPseudonymizer(
+            base_url=settings.trace_sidecar_url,
+            timeout=settings.trace_sidecar_timeout_s,
+        ),
+    )
+
     # 5c. Create memory repositories
     from cortex.memory.interfaces import ConceptRepository, FactRepository
     from cortex.memory.repository import PostgresConceptRepository, PostgresFactRepository
@@ -237,6 +253,7 @@ async def initialize_app() -> CortexApp:
         agent_loop=agent_loop,
         event_bus=cortex.event_bus,
         goal_repository=goal_repo,
+        trace_recorder=trace_recorder,
     )
 
     # Resume goals left running at a previous shutdown. Startup concern —

--- a/src/cortex/trace/__init__.py
+++ b/src/cortex/trace/__init__.py
@@ -1,9 +1,10 @@
 """Cortex Trace Module.
 
-Persistence layer for loop-trace capture (issue #111 T1): the opt-in
-``trace_enabled`` session flag plus the ``loop_events`` store behind
-TraceRepository. Capture wiring (turning AgentLoop events into inserts)
-lands in a later ticket.
+Persistence layer for loop-trace capture: the opt-in ``trace_enabled`` session
+flag plus the ``loop_events`` store behind TraceRepository (issue #111 T1),
+and the T2 capture machinery — TraceRecorder (a consumer of the LoopEvent
+stream that pseudonymizes PII-bearing fields before storage) behind the
+Pseudonymizer interface with the local rizzo-pii HTTP implementation.
 """
 
 from cortex.trace.interfaces import TraceRepository

--- a/src/cortex/trace/interfaces.py
+++ b/src/cortex/trace/interfaces.py
@@ -12,10 +12,13 @@ class TraceRepository(ABC):
     """
     Abstract interface for loop-trace persistence.
 
-    Persistence primitives for the ``loop_events`` table. Capture wiring
-    (turning AgentLoop events into insert_event calls) lands in a later
-    ticket. ``payload`` is an event's self-describing ``to_dict()`` JSON and
-    is treated as opaque — implementations must not inspect its fields.
+    Persistence primitives for the ``loop_events`` table. ``payload`` is an
+    event's self-describing ``to_dict()`` JSON and is treated as opaque —
+    implementations must not inspect its fields.
+
+    ``max_seq`` is the cross-turn seq-continuity primitive (issue #112 T2):
+    the recorder starts each capture at ``max_seq + 1`` so seq stays monotonic
+    per session across turns under ``UNIQUE(session_id, seq)``.
     """
 
     @abstractmethod
@@ -32,6 +35,12 @@ class TraceRepository(ABC):
     @abstractmethod
     async def list_events(self, session_id: UUID) -> list[TraceEvent]:
         """List a session's loop events in seq order (oldest first)."""
+        ...
+
+    @abstractmethod
+    async def max_seq(self, session_id: UUID) -> int | None:
+        """Return the highest seq persisted for a session, or None when the
+        session has no ``loop_events`` rows yet."""
         ...
 
     @abstractmethod

--- a/src/cortex/trace/pseudonymizer.py
+++ b/src/cortex/trace/pseudonymizer.py
@@ -1,0 +1,96 @@
+"""Pseudonymizer interface + rizzo-pii HTTP implementation (issue #112 T2).
+
+The pseudonymizer sits behind a one-method interface so capture code (the
+recorder) is sidecar-agnostic: production uses the local rizzo-pii sidecar,
+tests inject a fake.
+
+Pinned rizzo-pii wire contract (verified from upstream source @ v2.0.0):
+
+* ``POST {base_url}/analyze`` with JSON ``{"text": "...", "include_mapping": false}``
+* 200 → ``{"anonymized_text": "...", "segments": [...], "mapping": {},
+  "mapping_enabled": false, "n_chars": N, "n_entities": N, ...}``
+* ``include_mapping=false`` keeps real values out of the consumed fields
+  (mapping stays server-internal per request); placeholders are stable
+  ``[TAG_N]`` within one request and numbering restarts per request.
+* ``GET /health`` → 200 when the model is ready, 503 until then.
+
+Any sidecar failure (unreachable, non-2xx, malformed body) raises — the
+recorder turns failures into skip + log, never a partial result or raw-text
+fallthrough.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+import httpx
+
+
+class Pseudonymizer(ABC):
+    """Abstract pseudonymization service: free text in, ``[TAG_N]`` out."""
+
+    @abstractmethod
+    async def anonymize(self, text: str) -> str:
+        """Pseudonymize PII-bearing free text.
+
+        Args:
+            text: Free text that may contain personal data.
+
+        Returns:
+            The same text with PII spans replaced by stable ``[TAG_N]``
+            placeholders (numbering restarts per request by sidecar design).
+
+        Raises:
+            On any sidecar failure (unreachable, non-2xx, malformed response).
+            Implementations never return raw text on failure — the caller
+            (TraceRecorder) treats a raise as "do not store this event".
+        """
+        ...
+
+
+class RizzoPseudonymizer(Pseudonymizer):
+    """HTTP pseudonymizer for a local rizzo-pii sidecar.
+
+    One ``/analyze`` call per field; only ``anonymized_text`` is read back.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        timeout: float = 10.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        """Initialize the sidecar client.
+
+        Args:
+            base_url: Sidecar root, e.g. ``http://127.0.0.1:5005``.
+            timeout: Per-request timeout in seconds (httpx applies it per
+                connect/read/write/pool step).
+            client: Optional pre-built ``httpx.AsyncClient`` (tests inject one
+                with a MockTransport); when omitted the impl builds its own
+                against ``base_url``.
+        """
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        if client is None:
+            client = httpx.AsyncClient(base_url=self._base_url, timeout=timeout)
+        self._client = client
+
+    async def anonymize(self, text: str) -> str:
+        """Pseudonymize ``text`` via ``POST /analyze`` (include_mapping=false).
+
+        An empty string carries no PII and is returned as-is without a
+        round-trip. Raises ``httpx.HTTPStatusError`` on non-2xx responses
+        (e.g. 503 while the model loads) and httpx transport errors when the
+        sidecar is unreachable.
+        """
+        if not text:
+            return text
+        response = await self._client.post(
+            "/analyze",
+            json={"text": text, "include_mapping": False},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return str(payload["anonymized_text"])

--- a/src/cortex/trace/recorder.py
+++ b/src/cortex/trace/recorder.py
@@ -1,0 +1,159 @@
+"""TraceRecorder — tees a LoopEvent stream into ``loop_events`` storage
+(issue #112 T2).
+
+The recorder is a *consumer* of the AgentLoop async-generator stream, wired in
+``ExecutionModule.stream_chat`` (the passthrough between the chat route and the
+loop) — never inside the loop. It wraps the upstream stream, and for each event:
+
+1. builds the event's self-describing ``to_dict()`` payload,
+2. pseudonymizes PII-bearing string fields via the injected Pseudonymizer
+   (one sidecar ``/analyze`` call per non-empty field), replacing them in the
+   *stored copy* only — the original event object is re-yielded untouched,
+3. persists the pseudonymized payload with the next monotonic ``seq``.
+
+Fail-closed capture semantics (the caller's stream is NEVER altered or
+interrupted):
+
+* Pseudonymization failure (sidecar unreachable / non-2xx / malformed) —
+  events are pseudonymized and persisted as they stream, so on the first
+  failure the recorder latches degraded for the rest of the turn: the failing
+  event and all later events of that turn are not stored, while events
+  already persisted for the turn (its PII-free leading events) may remain in
+  the store. Raw text is never stored: pseudonymization precedes every
+  insert. Latching instead of retrying per event avoids repeated
+  ``/analyze`` timeouts against a down sidecar and guarantees the stream is
+  never interrupted (US6). A warning is logged.
+* Persistence failure — only that event is skipped (DB errors are transient,
+  not a PII risk); later events still attempt their insert. ``seq`` advances
+  per attempt, so gaps are safe under ``UNIQUE(session_id, seq)``.
+* ``max_seq`` failure at capture start — the starting seq cannot be derived
+  safely, so nothing is stored for the turn.
+
+``seq`` is monotonic per session across turns: a fresh session's first event
+is ``seq`` 0, and later turns continue at the last persisted ``seq`` + 1
+(never restarting at 0). v1 assumption: one active stream per session.
+
+PII-bearing fields per spec: thinking.message, text.delta, done.message,
+tool_done output/error, and ask_user.question (it echoes conversation PII).
+tool_start fields and error.error are stored as-is per the spec field list.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterable, AsyncIterator
+from typing import TYPE_CHECKING, Any
+from uuid import UUID
+
+from cortex.agentic.events import (
+    AskUserEvent,
+    LoopEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+)
+
+if TYPE_CHECKING:
+    from cortex.trace.interfaces import TraceRepository
+    from cortex.trace.pseudonymizer import Pseudonymizer
+
+logger = logging.getLogger(__name__)
+
+# Field names per event type that may echo conversation PII and are therefore
+# pseudonymized (one sidecar call per non-empty field) BEFORE the insert.
+_PII_FIELDS: dict[type[LoopEvent], tuple[str, ...]] = {
+    ThinkingEvent: ("message",),
+    TextDeltaEvent: ("delta",),
+    ToolResultEvent: ("output", "error"),
+    ResponseDoneEvent: ("message",),
+    AskUserEvent: ("question",),
+}
+
+
+class TraceRecorder:
+    """Consumes a LoopEvent stream, persisting pseudonymized events."""
+
+    def __init__(self, repository: TraceRepository, pseudonymizer: Pseudonymizer):
+        self._repository = repository
+        self._pseudonymizer = pseudonymizer
+
+    async def capture(
+        self,
+        session_id: UUID,
+        events: AsyncIterable[LoopEvent],
+    ) -> AsyncIterator[LoopEvent]:
+        """Tee ``events`` into loop_events storage, re-yielding each unchanged.
+
+        Args:
+            session_id: The session the events belong to (seq continuity is
+                per session across turns).
+            events: The upstream AgentLoop event stream.
+
+        Yields:
+            Every event from ``events``, in order, exactly as received — even
+            when its capture failed (see module docstring).
+        """
+        degraded = False
+        # The first stored event of a turn is numbered max_seq + 1; a session
+        # with no rows yet (max_seq -> None) starts from this -1 base, so its
+        # first insert lands at seq 0. Never read once a failure below latches
+        # ``degraded`` for the rest of the turn.
+        seq = -1
+        try:
+            last_seq = await self._repository.max_seq(session_id)
+        except Exception as exc:
+            degraded = True
+            logger.warning(
+                "Trace capture skipped for session %s: cannot determine the "
+                "last persisted seq (%r); no events stored for this turn",
+                session_id,
+                exc,
+            )
+        else:
+            if last_seq is not None:
+                seq = last_seq
+
+        async for event in events:
+            if not degraded:
+                try:
+                    payload = await self._pseudonymized_payload(event)
+                except Exception as exc:
+                    degraded = True
+                    logger.warning(
+                        "Trace capture: pseudonymization failed for a %s event "
+                        "(session %s); the event and the remaining events of this "
+                        "turn are not stored (%r)",
+                        event.event_type,
+                        session_id,
+                        exc,
+                    )
+                else:
+                    try:
+                        seq += 1
+                        await self._repository.insert_event(
+                            session_id, seq, event.event_type, payload
+                        )
+                    except Exception as exc:
+                        logger.warning(
+                            "Trace capture: persistence failed for a %s event "
+                            "(session %s); event skipped (%r)",
+                            event.event_type,
+                            session_id,
+                            exc,
+                        )
+            yield event
+
+    async def _pseudonymized_payload(self, event: LoopEvent) -> dict[str, Any]:
+        """``event.to_dict()`` with PII-bearing string fields pseudonymized.
+
+        Works on a fresh copy: the original event object is never mutated, so
+        the stream delivered to the caller keeps its clear text.
+        """
+        payload = event.to_dict()
+        for field in _PII_FIELDS.get(type(event), ()):
+            value = payload.get(field)
+            # Empty/None values carry nothing to pseudonymize — skip the call.
+            if isinstance(value, str) and value:
+                payload[field] = await self._pseudonymizer.anonymize(value)
+        return payload

--- a/src/cortex/trace/repository.py
+++ b/src/cortex/trace/repository.py
@@ -56,6 +56,24 @@ class PostgresTraceRepository(TraceRepository):
             )
             return [self._row_to_event(row) for row in rows]
 
+    async def max_seq(self, session_id: UUID) -> int | None:
+        """Return the highest seq persisted for a session, or None when the
+        session has no ``loop_events`` rows yet (issue #112 T2)."""
+        async with DbSession() as db:
+            row = await db.fetchrow(
+                """
+                SELECT MAX(seq) AS max_seq
+                FROM loop_events
+                WHERE session_id = $1
+                """,
+                session_id,
+            )
+            # A bare aggregate always returns one row (NULL when the session
+            # has no rows); the None guard narrows the Record | None type.
+            if row is None or row["max_seq"] is None:
+                return None
+            return int(row["max_seq"])
+
     async def delete_older_than(self, cutoff: datetime) -> int:
         """Delete loop-event rows strictly older than the cutoff.
 

--- a/tests/unit/api/test_chat_stream.py
+++ b/tests/unit/api/test_chat_stream.py
@@ -60,7 +60,7 @@ class FakeExecutionModule:
     ):
         self._events = events or []
         self._exc = exc
-        self.calls: list[tuple[UUID, str, int | None, bool]] = []
+        self.calls: list[tuple[UUID, str, int | None, bool, bool]] = []
 
     async def stream_chat(
         self,
@@ -69,8 +69,9 @@ class FakeExecutionModule:
         *,
         max_iterations: int | None = None,
         stream: bool = False,
+        trace_enabled: bool = False,
     ):
-        self.calls.append((session_id, user_message, max_iterations, stream))
+        self.calls.append((session_id, user_message, max_iterations, stream, trace_enabled))
         if self._exc is not None:
             raise self._exc
         for event in self._events:
@@ -152,7 +153,7 @@ class TestChatStreamSSE:
             ("text", {"delta": "Hello there!"}),
             ("done", {"final_message": "Hello there!", "tool_calls": [], "iterations": 1}),
         ]
-        assert fake_exec.calls == [(session_id, "hi", 20, True)]
+        assert fake_exec.calls == [(session_id, "hi", 20, True, False)]
 
     def test_stream_flag_defaults_true_and_honors_false(self):
         """The `stream` flag reaches execution_module.stream_chat: defaults to
@@ -586,3 +587,40 @@ class TestChatStreamSSE:
                 "POST", "/chat/stream", json=payload, headers=AUTH_HEADERS
             ):
                 pass
+
+    def test_trace_enabled_session_flag_reaches_stream_chat(self):
+        """The resolved session's trace_enabled is forwarded to
+        execution_module.stream_chat: True for a traced session, False by
+        default — capture only ever starts for opted-in sessions."""
+        traced_id = uuid4()
+        fake_traced = FakeExecutionModule([
+            ResponseDoneEvent(session_id=traced_id, message="ok", tools_used=[], iterations=0),
+        ])
+        client = build_client(
+            fake_traced,
+            FakeInteractionService(
+                existing_session=Session(id=traced_id, trace_enabled=True)
+            ),
+        )
+        client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(traced_id)},
+            headers=AUTH_HEADERS,
+        )
+        assert fake_traced.calls[0][4] is True
+
+        # Default (untraced) session -> False, and the stream still runs.
+        plain_id = uuid4()
+        fake_plain = FakeExecutionModule([
+            ResponseDoneEvent(session_id=plain_id, message="ok", tools_used=[], iterations=0),
+        ])
+        client = build_client(
+            fake_plain,
+            FakeInteractionService(existing_session=Session(id=plain_id)),
+        )
+        client.post(
+            "/chat/stream",
+            json={"message": "hi", "session_id": str(plain_id)},
+            headers=AUTH_HEADERS,
+        )
+        assert fake_plain.calls[0][4] is False

--- a/tests/unit/execution/test_trace_wiring.py
+++ b/tests/unit/execution/test_trace_wiring.py
@@ -1,0 +1,179 @@
+"""Wiring tests: ExecutionModule.stream_chat tees trace-enabled sessions into
+the TraceRecorder (issue #112 T2).
+
+The seam under test is ExecutionModule.stream_chat — the passthrough between
+the chat route and AgentLoop. The recorder is injected explicitly (the module
+never builds trace machinery itself): when ``trace_enabled`` is True each
+yielded event is handed to the recorder (pseudonymize PII fields -> persist ->
+yield); when False nothing is persisted and the stream is a transparent
+passthrough. In every mode the stream delivered to the caller is never altered
+or interrupted.
+"""
+
+import logging
+from uuid import UUID, uuid4
+
+import pytest
+
+from cortex.agentic.events import (
+    ErrorEvent,
+    LoopEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+)
+from cortex.agentic.models import MaxIterationsError
+from cortex.execution.module import ExecutionModule
+from cortex.trace.pseudonymizer import Pseudonymizer
+from cortex.trace.recorder import TraceRecorder
+from tests.unit.trace.fakes import (
+    CF_SEED,
+    EMAIL_SEED,
+    FailingPseudonymizer,
+    FakePseudonymizer,
+    InMemoryTraceRepository,
+)
+
+
+class ScriptedLoop:
+    """Async-generator stub loop mirroring the AgentLoop stream contract."""
+
+    def __init__(
+        self, events: list[LoopEvent], exc: Exception | None = None
+    ) -> None:
+        self._events = events
+        self._exc = exc
+        self.calls: list[tuple[UUID, str, int | None, bool]] = []
+
+    async def stream_chat(
+        self,
+        session_id: UUID,
+        user_message: str,
+        *,
+        max_iterations: int | None = None,
+        stream: bool = False,
+    ):
+        self.calls.append((session_id, user_message, max_iterations, stream))
+        for event in self._events:
+            yield event
+        if self._exc is not None:
+            raise self._exc
+
+
+def traced_module(
+    events: list[LoopEvent],
+    pseudonymizer: Pseudonymizer | None = None,
+    loop_exc: Exception | None = None,
+) -> tuple[ExecutionModule, ScriptedLoop, InMemoryTraceRepository, Pseudonymizer]:
+    """ExecutionModule wired like production: recorder over a repo + sidecar."""
+    loop = ScriptedLoop(events, exc=loop_exc)
+    repo = InMemoryTraceRepository()
+    pz = pseudonymizer or FakePseudonymizer()
+    module = ExecutionModule(
+        agent_loop=loop,
+        trace_recorder=TraceRecorder(repository=repo, pseudonymizer=pz),
+    )
+    return module, loop, repo, pz
+
+
+class TestStreamChatTraceWiring:
+    """trace_enabled=True routes the stream through the recorder."""
+
+    @pytest.mark.asyncio
+    async def test_trace_enabled_stream_persists_pseudonymized_rows(self):
+        """A traced turn: every event persisted (pseudonymized payloads, seq
+        order) while the caller receives the original events unchanged."""
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id, message=f"check {EMAIL_SEED}"),
+            TextDeltaEvent(session_id, delta=f"mail {EMAIL_SEED}"),
+            ResponseDoneEvent(session_id, message=f"ok {CF_SEED}", tools_used=[], iterations=1),
+        ]
+        module, loop, repo, pz = traced_module(scripted)
+
+        seen = [e async for e in module.stream_chat(session_id, "hello", trace_enabled=True)]
+
+        assert seen == scripted
+        assert loop.calls == [(session_id, "hello", None, False)]
+        rows = await repo.list_events(session_id)
+        assert [r.seq for r in rows] == [0, 1, 2]
+        assert [r.event_type for r in rows] == ["thinking", "text", "done"]
+        # I1 anti-vacuity: rows exist AND no stored payload carries the seed.
+        assert rows
+        blob = "".join(str(r.payload) for r in rows)
+        assert EMAIL_SEED not in blob and CF_SEED not in blob
+        assert len(pz.calls) == 3  # one /analyze per PII-bearing field
+
+    @pytest.mark.asyncio
+    async def test_untraced_stream_persists_nothing(self):
+        """Untraced session, identical turn -> zero rows; the recorder is never
+        invoked (this assertion would fail if capture leaked)."""
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id, message=f"check {EMAIL_SEED}"),
+            TextDeltaEvent(session_id, delta=f"mail {EMAIL_SEED}"),
+            ResponseDoneEvent(session_id, message=f"ok {CF_SEED}", tools_used=[], iterations=1),
+        ]
+        module, loop, repo, pz = traced_module(scripted)
+
+        seen = [e async for e in module.stream_chat(session_id, "hello")]
+
+        assert seen == scripted
+        assert await repo.list_events(session_id) == []
+        assert pz.calls == []  # recorder (and sidecar) never touched
+
+    @pytest.mark.asyncio
+    async def test_stream_flag_and_args_still_forwarded_when_traced(self):
+        session_id = uuid4()
+        scripted = [TextDeltaEvent(session_id, delta="hi")]
+        module, loop, repo, _ = traced_module(scripted)
+
+        _ = [e async for e in module.stream_chat(session_id, "hi", max_iterations=5, stream=True, trace_enabled=True)]
+
+        assert loop.calls == [(session_id, "hi", 5, True)]
+
+    @pytest.mark.asyncio
+    async def test_error_contract_preserved_through_recorder(self):
+        """A turn that raises still persists the events before the error
+        (incl. the ErrorEvent itself) and the exception still propagates —
+        capture never swallows or alters the stream (criterion 6)."""
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id, message="thinking before the error"),
+            TextDeltaEvent(session_id, delta="text before the error"),
+            ErrorEvent(session_id, error="Max iterations exceeded", code="max_iterations"),
+        ]
+        module, loop, repo, _ = traced_module(scripted, loop_exc=MaxIterationsError(3))
+
+        seen: list[LoopEvent] = []
+        with pytest.raises(MaxIterationsError):
+            async for event in module.stream_chat(session_id, "hello", trace_enabled=True):
+                seen.append(event)
+
+        assert [type(e).__name__ for e in seen] == [
+            "ThinkingEvent", "TextDeltaEvent", "ErrorEvent",
+        ]
+        rows = await repo.list_events(session_id)
+        assert [r.event_type for r in rows] == ["thinking", "text", "error"]
+        assert [r.seq for r in rows] == [0, 1, 2]
+
+    @pytest.mark.asyncio
+    async def test_trace_enabled_sidecar_down_never_interrupts_stream(self, caplog):
+        """Sidecar unreachable: the stream completes normally and nothing is
+        persisted for the turn (fail-closed, US6)."""
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id, message="think"),
+            TextDeltaEvent(session_id, delta="hi"),
+            ResponseDoneEvent(session_id, message="done"),
+        ]
+        module, loop, repo, _ = traced_module(scripted, pseudonymizer=FailingPseudonymizer())
+
+        with caplog.at_level(logging.WARNING, logger="cortex.trace.recorder"):
+            seen = [e async for e in module.stream_chat(session_id, "hello", trace_enabled=True)]
+
+        # Chat stream never interrupted or altered.
+        assert seen == scripted
+        # Zero rows for the turn — the raw-thinking skip cascades to the rest.
+        assert await repo.list_events(session_id) == []
+        assert any("pseudonymization failed" in r.message for r in caplog.records)

--- a/tests/unit/test_trace_settings.py
+++ b/tests/unit/test_trace_settings.py
@@ -1,0 +1,75 @@
+"""Settings tests for trace capture configuration (issue #112 T2).
+
+The sidecar base URL (+ per-request timeout) must be configurable: flat
+``Settings`` fields with sane defaults, uppercase env overrides
+(TRACE_SIDECAR_URL / TRACE_SIDECAR_TIMEOUT_S, flat passthrough like
+LLM_PRICING), and an optional nested YAML ``trace`` block mapped to the flat
+fields by the loader (mirroring the existing blocks).
+"""
+
+from cortex.config.loader import load_settings
+from cortex.config.models import Settings
+
+
+class TestTraceSettingsDefaults:
+    def test_sidecar_defaults(self):
+        """Flat defaults: localhost sidecar + a sane per-request timeout."""
+        settings = Settings(llm_api_key="test-key")
+        assert settings.trace_sidecar_url == "http://127.0.0.1:5005"
+        assert settings.trace_sidecar_timeout_s == 10.0
+
+
+class TestTraceSettingsEnvOverrides:
+    def test_env_overrides_sidecar_url(self, monkeypatch):
+        monkeypatch.setenv("TRACE_SIDECAR_URL", "http://127.0.0.1:6000")
+        settings = Settings(llm_api_key="test-key")
+        assert settings.trace_sidecar_url == "http://127.0.0.1:6000"
+
+    def test_env_overrides_sidecar_timeout(self, monkeypatch):
+        monkeypatch.setenv("TRACE_SIDECAR_TIMEOUT_S", "2.5")
+        settings = Settings(llm_api_key="test-key")
+        assert settings.trace_sidecar_timeout_s == 2.5
+
+    def test_constructor_kwargs_win_over_env(self, monkeypatch):
+        """Explicit constructor values still beat env (init-args precedence)."""
+        monkeypatch.setenv("TRACE_SIDECAR_URL", "http://env:1")
+        settings = Settings(llm_api_key="test-key", trace_sidecar_url="http://ctor:1")
+        assert settings.trace_sidecar_url == "http://ctor:1"
+
+
+class TestTraceSettingsLoader:
+    def test_nested_trace_block_maps_to_flat_fields(self, tmp_path):
+        """loader maps a YAML `trace:` block onto the flat Settings fields."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text(
+            "trace:\n"
+            "  sidecar_url: http://rizzo:5005\n"
+            "  sidecar_timeout_s: 4.5\n"
+        )
+
+        settings = load_settings(config_path=cfg)
+
+        assert settings.trace_sidecar_url == "http://rizzo:5005"
+        assert settings.trace_sidecar_timeout_s == 4.5
+
+    def test_loader_without_trace_block_keeps_defaults(self, tmp_path):
+        """A config file without a trace block leaves the flat defaults in place."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("app:\n  port: 8123\n")
+
+        settings = load_settings(config_path=cfg)
+
+        assert settings.app_port == 8123
+        assert settings.trace_sidecar_url == "http://127.0.0.1:5005"
+        assert settings.trace_sidecar_timeout_s == 10.0
+
+    def test_env_override_reaches_settings_when_no_yaml_trace_block(self, tmp_path, monkeypatch):
+        """Flat env passthrough (LLM_PRICING-style): with no YAML value present
+        the env var supplies the field."""
+        monkeypatch.setenv("TRACE_SIDECAR_URL", "http://127.0.0.1:7000")
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("app:\n  port: 8123\n")
+
+        settings = load_settings(config_path=cfg)
+
+        assert settings.trace_sidecar_url == "http://127.0.0.1:7000"

--- a/tests/unit/trace/fakes.py
+++ b/tests/unit/trace/fakes.py
@@ -1,0 +1,101 @@
+"""Shared in-memory fakes for trace capture tests (issue #112 T2).
+
+Used by both ``tests/unit/trace/test_recorder.py`` (the TraceRecorder unit
+tests) and ``tests/unit/execution/test_trace_wiring.py`` (the
+ExecutionModule.stream_chat wiring tests) so the recorder contract is pinned
+against one repository fake and one pseudonymizer fake.
+
+* ``InMemoryTraceRepository`` — a TraceRepository whose ``max_seq`` derives
+  from stored rows, modeling the real Postgres continuity across turns.
+* ``FakePseudonymizer`` — deterministic sidecar stand-in: swaps each PII seed
+  for a stable ``[TAG_N]`` placeholder and records every call.
+* ``FailingPseudonymizer`` — raises on every call, modeling a down sidecar.
+
+``EMAIL_SEED``/``CF_SEED`` are the PII seeds planted in scripted event text
+(I1: email + codice fiscale): a stored payload containing either seed verbatim
+means capture leaked clear PII.
+"""
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID
+
+from cortex.trace.interfaces import TraceRepository
+from cortex.trace.models import TraceEvent
+from cortex.trace.pseudonymizer import Pseudonymizer
+
+EMAIL_SEED = "mario.rossi@example.com"
+CF_SEED = "RSSMRA85H12F205Z"
+PII_SEEDS = (EMAIL_SEED, CF_SEED)
+
+
+class InMemoryTraceRepository(TraceRepository):
+    """In-memory TraceRepository: max_seq derives from stored rows, so it
+    models the real Postgres continuity across capture() calls."""
+
+    def __init__(self) -> None:
+        self.rows: list[TraceEvent] = []
+        self._next_id = 1
+
+    async def insert_event(
+        self,
+        session_id: UUID,
+        seq: int,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> TraceEvent:
+        row = TraceEvent(
+            id=self._next_id,
+            session_id=session_id,
+            seq=seq,
+            event_type=event_type,
+            payload=payload,
+            created_at=datetime.now(UTC),
+        )
+        self._next_id += 1
+        self.rows.append(row)
+        return row
+
+    async def list_events(self, session_id: UUID) -> list[TraceEvent]:
+        return sorted(
+            (r for r in self.rows if r.session_id == session_id), key=lambda r: r.seq
+        )
+
+    async def delete_older_than(self, cutoff: datetime) -> int:
+        kept = [r for r in self.rows if r.created_at >= cutoff]
+        deleted = len(self.rows) - len(kept)
+        self.rows = kept
+        return deleted
+
+    async def max_seq(self, session_id: UUID) -> int | None:
+        seqs = [r.seq for r in self.rows if r.session_id == session_id]
+        return max(seqs) if seqs else None
+
+
+class FakePseudonymizer(Pseudonymizer):
+    """Deterministic sidecar stand-in: swaps each PII seed for a stable
+    [TAG_N] placeholder; numbering restarts per anonymize() call (same
+    contract shape as the pinned rizzo sidecar)."""
+
+    def __init__(self, seeds: tuple[str, ...] = PII_SEEDS) -> None:
+        self._seeds = seeds
+        self.calls: list[str] = []
+
+    async def anonymize(self, text: str) -> str:
+        self.calls.append(text)
+        anonymized = text
+        for index, seed in enumerate(self._seeds, start=1):
+            anonymized = anonymized.replace(seed, f"[TAG_{index}]")
+        return anonymized
+
+
+class FailingPseudonymizer(Pseudonymizer):
+    """Raises on every anonymize() call — models an unreachable sidecar."""
+
+    def __init__(self, error: Exception | None = None) -> None:
+        self._error = error or RuntimeError("sidecar unreachable")
+        self.calls: list[str] = []
+
+    async def anonymize(self, text: str) -> str:
+        self.calls.append(text)
+        raise self._error

--- a/tests/unit/trace/test_pseudonymizer.py
+++ b/tests/unit/trace/test_pseudonymizer.py
@@ -1,0 +1,190 @@
+"""Tests for the Pseudonymizer interface + rizzo-pii HTTP impl (issue #112 T2).
+
+The contract under test is the pinned rizzo-pii /analyze response shape
+(verified from upstream source at tag v2.0.0):
+
+* POST ``{base_url}/analyze`` with JSON ``{"text": ..., "include_mapping": false}``
+* 200 → ``{"anonymized_text": "...", "segments": [...], "mapping": {},
+  "mapping_enabled": false, "n_chars": N, "n_entities": N, ...}``
+* The client reads ONLY ``anonymized_text``; ``include_mapping=false`` keeps
+  real values out of every field the client consumes.
+* non-200 (503 while the model loads) and network errors propagate — the
+  recorder turns them into skip + log, never a partial result.
+"""
+
+import json
+from abc import ABC
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from cortex.trace.pseudonymizer import Pseudonymizer, RizzoPseudonymizer
+
+EMAIL_SEED = "mario.rossi@example.com"
+
+
+def pinned_analyze_response(text: str) -> dict:
+    """A realistic pinned rizzo-pii /analyze body (include_mapping=false)."""
+    return {
+        "segments": [
+            {"t": "Contact "},
+            {
+                "label": "EMAIL",
+                "ph": "[EMAIL_1]",
+                "src": "regex",
+                "validated": True,
+                # mapping_enabled=false -> segments never carry the real value
+            },
+            {"t": " today"},
+        ],
+        "anonymized_text": "Contact [EMAIL_1] today",
+        "mapping": {},
+        "mapping_enabled": False,
+        "n_chars": len(text),
+        "n_entities": 1,
+        "n_unique": 1,
+        "by_label": {"EMAIL": 1},
+        "by_source": {"regex": 1},
+        "excluded_tags": [],
+    }
+
+
+class TestPseudonymizerInterface:
+    """The interface is the recorder's seam: one async method, failure = raise."""
+
+    def test_interface_is_abstract(self):
+        """Pseudonymizer is abstract and cannot be instantiated directly."""
+        assert issubclass(Pseudonymizer, ABC)
+        with pytest.raises(TypeError, match="abstract"):
+            Pseudonymizer()
+
+    def test_interface_declares_anonymize(self):
+        """The seam is `async anonymize(text: str) -> str`."""
+        assert callable(getattr(Pseudonymizer, "anonymize"))
+
+    def test_rizzo_impl_is_concrete_subclass(self):
+        assert issubclass(RizzoPseudonymizer, Pseudonymizer)
+
+
+class TestRizzoPseudonymizerContract:
+    """Wire contract against the pinned rizzo-pii response shape (fake HTTP)."""
+
+    @pytest.mark.asyncio
+    async def test_anonymize_returns_anonymized_text_and_asserts_request(self):
+        """POST /analyze carries {"text", "include_mapping": false}; the pinned
+        response's anonymized_text is returned (nothing else is read)."""
+        seen: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["url"] = str(request.url)
+            seen["json"] = json.loads(request.content)
+            seen["headers"] = request.headers
+            return httpx.Response(200, json=pinned_analyze_response(EMAIL_SEED))
+
+        pseudonymizer = RizzoPseudonymizer(
+            base_url="http://127.0.0.1:5005",
+            client=httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), base_url="http://rizzo.test"
+            ),
+        )
+
+        result = await pseudonymizer.anonymize(f"Contact {EMAIL_SEED} today")
+
+        assert result == "Contact [EMAIL_1] today"
+        assert seen["method"] == "POST"
+        assert seen["url"] == "http://rizzo.test/analyze"
+        # include_mapping=false is asserted on the wire (the acceptance pin).
+        assert seen["json"] == {"text": f"Contact {EMAIL_SEED} today", "include_mapping": False}
+
+    @pytest.mark.asyncio
+    async def test_503_readiness_raises(self):
+        """A 503 (model not ready) is a failure — never a partial/empty result."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(503, json={"status": "loading"})
+
+        pseudonymizer = RizzoPseudonymizer(
+            base_url="http://127.0.0.1:5005",
+            client=httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), base_url="http://rizzo.test"
+            ),
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await pseudonymizer.anonymize("anything")
+
+    @pytest.mark.asyncio
+    async def test_http_500_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, json={"error": "boom"})
+
+        pseudonymizer = RizzoPseudonymizer(
+            base_url="http://127.0.0.1:5005",
+            client=httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), base_url="http://rizzo.test"
+            ),
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await pseudonymizer.anonymize("anything")
+
+    @pytest.mark.asyncio
+    async def test_network_error_propagates(self):
+        """Unreachable sidecar (connection refused) raises instead of returning
+        raw text — raw text must never silently pass through."""
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused")
+
+        pseudonymizer = RizzoPseudonymizer(
+            base_url="http://127.0.0.1:5005",
+            client=httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), base_url="http://rizzo.test"
+            ),
+        )
+
+        with pytest.raises(httpx.ConnectError):
+            await pseudonymizer.anonymize(f"secret {EMAIL_SEED}")
+
+    @pytest.mark.asyncio
+    async def test_empty_text_skips_the_sidecar(self):
+        """Empty strings carry no PII: no HTTP round-trip, empty string back."""
+        hit = False
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            nonlocal hit
+            hit = True
+            return httpx.Response(200, json=pinned_analyze_response(""))
+
+        pseudonymizer = RizzoPseudonymizer(
+            base_url="http://127.0.0.1:5005",
+            client=httpx.AsyncClient(
+                transport=httpx.MockTransport(handler), base_url="http://rizzo.test"
+            ),
+        )
+
+        assert await pseudonymizer.anonymize("") == ""
+        assert hit is False
+
+    @pytest.mark.asyncio
+    async def test_own_client_built_from_base_url_when_none_injected(self):
+        """Without an injected client the impl builds one against base_url
+        (production path) — verified by patching httpx.AsyncClient."""
+        import cortex.trace.pseudonymizer as pseudonymizer_module
+
+        fake_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(
+                lambda request: httpx.Response(200, json=pinned_analyze_response("x"))
+            ),
+            base_url="http://127.0.0.1:5005",
+        )
+        with patch.object(
+            pseudonymizer_module.httpx, "AsyncClient", return_value=fake_client
+        ) as client_cls:
+            pseudonymizer = RizzoPseudonymizer(
+                base_url="http://127.0.0.1:5005", timeout=3.0
+            )
+            assert await pseudonymizer.anonymize("hi") == "Contact [EMAIL_1] today"
+        client_cls.assert_called_once_with(base_url="http://127.0.0.1:5005", timeout=3.0)

--- a/tests/unit/trace/test_recorder.py
+++ b/tests/unit/trace/test_recorder.py
@@ -1,0 +1,391 @@
+"""Tests for TraceRecorder — the LoopEvent-stream consumer (issue #112 T2).
+
+The recorder contract under test:
+
+* capture() tees a LoopEvent async stream into ``loop_events``: each event is
+  persisted in seq order (starting after the session's last persisted seq, so
+  seq stays monotonic ACROSS turns under UNIQUE(session_id, seq)) and then
+  re-yielded *unchanged* — the stream delivered to the caller is never altered.
+* PII-bearing string fields (thinking.message, text.delta, done.message,
+  tool_done output/error, ask_user.question) are pseudonymized via the injected
+  Pseudonymizer BEFORE the insert; tool_start fields and error.error stay as-is
+  per the spec field list. Raw text is therefore never stored.
+* Fail-closed: a pseudonymization failure (sidecar down) means the affected
+  event and the remainder of the turn are not persisted; a persistence failure
+  skips only that event; a max_seq failure at capture start stores nothing.
+  In every failure mode every event is still yielded downstream.
+"""
+
+import json
+import logging
+from typing import Any
+from uuid import UUID, uuid4
+
+import pytest
+
+from cortex.agentic.events import (
+    AskUserEvent,
+    ErrorEvent,
+    LoopEvent,
+    ResponseDoneEvent,
+    TextDeltaEvent,
+    ThinkingEvent,
+    ToolResultEvent,
+    ToolStartEvent,
+)
+from cortex.trace.models import TraceEvent
+from cortex.trace.recorder import TraceRecorder
+from tests.unit.trace.fakes import (
+    CF_SEED,
+    EMAIL_SEED,
+    PII_SEEDS,
+    FailingPseudonymizer,
+    FakePseudonymizer,
+    InMemoryTraceRepository,
+)
+
+
+def make_events(session_id: UUID) -> list[LoopEvent]:
+    """A realistic full turn covering every streamed event type (I2)."""
+    return [
+        ThinkingEvent(session_id, message=f"Let me look up {EMAIL_SEED}."),
+        ToolStartEvent(session_id, tool_name="web_search", tool_call_id="call_1"),
+        ToolResultEvent(
+            session_id,
+            tool_name="web_search",
+            tool_call_id="call_1",
+            success=True,
+            output=f"Found CF {CF_SEED}",
+            error=None,
+        ),
+        ToolResultEvent(
+            session_id,
+            tool_name="shell",
+            tool_call_id="call_2",
+            success=False,
+            output=None,
+            error=f"could not reach {EMAIL_SEED}",
+        ),
+        TextDeltaEvent(session_id, delta=f"Contact {EMAIL_SEED} or {CF_SEED}."),
+        ResponseDoneEvent(
+            session_id,
+            message=f"Done — {EMAIL_SEED} / {CF_SEED}.",
+            tools_used=["web_search", "shell"],
+            iterations=2,
+        ),
+        ErrorEvent(session_id, error="boom: no retries left", code="max_iterations"),
+    ]
+
+
+def payloads_json(events: list[TraceEvent]) -> str:
+    """All stored payloads serialized as one JSON blob (any-level seed check)."""
+    return json.dumps([e.payload for e in events])
+
+
+class FlakyOnTextPseudonymizer(FakePseudonymizer):
+    """Fails only for one exact input; the rest pass through to Fake semantics."""
+
+    def __init__(self, failing_text: str, seeds: tuple[str, ...] = PII_SEEDS) -> None:
+        super().__init__(seeds=seeds)
+        self._failing_text = failing_text
+
+    async def anonymize(self, text: str) -> str:
+        if text == self._failing_text:
+            self.calls.append(text)
+            raise RuntimeError("transient sidecar blip")
+        return await super().anonymize(text)
+
+
+class FlakyInsertRepository(InMemoryTraceRepository):
+    """Raises on insert for specific seqs (models transient DB failures)."""
+
+    def __init__(self, failing_seqs: set[int]) -> None:
+        super().__init__()
+        self._failing_seqs = failing_seqs
+
+    async def insert_event(
+        self,
+        session_id: UUID,
+        seq: int,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> TraceEvent:
+        if seq in self._failing_seqs:
+            raise RuntimeError("db connection lost")
+        return await super().insert_event(session_id, seq, event_type, payload)
+
+
+class BrokenMaxSeqRepository(InMemoryTraceRepository):
+    """max_seq raises — models the trace store being unreachable."""
+
+    async def max_seq(self, session_id: UUID) -> int | None:
+        raise RuntimeError("db connection lost")
+
+
+async def _drain(
+    recorder: TraceRecorder, session_id: UUID, events: list[LoopEvent]
+) -> list[LoopEvent]:
+    async def _agen() -> Any:
+        for event in events:
+            yield event
+
+    return [e async for e in recorder.capture(session_id, _agen())]
+
+
+@pytest.fixture
+def recorder() -> tuple[TraceRecorder, InMemoryTraceRepository, FakePseudonymizer]:
+    repo = InMemoryTraceRepository()
+    pseudonymizer = FakePseudonymizer()
+    return TraceRecorder(repository=repo, pseudonymizer=pseudonymizer), repo, pseudonymizer
+
+
+class TestTraceRecorderCapture:
+    """Happy-path capture: seq order, coverage of all event types, PII scope."""
+
+    @pytest.mark.asyncio
+    async def test_full_turn_persisted_in_seq_order_with_every_event_type(self, recorder):
+        """A full chat turn (thinking + tools + text + done + error) persists one
+        row per event, in seq order, covering every streamed event type (I2)."""
+        trace_recorder, repo, _ = recorder
+        session_id = uuid4()
+        scripted = make_events(session_id)
+
+        seen = await _drain(trace_recorder, session_id, scripted)
+
+        # The stream delivered to the caller is untouched: same objects, same order.
+        assert seen == scripted
+        assert all(a is b for a, b in zip(seen, scripted))
+
+        rows = await repo.list_events(session_id)
+        assert [r.event_type for r in rows] == [
+            "thinking",
+            "tool_start",
+            "tool_done",
+            "tool_done",
+            "text",
+            "done",
+            "error",
+        ]
+        assert [r.seq for r in rows] == [0, 1, 2, 3, 4, 5, 6]
+        assert rows  # anti-vacuity: rows exist, the assertions below are not vacuous
+
+    @pytest.mark.asyncio
+    async def test_stored_payloads_never_contain_seeded_pii(self, recorder):
+        """I1: seeded PII (email / codice fiscale) in user/assistant/tool text
+        never appears in clear in any stored payload — while rows DO exist and
+        PII-bearing fields ARE pseudonymized to placeholders."""
+        trace_recorder, repo, _ = recorder
+        session_id = uuid4()
+        scripted = make_events(session_id)
+
+        await _drain(trace_recorder, session_id, scripted)
+
+        rows = await repo.list_events(session_id)
+        assert rows  # anti-vacuity: a capture that leaked by persisting nothing
+        # would still pass the "no seed" check below — so require rows first.
+        blob = payloads_json(rows)
+        assert EMAIL_SEED not in blob
+        assert CF_SEED not in blob
+
+        by_type = {r.event_type: r.payload for r in rows}
+        assert "[TAG_1]" in by_type["thinking"]["message"]  # thinking.message
+        assert "[TAG_1]" in by_type["text"]["delta"]  # text.delta
+        # done.message pseudonymized whole — one coherent placeholder text.
+        assert "[TAG_1]" in by_type["done"]["message"]
+        assert "[TAG_2]" in by_type["done"]["message"]
+        # tool_done.output and tool_done.error each pseudonymized (one row each).
+        tool_done = [r.payload for r in rows if r.event_type == "tool_done"]
+        assert "[TAG_2]" in tool_done[0]["output"]
+        assert "[TAG_1]" in tool_done[1]["error"]
+
+    @pytest.mark.asyncio
+    async def test_ask_user_question_pseudonymized_and_tool_start_error_raw(self, recorder):
+        """ask_user.question is pseudonymized too (it echoes conversation PII);
+        tool_start fields and error.error stay as-is per the spec field list."""
+        trace_recorder, repo, pseudonymizer = recorder
+        session_id = uuid4()
+        scripted = [
+            ToolStartEvent(session_id, tool_name="ask_user", tool_call_id="call_9"),
+            AskUserEvent(session_id, question=f"Is {EMAIL_SEED} correct?"),
+            ResponseDoneEvent(session_id, message=f"Is {EMAIL_SEED} correct?"),
+            ErrorEvent(session_id, error="loop failed: no retries", code=None),
+        ]
+
+        await _drain(trace_recorder, session_id, scripted)
+
+        rows = await repo.list_events(session_id)
+        by_type = {r.event_type: r.payload for r in rows}
+        assert EMAIL_SEED not in payloads_json(rows)
+        assert CF_SEED not in payloads_json(rows)
+        assert by_type["ask_user"]["question"] == "Is [TAG_1] correct?"
+        # tool_start: no PII-bearing field per spec — stored verbatim.
+        assert by_type["tool_start"]["tool_name"] == "ask_user"
+        assert by_type["tool_start"]["tool_call_id"] == "call_9"
+        # error.error: intentionally NOT pseudonymized per spec field list.
+        assert by_type["error"]["error"] == "loop failed: no retries"
+        assert by_type["error"]["code"] is None
+        # One anonymize call per PII field: ask_user.question + done.message.
+        assert len(pseudonymizer.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_capture_continues_seq_across_turns(self, recorder):
+        """seq is monotonic per session ACROSS capture() calls: the second turn
+        starts right after the highest seq the first turn persisted."""
+        trace_recorder, repo, _ = recorder
+        session_id = uuid4()
+        first_turn = [
+            ThinkingEvent(session_id, message="one"),
+            TextDeltaEvent(session_id, delta="hello"),
+        ]
+        second_turn = [
+            ThinkingEvent(session_id, message="two"),
+            ResponseDoneEvent(session_id, message="done"),
+        ]
+
+        await _drain(trace_recorder, session_id, first_turn)
+        await _drain(trace_recorder, session_id, second_turn)
+
+        rows = await repo.list_events(session_id)
+        # Turn one: seq 0-1. Turn two must NOT restart at 0 (UNIQUE(session_id, seq)).
+        assert [r.seq for r in rows] == [0, 1, 2, 3]
+        assert [r.event_type for r in rows] == [
+            "thinking", "text", "thinking", "done",
+        ]
+        seqs = [r.seq for r in rows]
+        assert len(seqs) == len(set(seqs))  # no duplicates
+
+    @pytest.mark.asyncio
+    async def test_capture_after_pre_seeded_session_continues_above_max(self, recorder):
+        """A session with rows from a previous process/run continues above the
+        persisted max (the recorder never assumes it starts at zero)."""
+        trace_recorder, repo, _ = recorder
+        session_id = uuid4()
+        # Pre-existing rows (e.g. a prior capture before a restart).
+        await repo.insert_event(session_id, 0, "thinking", {"message": "old"})
+        await repo.insert_event(session_id, 1, "done", {"message": "old"})
+
+        await _drain(
+            trace_recorder,
+            session_id,
+            [TextDeltaEvent(session_id, delta="new turn")],
+        )
+
+        rows = await repo.list_events(session_id)
+        assert [r.seq for r in rows] == [0, 1, 2]
+        assert rows[-1].event_type == "text"
+
+    @pytest.mark.asyncio
+    async def test_empty_or_none_pii_fields_skip_the_sidecar(self, recorder):
+        """Empty/None PII fields carry nothing to pseudonymize: no /analyze call
+        is made and the empty value is stored as-is."""
+        trace_recorder, repo, pseudonymizer = recorder
+        session_id = uuid4()
+        scripted = [
+            TextDeltaEvent(session_id, delta=""),
+            ToolResultEvent(
+                session_id,
+                tool_name="shell",
+                tool_call_id="call_1",
+                success=True,
+                output="",
+                error=None,
+            ),
+        ]
+
+        await _drain(trace_recorder, session_id, scripted)
+
+        assert pseudonymizer.calls == []
+        rows = await repo.list_events(session_id)
+        assert len(rows) == 2
+        assert rows[0].payload["delta"] == ""
+        assert rows[1].payload["output"] == ""
+        assert rows[1].payload["error"] is None
+
+
+class TestTraceRecorderFailClosed:
+    """Every failure mode logs a warning and never alters the stream."""
+
+    @pytest.mark.asyncio
+    async def test_sidecar_down_stores_nothing_and_stream_completes(self, caplog):
+        """Sidecar unreachable → the turn completes normally and NO rows are
+        persisted for it (fail-closed); a warning is logged (US6)."""
+        repo = InMemoryTraceRepository()
+        failing = FailingPseudonymizer()
+        trace_recorder = TraceRecorder(repository=repo, pseudonymizer=failing)
+        session_id = uuid4()
+        scripted = make_events(session_id)
+
+        with caplog.at_level(logging.WARNING, logger="cortex.trace.recorder"):
+            seen = await _drain(trace_recorder, session_id, scripted)
+
+        # Chat stream never interrupted or altered.
+        assert seen == scripted
+        # Zero rows for the turn — the raw-thinking skip cascades to the rest.
+        assert await repo.list_events(session_id) == []
+        assert any("pseudonymization failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_one_failed_field_skips_its_event_and_turn_remainder(self, caplog):
+        """Fail-closed per event: a failed pseudonymization drops the affected
+        event (and, since the sidecar may stay down, the rest of the turn) while
+        earlier events persist and every event still reaches the caller."""
+        repo = InMemoryTraceRepository()
+        flaky = FlakyOnTextPseudonymizer(failing_text="boom text")
+        trace_recorder = TraceRecorder(repository=repo, pseudonymizer=flaky)
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id, message="fine thinking"),
+            TextDeltaEvent(session_id, delta="boom text"),  # only this call fails
+            ResponseDoneEvent(session_id, message="never stored"),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="cortex.trace.recorder"):
+            seen = await _drain(trace_recorder, session_id, scripted)
+
+        assert seen == scripted  # stream untouched
+        rows = await repo.list_events(session_id)
+        assert [r.event_type for r in rows] == ["thinking"]
+        assert any("pseudonymization failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_insert_failure_skips_only_that_event(self, caplog):
+        """A persistence (DB) failure is transient, not a PII risk: only the
+        affected event is skipped — later events still persist, with seq gaps
+        safe under UNIQUE(session_id, seq)."""
+        repo = FlakyInsertRepository(failing_seqs={1})
+        pseudonymizer = FakePseudonymizer()
+        trace_recorder = TraceRecorder(repository=repo, pseudonymizer=pseudonymizer)
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id, message="think"),
+            TextDeltaEvent(session_id, delta="will fail"),
+            ResponseDoneEvent(session_id, message="persisted after the gap"),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="cortex.trace.recorder"):
+            seen = await _drain(trace_recorder, session_id, scripted)
+
+        assert seen == scripted
+        rows = await repo.list_events(session_id)
+        assert [r.seq for r in rows] == [0, 2]
+        assert [r.event_type for r in rows] == ["thinking", "done"]
+        assert any("persistence failed" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_max_seq_failure_stores_nothing_for_the_turn(self, caplog):
+        """If the starting seq cannot be determined the recorder cannot safely
+        number this turn: nothing is stored and the stream still flows."""
+        repo = BrokenMaxSeqRepository()
+        trace_recorder = TraceRecorder(repository=repo, pseudonymizer=FakePseudonymizer())
+        session_id = uuid4()
+        scripted = [
+            ThinkingEvent(session_id, message="think"),
+            TextDeltaEvent(session_id, delta="hi"),
+        ]
+
+        with caplog.at_level(logging.WARNING, logger="cortex.trace.recorder"):
+            seen = await _drain(trace_recorder, session_id, scripted)
+
+        assert seen == scripted
+        assert await repo.list_events(session_id) == []
+        assert any("cannot determine the last persisted seq" in r.message for r in caplog.records)

--- a/tests/unit/trace/test_trace_repository.py
+++ b/tests/unit/trace/test_trace_repository.py
@@ -33,7 +33,7 @@ class TestTraceRepositoryInterface:
 
     def test_repository_has_required_methods(self):
         """All required persistence primitives are declared."""
-        for method in ("insert_event", "list_events", "delete_older_than"):
+        for method in ("insert_event", "list_events", "delete_older_than", "max_seq"):
             assert hasattr(TraceRepository, method)
             assert callable(getattr(TraceRepository, method))
 
@@ -205,3 +205,30 @@ class TestPostgresTraceRepository:
         deleted = await repo.delete_older_than(datetime.now(UTC))
 
         assert deleted == 0
+
+    @pytest.mark.asyncio
+    async def test_max_seq_returns_highest_persisted_seq(self, repo_with_mock):
+        """A session with rows reports the maximum persisted seq."""
+        repo, mock_db_session = repo_with_mock
+        session_id = uuid4()
+        mock_db_session.fetchrow.return_value = {"max_seq": 12}
+
+        result = await repo.max_seq(session_id)
+
+        assert result == 12
+        sql = mock_db_session.fetchrow.call_args.args[0]
+        assert "SELECT MAX(seq)" in sql
+        assert "FROM loop_events" in sql
+        assert "WHERE session_id = $1" in sql
+        # The session is the only bound parameter.
+        assert mock_db_session.fetchrow.call_args.args[1:] == (session_id,)
+
+    @pytest.mark.asyncio
+    async def test_max_seq_is_none_for_session_without_rows(self, repo_with_mock):
+        """An aggregate MAX over zero rows yields SQL NULL - mapped to None."""
+        repo, mock_db_session = repo_with_mock
+        mock_db_session.fetchrow.return_value = {"max_seq": None}
+
+        result = await repo.max_seq(uuid4())
+
+        assert result is None


### PR DESCRIPTION
Implements **T2** (#112) of spec #105 (Runtime trace capture and audit). Blocked-by #111 (merged).

**Delivers:** TraceRecorder tees the chat stream_chat path when `session.trace_enabled` — every event persisted to `loop_events` in seq order with PII fields (thinking.message, text.delta, done.message, tool_done output/error, ask_user.question) pseudonymized per field via a local rizzo-pii sidecar before insert; untraced sessions persist nothing (I2); sidecar unreachable → fail-closed latch (skip + log, stream never interrupted — US6); seq monotonic per session across turns (repository max_seq). RizzoPseudonymizer: `POST /analyze` with `include_mapping=false`, pinned `anonymized_text` contract. Recorder composed at the root in main.py; ExecutionModule gains `trace_recorder` param. Settings `trace_sidecar_url`/`trace_sidecar_timeout_s`; docker-compose `rizzo-pii` service under profile `trace` (pinned v2.0.0) for real-sidecar verification.

**Known deviation (documented, accepted):** pseudonymizer failure latches for the rest of the turn (rather than spec's literal per-event skip) — satisfies AC3/I1, conservative (never stores raw; avoids repeated timeouts against a down sidecar); docstring states exact semantics.

**Verification:** 976 unit tests (+34), ruff + mypy clean, coverage 81.0% (gate ≥70). Two full three-axis review rounds: round-1 findings fixed (composition-root wiring replacing lazy factory; shared test fakes; docstring precision), round-2 findings fixed (restored vacuous wiring-test assertions; docstring seq clause; loop collapse; dead guard; __init__ re-exports; E302). Final targeted verification: 3/3 sites FIXED.

Tickets: #112 → #113 (T3 audit, blocked); #114 (T4 retention) can proceed after this merges.