### PR TITLE
fix(trace): skip sidecar call for whitespace-only PII fields (#112)

### DIFF
--- a/src/cortex/trace/recorder.py
+++ b/src/cortex/trace/recorder.py
@@ -153,7 +153,8 @@ class TraceRecorder:
         payload = event.to_dict()
         for field in _PII_FIELDS.get(type(event), ()):
             value = payload.get(field)
-            # Empty/None values carry nothing to pseudonymize — skip the call.
-            if isinstance(value, str) and value:
+            # Empty/None/whitespace-only values carry nothing to pseudonymize
+            # — skip the call (the sidecar 400s on whitespace-only text).
+            if isinstance(value, str) and value.strip():
                 payload[field] = await self._pseudonymizer.anonymize(value)
         return payload

--- a/tests/unit/trace/test_recorder.py
+++ b/tests/unit/trace/test_recorder.py
@@ -301,6 +301,44 @@ class TestTraceRecorderCapture:
         assert rows[1].payload["output"] == ""
         assert rows[1].payload["error"] is None
 
+    @pytest.mark.asyncio
+    async def test_whitespace_only_delta_skips_sidecar_and_rest_of_turn_persists(self, recorder):
+        """A whitespace-only text delta (e.g. ``" "`` between streamed tokens)
+        carries no PII: no /analyze call is made for it, it is stored verbatim,
+        and the later events of the turn still persist pseudonymized — the
+        400/latch drop path is never triggered."""
+        trace_recorder, repo, pseudonymizer = recorder
+        session_id = uuid4()
+        scripted = [
+            TextDeltaEvent(session_id, delta="Hi "),
+            TextDeltaEvent(session_id, delta=" "),  # whitespace-only token boundary
+            TextDeltaEvent(session_id, delta=f"there {EMAIL_SEED}"),
+            ResponseDoneEvent(session_id, message="done"),
+        ]
+
+        await _drain(trace_recorder, session_id, scripted)
+
+        # One /analyze call per non-empty PII field; the whitespace-only delta
+        # never reaches the pseudonymizer.
+        assert pseudonymizer.calls == [
+            "Hi ",
+            f"there {EMAIL_SEED}",
+            "done",
+        ]
+        assert " " not in pseudonymizer.calls
+
+        # Every event of the turn persisted, in order — whitespace included.
+        rows = await repo.list_events(session_id)
+        assert [r.event_type for r in rows] == ["text", "text", "text", "done"]
+        assert [r.seq for r in rows] == [0, 1, 2, 3]
+        # The whitespace delta is stored verbatim; later PII still pseudonymized.
+        assert [r.payload["delta"] for r in rows[:3]] == [
+            "Hi ",
+            " ",
+            "there [TAG_1]",
+        ]
+        assert EMAIL_SEED not in payloads_json(rows)
+
 
 class TestTraceRecorderFailClosed:
     """Every failure mode logs a warning and never alters the stream."""


### PR DESCRIPTION
Real bug found by the end-to-end smoke test (contract-faithful fake rizzo-pii sidecar, no model).

**Bug:** streamed text deltas can be single whitespace tokens (`" "`). The recorder's guard (`isinstance(value, str) and value`) passed whitespace-only fields to rizzo-pii, which answers **400 Bad Request** for whitespace-only text (`text.strip()` empty — upstream behavior). The fail-closed latch then treated the 400 as a pseudonymization failure and dropped that event AND every remaining event of the turn (thinking/ask_user/done were lost). Unit tests never caught it because scripted deltas were non-empty.

**Fix:** guard now skips fields empty after `strip()` — no sidecar call, no latch, turn fully persisted. Regression test `test_whitespace_only_delta_skips_sidecar_and_rest_of_turn_persists`.

**Verification:** trace suite green (61 passed); full smoke re-run against the fake sidecar after the fix persisted all 459 events of a real turn (456 text + thinking + ask_user + done) with seeded PII (email + codice fiscale) never in clear.

Issue: #112 (T2 — capture; follow-up fix to its recorder).
