### PR TITLE
feat(trace): retention setting + traces:cleanup CLI (#114)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,9 @@ LLM_JUDGE_MODEL=deepseek-v4-pro
 TRACE_SIDECAR_URL=http://127.0.0.1:5005
 TRACE_SIDECAR_TIMEOUT_S=10.0
 
+# Trace retention (cortex traces:cleanup deletes loop_events older than this)
+TRACE_RETENTION_DAYS=30
+
 # MQTT Broker
 MQTT_BROKER_URL=mqtt://localhost:1883
 

--- a/config.yaml
+++ b/config.yaml
@@ -19,6 +19,8 @@ trace:
   # (docker compose --profile trace)
   sidecar_url: "http://127.0.0.1:5005"
   sidecar_timeout_s: 10.0
+  # Loop events older than this many days are deleted by `cortex traces:cleanup`
+  retention_days: 30
 
 mqtt:
   broker_url: "mqtt://localhost:1883"

--- a/docs/ZOOM_OUT_MAP.md
+++ b/docs/ZOOM_OUT_MAP.md
@@ -266,7 +266,7 @@ laptop-minion/ (separate package, own pyproject.toml)
 
 | Entry Point | File | Description |
 |-------------|------|-------------|
-| `cortex` (CLI) | `src/cortex/cli.py` | `cortex token:create`, `cortex version` |
+| `cortex` (CLI) | `src/cortex/cli.py` | `cortex token:create`, `cortex traces:cleanup`, `cortex version` |
 | `cortex.main` | `src/cortex/main.py` | `initialize_app()` → `CortexApp` |
 | `cortex.__main__` | `src/cortex/__main__.py` | `python -m cortex` |
 | FastAPI app | `src/cortex/api/main.py` | `create_api_app()` — mounted by bootstrap |
@@ -281,7 +281,7 @@ src/cortex/
 ├── __init__.py
 ├── __main__.py              # python -m cortex
 ├── main.py                  # initialize_app() — wires everything
-├── cli.py                   # Typer CLI (token:create, version)
+├── cli.py                   # Typer CLI (token:create, traces:cleanup, version)
 │
 ├── agentic/                 # Wave 4 — Agentic Core
 │   ├── __init__.py

--- a/src/cortex/cli.py
+++ b/src/cortex/cli.py
@@ -64,6 +64,60 @@ def token_create(
     asyncio.run(create_token())
 
 
+@cli.command("traces:cleanup", help="Delete loop-event trace rows older than the retention window")
+def traces_cleanup(
+    db_url: str | None = typer.Option(None, "--db-url", help="Database URL"),
+    days: int | None = typer.Option(
+        None,
+        "--days",
+        min=1,
+        help="Retention window in days (defaults to trace_retention_days setting)",
+    ),
+) -> None:
+    """Delete loop_events rows older than now - retention window (issue #114 T4).
+
+    Mirrors token:create's convention (nested async runner, direct asyncpg
+    connection). Only loop_events is touched — never sessions or messages.
+    Safe on an empty database and idempotent; prints the deleted count.
+    """
+    import asyncio
+
+    async def cleanup() -> None:
+        from datetime import UTC, datetime, timedelta
+
+        import asyncpg
+
+        # DB URL + retention: explicit flags win; settings are only loaded
+        # (and required) for whatever is not given explicitly.
+        database_url = db_url
+        retention_days = days
+        if not database_url or retention_days is None:
+            from cortex.config.loader import get_settings
+
+            settings = get_settings()
+            if not database_url:
+                database_url = settings.database_url
+            if retention_days is None:
+                retention_days = settings.trace_retention_days
+
+        # Same predicate as TraceRepository.delete_older_than (strictly older
+        # than the cutoff), mirrored on the CLI's own connection so --db-url is
+        # honored instead of going through the shared pool.
+        cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+        conn = await asyncpg.connect(database_url)
+        try:
+            status = await conn.execute(
+                "DELETE FROM loop_events WHERE created_at < $1", cutoff
+            )
+        finally:
+            await conn.close()
+
+        deleted = int(status.split()[-1])
+        typer.echo(f"Deleted {deleted} expired loop event(s) (created_at < {cutoff.isoformat()}).")
+
+    asyncio.run(cleanup())
+
+
 @cli.command("version", help="Show Cortex version")
 def version() -> None:
     """Show the installed Cortex version."""

--- a/src/cortex/config/loader.py
+++ b/src/cortex/config/loader.py
@@ -179,6 +179,8 @@ def load_settings(config_path: Path | None = None) -> Settings:
             settings_data["trace_sidecar_url"] = trace["sidecar_url"]
         if "sidecar_timeout_s" in trace:
             settings_data["trace_sidecar_timeout_s"] = trace["sidecar_timeout_s"]
+        if "retention_days" in trace:
+            settings_data["trace_retention_days"] = trace["retention_days"]
 
     if "logging" in yaml_config:
         log = yaml_config["logging"]

--- a/src/cortex/config/models.py
+++ b/src/cortex/config/models.py
@@ -121,8 +121,9 @@ class Settings(BaseSettings):
 
     # ─── Trace capture ─────────────────────────────────────────
     # Local rizzo-pii pseudonymization sidecar for loop-trace capture (issue
-    # #112 T2). Flat, env-overridable (TRACE_SIDECAR_URL / TRACE_SIDECAR_TIMEOUT_S)
-    # like LLM_PRICING. Capture fails closed when the sidecar is unreachable.
+    # #112 T2). Flat, env-overridable (TRACE_SIDECAR_URL /
+    # TRACE_SIDECAR_TIMEOUT_S / TRACE_RETENTION_DAYS) like LLM_PRICING.
+    # Capture fails closed when the sidecar is unreachable.
     trace_sidecar_url: str = Field(
         default="http://127.0.0.1:5005",
         description="Base URL of the rizzo-pii pseudonymization sidecar",
@@ -131,6 +132,14 @@ class Settings(BaseSettings):
         default=10.0,
         gt=0,
         description="Per-request timeout in seconds for sidecar /analyze calls",
+    )
+    # Loop-event rows older than this many days are eligible for deletion by
+    # `cortex traces:cleanup` (issue #114 T4).
+    trace_retention_days: int = Field(
+        default=30,
+        ge=1,
+        description="Days of loop_events history to keep; older rows are "
+        "deleted by `cortex traces:cleanup`",
     )
 
     # ─── Logging ──────────────────────────────────────────────

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,146 @@
+"""Tests for `cortex traces:cleanup` (issue #114 T4).
+
+The command follows the token:create CLI conventions (typer command, nested
+async runner via asyncio.run, direct asyncpg connection from --db-url or
+settings.database_url) and deletes ONLY ``loop_events`` rows strictly older
+than ``now - retention window`` — the same predicate as
+TraceRepository.delete_older_than, mirrored on the CLI's own connection so an
+explicit --db-url is honored. It is safe on an empty DB and idempotent.
+
+The DB is faked at the asyncpg.connect seam (repo convention: mocked
+sessions), and the clock is pinned to FIXED_NOW so the cutoff is
+deterministic.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncpg
+import pytest
+from typer.testing import CliRunner
+
+from cortex.cli import cli
+
+runner = CliRunner()
+
+FIXED_NOW = dt.datetime(2026, 9, 1, 12, 0, 0, tzinfo=dt.UTC)
+
+
+@pytest.fixture
+def pinned_clock(monkeypatch):
+    """Pin datetime.now() (resolved at call time by the CLI) to FIXED_NOW."""
+
+    class _FixedClock(dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return FIXED_NOW
+
+    monkeypatch.setattr(dt, "datetime", _FixedClock)
+    return FIXED_NOW
+
+
+@pytest.fixture
+def fake_settings(monkeypatch):
+    """Stub get_settings so DB URL + retention come from a controllable source."""
+    stub = SimpleNamespace(
+        database_url="postgresql://settings:5432/cortex",
+        trace_retention_days=45,
+    )
+    monkeypatch.setattr("cortex.config.loader.get_settings", lambda: stub)
+    return stub
+
+
+@pytest.fixture
+def fake_db(monkeypatch):
+    """Fake asyncpg.connect returning a recording connection."""
+    conn = AsyncMock()
+    conn.execute.return_value = "DELETE 0"
+    connect = AsyncMock(return_value=conn)
+    monkeypatch.setattr(asyncpg, "connect", connect)
+    return connect, conn
+
+
+class TestTracesCleanup:
+    def test_deletes_only_rows_older_than_retention_window(self, pinned_clock, fake_settings, fake_db):
+        """The single executed statement targets only loop_events with
+        created_at < now - retention: rows at/after the cutoff are untouched
+        (strict less-than, same semantics as TraceRepository.delete_older_than).
+        """
+        connect, conn = fake_db
+        conn.execute.return_value = "DELETE 3"
+
+        result = runner.invoke(
+            cli,
+            ["traces:cleanup", "--db-url", "postgresql://flag:5432/cortex", "--days", "30"],
+        )
+
+        assert result.exit_code == 0, result.output
+        # --db-url flag wins over settings.database_url.
+        connect.assert_awaited_once_with("postgresql://flag:5432/cortex")
+        # Exactly one statement ran — nothing else (sessions/messages) was touched.
+        assert conn.execute.await_count == 1
+        sql, cutoff = conn.execute.await_args.args
+        assert sql.strip() == "DELETE FROM loop_events WHERE created_at < $1"
+        assert cutoff == FIXED_NOW - dt.timedelta(days=30)
+        conn.close.assert_awaited_once()
+        assert "Deleted 3" in result.output
+
+    def test_db_url_and_retention_default_to_settings(self, pinned_clock, fake_settings, fake_db):
+        """No flags: connection URL and retention days come from settings."""
+        connect, conn = fake_db
+        conn.execute.return_value = "DELETE 2"
+
+        result = runner.invoke(cli, ["traces:cleanup"])
+
+        assert result.exit_code == 0, result.output
+        connect.assert_awaited_once_with("postgresql://settings:5432/cortex")
+        _, cutoff = conn.execute.await_args.args
+        assert cutoff == FIXED_NOW - dt.timedelta(days=45)
+        assert "Deleted 2" in result.output
+
+    def test_days_flag_overrides_settings_retention(self, pinned_clock, fake_settings, fake_db):
+        """--days narrows the retention window relative to the setting."""
+        connect, conn = fake_db
+        conn.execute.return_value = "DELETE 1"
+
+        result = runner.invoke(cli, ["traces:cleanup", "--days", "7"])
+
+        assert result.exit_code == 0, result.output
+        connect.assert_awaited_once_with("postgresql://settings:5432/cortex")
+        _, cutoff = conn.execute.await_args.args
+        assert cutoff == FIXED_NOW - dt.timedelta(days=7)
+
+    def test_safe_on_empty_db_and_idempotent(self, pinned_clock, fake_settings, fake_db):
+        """DELETE 0 exits 0 and a second run repeats the identical statement."""
+        connect, conn = fake_db
+        conn.execute.return_value = "DELETE 0"
+        args = ["traces:cleanup", "--days", "30"]
+
+        first = runner.invoke(cli, args)
+        second = runner.invoke(cli, args)
+
+        assert first.exit_code == 0, first.output
+        assert second.exit_code == 0, second.output
+        assert "Deleted 0" in first.output
+        assert "Deleted 0" in second.output
+        assert conn.execute.await_count == 2
+        for call in conn.execute.await_args_list:
+            assert call.args[0].strip() == "DELETE FROM loop_events WHERE created_at < $1"
+
+    def test_only_loop_events_are_touched(self, pinned_clock, fake_settings, fake_db):
+        """Invariant: the statement references loop_events exclusively — never
+        the sessions or messages tables."""
+        connect, conn = fake_db
+        conn.execute.return_value = "DELETE 5"
+
+        result = runner.invoke(cli, ["traces:cleanup", "--days", "30"])
+
+        assert result.exit_code == 0, result.output
+        assert conn.execute.await_count == 1
+        sql = conn.execute.await_args.args[0]
+        assert sql.strip() == "DELETE FROM loop_events WHERE created_at < $1"
+        assert "sessions" not in sql
+        assert "messages" not in sql

--- a/tests/unit/test_trace_settings.py
+++ b/tests/unit/test_trace_settings.py
@@ -73,3 +73,59 @@ class TestTraceSettingsLoader:
         settings = load_settings(config_path=cfg)
 
         assert settings.trace_sidecar_url == "http://127.0.0.1:7000"
+
+
+class TestTraceRetentionDefaults:
+    """Flat default for the loop-event retention window (issue #114 T4)."""
+
+    def test_retention_defaults_to_thirty_days(self):
+        """A sane default keeps a month of traces before cleanup is needed."""
+        settings = Settings(llm_api_key="test-key")
+        assert settings.trace_retention_days == 30
+
+
+class TestTraceRetentionEnvOverrides:
+    def test_env_overrides_retention_days(self, monkeypatch):
+        monkeypatch.setenv("TRACE_RETENTION_DAYS", "7")
+        settings = Settings(llm_api_key="test-key")
+        assert settings.trace_retention_days == 7
+
+    def test_constructor_kwargs_win_over_env(self, monkeypatch):
+        """Explicit constructor values still beat env (init-args precedence)."""
+        monkeypatch.setenv("TRACE_RETENTION_DAYS", "7")
+        settings = Settings(llm_api_key="test-key", trace_retention_days=14)
+        assert settings.trace_retention_days == 14
+
+
+class TestTraceRetentionLoader:
+    def test_nested_trace_block_maps_retention_days(self, tmp_path):
+        """loader maps YAML trace.retention_days onto the flat field."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("trace:\n  retention_days: 14\n")
+
+        settings = load_settings(config_path=cfg)
+
+        assert settings.trace_retention_days == 14
+
+    def test_loader_without_retention_key_keeps_default(self, tmp_path):
+        """A trace block without retention_days leaves the default in place."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("trace:\n  sidecar_url: http://rizzo:5005\n")
+
+        settings = load_settings(config_path=cfg)
+
+        assert settings.trace_retention_days == 30
+        assert settings.trace_sidecar_url == "http://rizzo:5005"
+
+    def test_env_override_reaches_settings_when_no_yaml_retention(self, tmp_path, monkeypatch):
+        """Flat env passthrough: without a YAML retention_days the env var
+        supplies the field. (An explicit YAML value would win — init kwargs
+        take precedence over env in pydantic-settings — so this mirrors the
+        sidecar loader tests.)"""
+        monkeypatch.setenv("TRACE_RETENTION_DAYS", "60")
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("trace:\n  sidecar_url: http://rizzo:5005\n")
+
+        settings = load_settings(config_path=cfg)
+
+        assert settings.trace_retention_days == 60


### PR DESCRIPTION
Implements **T4** (#114) of spec #105 (Runtime trace capture and audit). Blocked-by #112 (merged).

**Delivers:** `trace_retention_days` setting (default 30, ge=1; env + nested YAML; documented in .env.example/config.yaml) and `cortex traces:cleanup` CLI (mirrors token:create convention: async + `--db-url` or settings, falsy fallback, `--days` min=1) deleting ONLY `loop_events` older than the retention window (strict < cutoff); safe on empty DB, idempotent. Scheduled job out of scope v1. The DELETE mirrors the repository predicate on the CLI's own connection (pool is bound to settings.database_url — `--db-url` could never be honored through it); byte-identical SQL pinned on both sides in lockstep. ZOOM_OUT_MAP CLI enumerations updated.

**Review:** 3-axis — all PASS, mirror-vs-reuse adjudicated sound by all three axes (Spec + Standards + Ponytail); fixes applied: `--days min=1` (guard parity with ge=1), falsy `--db-url` fallback (token:create parity). Verification: 987 unit tests (+11), ruff + mypy clean, coverage 81.3% (gate ≥70). CI green below.